### PR TITLE
fix to messages and listing word overflow

### DIFF
--- a/components/display-product-modal.tsx
+++ b/components/display-product-modal.tsx
@@ -155,10 +155,8 @@ export default function DisplayProductModal({
               </div>
             </div>
             <Divider />
-            <div className="overflow-hidden break-words">
-              <span className="text-xl font-semibold">Summary: </span>
-              {productData.summary}
-            </div>
+            <span className="text-xl font-semibold">Summary: </span>
+            <span className="break-all">{productData.summary}</span>
           </ModalBody>
 
           <ModalFooter>

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -70,7 +70,7 @@ export default function ProductCard({
           </div>
           <Divider />
           <span className="mt-4 text-xl font-semibold">Summary: </span>
-          {productData.summary}
+          <span className="break-all">{productData.summary}</span>
           <Divider className="mt-4" />
           <span className="mt-4 text-xl font-semibold">Cost Breakdown: </span>
           <DisplayCostBreakdown monetaryInfo={productData} />

--- a/pages/messages/chat-message.tsx
+++ b/pages/messages/chat-message.tsx
@@ -30,7 +30,7 @@ export const ChatMessage = ({
             : "rounded-br-lg bg-gray-200 text-light-text dark:bg-gray-300 "
         }`}
       >
-        <p className={`inline-block flex-wrap overflow-x-hidden break-words`}>
+        <p className={`inline-block flex-wrap overflow-x-hidden break-all`}>
           {messageEvent.content}
         </p>
         <div className="m-1"></div>


### PR DESCRIPTION
Fix so that page does not overflow with text on long words (ie cashu token in message or product url in summary text)