### PR TITLE
Implement NIP-49 Encryption Standard for Private Keys

### DIFF
--- a/components/sign-in/SignInModal.tsx
+++ b/components/sign-in/SignInModal.tsx
@@ -14,6 +14,7 @@ import {
   validateNSecKey,
   parseBunkerToken,
 } from "@/utils/nostr/nostr-helper-functions";
+import { migrateToNip49, needsMigration } from "@/utils/nostr/encryption-migration";
 import ShopstrSpinner from "@/components/utility-components/shopstr-spinner";
 import { RelaysContext } from "../../utils/context/context";
 import { useRouter } from "next/router";
@@ -44,6 +45,8 @@ export default function SignInModal({
 
   const [showFailureModal, setShowFailureModal] = useState(false);
   const [failureText, setFailureText] = useState("");
+
+  const [migrationNeeded, setMigrationNeeded] = useState<boolean>(false);
 
   const relaysContext = useContext(RelaysContext);
 
@@ -111,6 +114,13 @@ export default function SignInModal({
     }
   }, [bunkerToken]);
 
+  useEffect(() => {
+    // Check if we need to migrate an existing key when modal opens
+    if (isOpen) {
+      setMigrationNeeded(needsMigration());
+    }
+  }, [isOpen]);
+
   const handleGenerateKeys = () => {
     router.push("/keys");
     onClose();
@@ -122,22 +132,38 @@ export default function SignInModal({
         setFailureText("No passphrase provided!");
         setShowFailureModal(true);
       } else {
-        const { encryptedPrivKey, pubkey } = NostrNSecSigner.getEncryptedNSEC(
-          privateKey,
-          passphrase
-        );
+        try {
+          // If migration is needed, attempt to migrate the existing key
+          if (migrationNeeded) {
+            const migrationSuccess = await migrateToNip49(passphrase);
+            if (!migrationSuccess) {
+              setFailureText("Key migration failed. Please try again.");
+              setShowFailureModal(true);
+              return;
+            }
+          }
+          
+          const { encryptedPrivKey, pubkey } = NostrNSecSigner.getEncryptedNSEC(
+            privateKey,
+            passphrase
+          );
 
-        setTimeout(() => {
-          onClose(); // avoids tree walker issue by closing modal
-        }, 500);
+          setTimeout(() => {
+            onClose(); // avoids tree walker issue by closing modal
+          }, 500);
 
-        const signer = newSigner!("nsec", {
-          encryptedPrivKey: encryptedPrivKey,
-          pubkey,
-        });
-        await signer.getPubKey();
-        saveSigner(signer);
-        onClose();
+          const signer = newSigner!("nsec", {
+            encryptedPrivKey: encryptedPrivKey,
+            pubkey,
+          });
+          await signer.getPubKey();
+          saveSigner(signer);
+          onClose();
+        } catch (error) {
+          console.error("Sign-in error:", error);
+          setFailureText("Failed to sign in. Please check your private key and passphrase.");
+          setShowFailureModal(true);
+        }
       }
     } else {
       setFailureText(
@@ -169,6 +195,7 @@ export default function SignInModal({
           setShowNsecSignIn(false);
           setPrivateKey("");
           setPassphrase("");
+          setMigrationNeeded(false);
           onClose();
         }}
         // className="bg-light-fg dark:bg-dark-fg text-black dark:text-white"

--- a/components/utility-components/migration-prompt-modal.tsx
+++ b/components/utility-components/migration-prompt-modal.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import { Modal, ModalContent, ModalBody, Button, Input } from "@nextui-org/react";
+import { migrateToNip49 } from "@/utils/nostr/encryption-migration";
+
+interface MigrationPromptModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function MigrationPromptModal({
+  isOpen,
+  onClose,
+  onSuccess,
+}: MigrationPromptModalProps) {
+  const [passphrase, setPassphrase] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleMigration = async () => {
+    if (!passphrase) {
+      setError("Please enter your passphrase");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const success = await migrateToNip49(passphrase);
+      if (success) {
+        onSuccess();
+        onClose();
+      } else {
+        setError("Migration failed. Please try again with the correct passphrase.");
+      }
+      return success;
+    } catch (err) {
+      setError("Failed to decrypt with the provided passphrase. Please try again.");
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const resetModal = () => {
+    setPassphrase("");
+    setError("");
+    setIsLoading(false);
+  };
+
+  return (
+    <Modal
+      backdrop="blur"
+      isOpen={isOpen}
+      onClose={() => {
+        resetModal();
+        onClose();
+      }}
+      classNames={{
+        body: "py-6",
+        backdrop: "bg-[#292f46]/50 backdrop-opacity-60",
+        header: "border-b-[1px] border-[#292f46]",
+        footer: "border-t-[1px] border-[#292f46]",
+        closeButton: "hover:bg-black/5 active:bg-white/10",
+      }}
+      isDismissable={true}
+      scrollBehavior={"normal"}
+      placement={"center"}
+      size="md"
+    >
+      <ModalContent>
+        <ModalBody className="flex flex-col overflow-hidden text-light-text dark:text-dark-text">
+          <div className="mb-4 text-center">
+            <h3 className="text-lg font-semibold">Encryption Upgrade</h3>
+            <p className="mt-2 text-sm">
+              We've improved our security! Please enter your passphrase to upgrade 
+              your key encryption to the latest standard.
+            </p>
+          </div>
+
+          <div className="mb-4">
+            <Input
+              type="password"
+              label="Your Passphrase"
+              placeholder="Enter your passphrase..."
+              width="100%"
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && passphrase) handleMigration();
+              }}
+              isInvalid={!!error}
+              errorMessage={error}
+            />
+          </div>
+
+          <div className="flex justify-end space-x-2">
+            <Button
+              color="default"
+              variant="light"
+              onClick={() => {
+                resetModal();
+                onClose();
+              }}
+            >
+              Later
+            </Button>
+            <Button
+              color="primary"
+              onClick={handleMigration}
+              isLoading={isLoading}
+              isDisabled={!passphrase || isLoading}
+            >
+              Upgrade Encryption
+            </Button>
+          </div>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+} 

--- a/components/utility-components/migration-prompt-modal.tsx
+++ b/components/utility-components/migration-prompt-modal.tsx
@@ -72,7 +72,7 @@ export default function MigrationPromptModal({
           <div className="mb-4 text-center">
             <h3 className="text-lg font-semibold">Encryption Upgrade</h3>
             <p className="mt-2 text-sm">
-              We've improved our security! Please enter your passphrase to upgrade 
+              We've upgraded our encryption to the NIP-49 standard for better security! Please enter your passphrase to upgrade 
               your key encryption to the latest standard.
             </p>
           </div>

--- a/components/utility-components/migration-prompt-modal.tsx
+++ b/components/utility-components/migration-prompt-modal.tsx
@@ -72,8 +72,7 @@ export default function MigrationPromptModal({
           <div className="mb-4 text-center">
             <h3 className="text-lg font-semibold">Encryption Upgrade</h3>
             <p className="mt-2 text-sm">
-              We've upgraded our encryption to the NIP-49 standard for better security! Please enter your passphrase to upgrade 
-              your key encryption to the latest standard.
+              We&apos;ve upgraded our encryption to the NIP-49 standard for better security! Please enter your existing passphrase so we can safely decrypt your current key and re-encrypt it with the new standard.
             </p>
           </div>
 

--- a/components/utility-components/migration-prompt-modal.tsx
+++ b/components/utility-components/migration-prompt-modal.tsx
@@ -27,13 +27,16 @@ export default function MigrationPromptModal({
     try {
       const success = await migrateToNip49(passphrase);
       if (success) {
+        console.log("✅ Migration completed successfully - reloading signer");
         onSuccess();
         onClose();
       } else {
+        console.error("❌ Migration failed");
         setError("Migration failed. Please try again with the correct passphrase.");
       }
       return success;
     } catch (err) {
+      console.error("❌ Migration error:", err);
       setError("Failed to decrypt with the provided passphrase. Please try again.");
       return false;
     } finally {

--- a/components/utility-components/nostr-context-provider.tsx
+++ b/components/utility-components/nostr-context-provider.tsx
@@ -226,6 +226,7 @@ export function SignerContextProvider({ children }: { children: ReactNode }) {
     } else {
       console.log("Not logged in yet, skipping migration check");
     }
+    return undefined;
   }, [isLoggedIn]);
 
   const newSigner = useCallback((type: string, args: any) => {

--- a/components/utility-components/nostr-context-provider.tsx
+++ b/components/utility-components/nostr-context-provider.tsx
@@ -119,7 +119,7 @@ export function SignerContextProvider({ children }: { children: ReactNode }) {
   const loadSigner = useCallback(() => {
     let existingSigner;
     const { signer, signInMethod } = getLocalStorageData();
-    
+
     if (signer) {
       existingSigner = signer;
     } else if (signInMethod) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/utils/nostr/encryption-migration.ts
+++ b/utils/nostr/encryption-migration.ts
@@ -1,0 +1,67 @@
+import { 
+  getLocalStorageData, 
+  setLocalStorageDataOnSignIn 
+} from './nostr-helper-functions';
+import { NostrNSecSigner } from './signers/nostr-nsec-signer';
+
+let migrationAttempted = false;
+
+export async function migrateToNip49(passphrase: string): Promise<boolean> {
+  if (migrationAttempted) return true;
+  
+  try {
+    const storedData = getLocalStorageData();
+    if (
+      storedData.encryptedPrivateKey && 
+      typeof storedData.encryptedPrivateKey === 'string' &&
+      !storedData.encryptedPrivateKey.startsWith('ncryptsec')
+    ) {
+      try {
+        // Create a temporary signer that just needs the encryptedPrivKey
+        // We'll handle getting the privkey manually without a challenge handler
+        const tempSigner = new NostrNSecSigner({
+          encryptedPrivKey: storedData.encryptedPrivateKey,
+          passphrase: passphrase
+        }, () => Promise.resolve({ res: "", remind: false }));
+        const privateKeyBytes = await tempSigner._getPrivKey();
+        const { encryptedPrivKey } = NostrNSecSigner.getEncryptedNSEC(
+          privateKeyBytes,
+          passphrase
+        );
+        
+        setLocalStorageDataOnSignIn({
+          encryptedPrivateKey: encryptedPrivKey,
+          relays: storedData.relays,
+          readRelays: storedData.readRelays,
+          writeRelays: storedData.writeRelays,
+          mints: storedData.mints,
+          wot: storedData.wot,
+        });
+        
+        console.log('Successfully migrated to NIP-49 encryption');
+        migrationAttempted = true;
+        return true;
+      } catch (error) {
+        console.error('Failed to decrypt with provided passphrase', error);
+        throw new Error('Failed to decrypt with provided passphrase');
+      }
+    }
+    
+    migrationAttempted = true;
+    return true;
+  } catch (error) {
+    console.error('NIP-49 Migration error:', error);
+    migrationAttempted = true;
+    return false;
+  }
+}
+
+export function needsMigration(): boolean {
+  const storedData = getLocalStorageData();
+  
+  return !!(
+    storedData.encryptedPrivateKey && 
+    typeof storedData.encryptedPrivateKey === 'string' &&
+    !storedData.encryptedPrivateKey.startsWith('ncryptsec')
+  );
+} 

--- a/utils/nostr/encryption-migration.ts
+++ b/utils/nostr/encryption-migration.ts
@@ -31,6 +31,7 @@ export async function migrateToNip49(passphrase: string): Promise<boolean> {
         
         setLocalStorageDataOnSignIn({
           encryptedPrivateKey: encryptedPrivKey,
+          migrationComplete: true,
           relays: storedData.relays,
           readRelays: storedData.readRelays,
           writeRelays: storedData.writeRelays,
@@ -58,6 +59,18 @@ export async function migrateToNip49(passphrase: string): Promise<boolean> {
 
 export function needsMigration(): boolean {
   const storedData = getLocalStorageData();
+  
+  console.log("Migration check - migrationComplete flag:", storedData.migrationComplete);
+  console.log("Migration check - encryptedPrivateKey exists:", !!storedData.encryptedPrivateKey);
+  
+  if (storedData.encryptedPrivateKey) {
+    console.log("Migration check - key type:", typeof storedData.encryptedPrivateKey);
+    console.log("Migration check - key starts with ncryptsec:", storedData.encryptedPrivateKey.startsWith('ncryptsec'));
+  }
+  
+  if (storedData.migrationComplete === true) {
+    return false;
+  }
   
   return !!(
     storedData.encryptedPrivateKey && 

--- a/utils/nostr/encryption-migration.ts
+++ b/utils/nostr/encryption-migration.ts
@@ -6,116 +6,74 @@ import { NostrNSecSigner } from './signers/nostr-nsec-signer';
 
 let migrationAttempted = false;
 
+function findEncryptedKey() {
+  const storedData = getLocalStorageData();
+  
+  if (storedData.encryptedPrivateKey) {
+    return {
+      key: storedData.encryptedPrivateKey,
+      inSigner: false
+    };
+  }
+
+  if (storedData.signer?.type === "nsec" && storedData.signer.encryptedPrivKey) {
+    return {
+      key: storedData.signer.encryptedPrivKey,
+      inSigner: true,
+      signer: storedData.signer
+    };
+  }
+  
+  return { key: null, inSigner: false };
+}
+
+export function needsMigration(): boolean {
+  if (getLocalStorageData().migrationComplete === true) {
+    return false;
+  }
+  const { key } = findEncryptedKey();
+
+  return !!(key && typeof key === 'string' && !key.startsWith('ncryptsec'));
+}
+
 export async function migrateToNip49(passphrase: string): Promise<boolean> {
   if (migrationAttempted) return true;
   
   try {
-    const storedData = getLocalStorageData();
+    const { key, inSigner, signer } = findEncryptedKey();
     
-    // Check both possible locations for the encrypted key
-    let encryptedKey = storedData.encryptedPrivateKey;
-    let inSignerObject = false;
-    
-    // If not found in the standard location, check if it's in the signer object
-    if (!encryptedKey && storedData.signer && storedData.signer.type === "nsec") {
-      encryptedKey = storedData.signer.encryptedPrivKey;
-      inSignerObject = true;
-      console.log("Migration - Found key in signer object");
+    if (!key || typeof key !== 'string' || key.startsWith('ncryptsec')) {
+      migrationAttempted = true;
+      return true;
     }
     
-    if (
-      encryptedKey && 
-      typeof encryptedKey === 'string' &&
-      !encryptedKey.startsWith('ncryptsec')
-    ) {
-      try {
-        console.log("Starting migration with key:", encryptedKey.substring(0, 10) + "...");
-        const tempSigner = new NostrNSecSigner({
-          encryptedPrivKey: encryptedKey,
-          passphrase: passphrase
-        }, () => Promise.resolve({ res: "", remind: false }));
-        
-        const privateKeyBytes = await tempSigner._getPrivKey();
-        console.log("Successfully decrypted legacy key");
-        
-        const { encryptedPrivKey } = NostrNSecSigner.getEncryptedNSEC(
-          privateKeyBytes,
-          passphrase
-        );
-        
-        console.log("Re-encrypted with NIP-49, updating storage");
-        
-        // If the key was in the signer object, update it there too
-        if (inSignerObject && storedData.signer) {
-          const updatedSigner = {
-            ...storedData.signer,
-            encryptedPrivKey
-          };
-          
-          setLocalStorageDataOnSignIn({
-            signer: updatedSigner as any, // Cast to any to avoid type checking as this is serialized data
-            migrationComplete: true
-          });
-        } else {
-          // Standard location update
-          setLocalStorageDataOnSignIn({
-            encryptedPrivateKey: encryptedPrivKey,
-            migrationComplete: true,
-            relays: storedData.relays,
-            readRelays: storedData.readRelays,
-            writeRelays: storedData.writeRelays,
-            mints: storedData.mints,
-            wot: storedData.wot,
-          });
-        }
-        
-        console.log('Successfully migrated to NIP-49 encryption');
-        migrationAttempted = true;
-        return true;
-      } catch (error) {
-        console.error('Failed to decrypt with provided passphrase', error);
-        throw new Error('Failed to decrypt with provided passphrase');
-      }
+    const tempSigner = new NostrNSecSigner({
+      encryptedPrivKey: key,
+      passphrase: passphrase
+    }, () => Promise.resolve({ res: "", remind: false }));
+    
+    const privateKeyBytes = await tempSigner._getPrivKey();
+    const { encryptedPrivKey } = NostrNSecSigner.getEncryptedNSEC(
+      privateKeyBytes, 
+      passphrase
+    );
+
+    if (inSigner && signer) {
+      setLocalStorageDataOnSignIn({
+        signer: { ...signer, encryptedPrivKey } as any,
+        migrationComplete: true
+      });
     } else {
-      console.log("No legacy key found that needs migration");
+      setLocalStorageDataOnSignIn({
+        encryptedPrivateKey: encryptedPrivKey,
+        migrationComplete: true
+      });
     }
     
     migrationAttempted = true;
     return true;
   } catch (error) {
-    console.error('NIP-49 Migration error:', error);
     migrationAttempted = true;
     return false;
   }
-}
-
-export function needsMigration(): boolean {
-  const storedData = getLocalStorageData();
-  
-  // Check directly in localStorage for both possible key names
-  let encryptedKey = storedData.encryptedPrivateKey;
-  
-  // If not found in the standard location, check if it's in the signer object
-  if (!encryptedKey && storedData.signer && storedData.signer.type === "nsec") {
-    encryptedKey = storedData.signer.encryptedPrivKey;
-    console.log("Found key in signer object:", !!encryptedKey);
-  }
-  
-  console.log("Migration check - migrationComplete flag:", storedData.migrationComplete);
-  console.log("Migration check - encryptedPrivateKey found:", !!encryptedKey);
-  
-  if (encryptedKey) {
-    console.log("Migration check - key type:", typeof encryptedKey);
-    console.log("Migration check - key starts with ncryptsec:", encryptedKey.startsWith('ncryptsec'));
-  }
-  
-  if (storedData.migrationComplete === true) {
-    return false;
-  }
-  
-  return !!(
-    encryptedKey && 
-    typeof encryptedKey === 'string' &&
-    !encryptedKey.startsWith('ncryptsec')
-  );
 } 

--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -1033,7 +1033,6 @@ export const getLocalStorageData = (): LocalStorageInterface => {
           break;
       }
     }
-
     migrationComplete = localStorage.getItem("migrationComplete") === "true";
   }
   return {

--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -799,6 +799,7 @@ export const setLocalStorageDataOnSignIn = ({
   bunkerRelays,
   bunkerSecret,
   signer,
+  migrationComplete,
 }: {
   encryptedPrivateKey?: string;
   relays?: string[];
@@ -812,6 +813,7 @@ export const setLocalStorageDataOnSignIn = ({
   bunkerRelays?: string[];
   bunkerSecret?: string;
   signer?: NostrSigner;
+  migrationComplete?: boolean;
 }) => {
   if (encryptedPrivateKey) {
     localStorage.setItem(
@@ -864,6 +866,10 @@ export const setLocalStorageDataOnSignIn = ({
     localStorage.setItem(LOCALSTORAGECONSTANTS.signer, JSON.stringify(signer));
   }
 
+  if (migrationComplete) {
+    localStorage.setItem("migrationComplete", migrationComplete.toString());
+  }
+
   window.dispatchEvent(new Event("storage"));
 };
 
@@ -885,6 +891,7 @@ export interface LocalStorageInterface {
   bunkerRelays?: string[];
   bunkerSecret?: string;
   signer?: { [key: string]: string };
+  migrationComplete?: boolean;
 }
 
 export const getLocalStorageData = (): LocalStorageInterface => {
@@ -902,6 +909,7 @@ export const getLocalStorageData = (): LocalStorageInterface => {
   let bunkerRelays;
   let bunkerSecret;
   let signer;
+  let migrationComplete;
 
   if (typeof window !== "undefined") {
     encryptedPrivateKey = localStorage.getItem(
@@ -1025,6 +1033,8 @@ export const getLocalStorageData = (): LocalStorageInterface => {
           break;
       }
     }
+
+    migrationComplete = localStorage.getItem("migrationComplete") === "true";
   }
   return {
     signInMethod: signInMethod as string,
@@ -1041,6 +1051,7 @@ export const getLocalStorageData = (): LocalStorageInterface => {
     bunkerRelays: bunkerRelays || [],
     bunkerSecret: bunkerSecret?.toString(),
     signer,
+    migrationComplete: migrationComplete || false,
   };
 };
 

--- a/utils/nostr/nostr-manager.ts
+++ b/utils/nostr/nostr-manager.ts
@@ -8,7 +8,7 @@ import {
 import {
   SubscribeManyParams,
   SubCloser,
-} from "nostr-tools/lib/types/abstract-pool";
+} from "nostr-tools/abstract-pool";
 
 import { NostrNIP46Signer } from "@/utils/nostr/signers/nostr-nip46-signer";
 import {

--- a/utils/nostr/signers/nostr-nsec-signer.ts
+++ b/utils/nostr/signers/nostr-nsec-signer.ts
@@ -13,6 +13,7 @@ import {
   NostrSigner,
 } from "@/utils/nostr/signers/nostr-signer";
 import * as nip49 from "nostr-tools/nip49";
+
 export type PassphraseResponse = {
   passphrase: string;
   remember: boolean;
@@ -77,11 +78,6 @@ export class NostrNSecSigner implements NostrSigner {
     this.challengeHandler = challengeHandler;
     this.pubkey = pubkey;
     this.passphrase = passphrase;
-    
-    // Add debugging
-    console.log("NSEC Signer - key begins with:", encryptedPrivKey.substring(0, 10));
-    console.log("NSEC Signer - detecting NIP-49 format:", encryptedPrivKey.startsWith('ncryptsec'));
-    
     this.isNip49Format = encryptedPrivKey.startsWith('ncryptsec');
   }
 

--- a/utils/nostr/signers/nostr-nsec-signer.ts
+++ b/utils/nostr/signers/nostr-nsec-signer.ts
@@ -12,7 +12,7 @@ import {
   ChallengeHandler,
   NostrSigner,
 } from "@/utils/nostr/signers/nostr-signer";
-
+import * as nip49 from "nostr-tools/nip49";
 export type PassphraseResponse = {
   passphrase: string;
   remember: boolean;
@@ -27,6 +27,7 @@ export class NostrNSecSigner implements NostrSigner {
   private rememberedPassphrase?: string;
   private inputPassphrase?: string;
   private inputPassphraseClearer?: any;
+  private isNip49Format: boolean = false;
 
   public static getEncryptedNSEC(
     privKey: Uint8Array | string,
@@ -36,17 +37,25 @@ export class NostrNSecSigner implements NostrSigner {
     passphrase: string;
     pubkey: string;
   } {
-    if (typeof privKey !== "string" || !privKey.startsWith("nsec")) {
-      if (typeof privKey === "string") privKey = hexToBytes(privKey);
-      privKey = nip19.nsecEncode(privKey);
+    let secretKey: Uint8Array;
+    if (typeof privKey === "string") {
+      if (privKey.startsWith("nsec")) {
+        secretKey = nip19.decode(privKey).data as Uint8Array;
+      } else {
+        secretKey = hexToBytes(privKey);
+      }
+    } else {
+      secretKey = privKey;
     }
-    const pubkey = getPublicKey(
-      nip19.decode(privKey as string).data as Uint8Array
+    
+    const pubkey = getPublicKey(secretKey);
+    const encryptedKey = nip49.encrypt(
+      secretKey,
+      passphrase
     );
-
-    privKey = CryptoJS.AES.encrypt(privKey as string, passphrase).toString();
+    
     return {
-      encryptedPrivKey: privKey as string,
+      encryptedPrivKey: encryptedKey,
       passphrase,
       pubkey,
     };
@@ -68,6 +77,7 @@ export class NostrNSecSigner implements NostrSigner {
     this.challengeHandler = challengeHandler;
     this.pubkey = pubkey;
     this.passphrase = passphrase;
+    this.isNip49Format = encryptedPrivKey.startsWith("ncryptsec");
   }
 
   static fromJSON(
@@ -140,15 +150,24 @@ export class NostrNSecSigner implements NostrSigner {
           error
         );
 
-        const privkey = CryptoJS.AES.decrypt(
-          this.encryptedPrivKey,
-          passphrase
-        ).toString(CryptoJS.enc.Utf8);
-        if (!privkey) throw new Error("Invalid passphrase");
+        let privKeyBytes: Uint8Array;
 
-        const privKeyBytes: Uint8Array = privkey.startsWith("nsec")
-          ? (nip19.decode(privkey).data as Uint8Array)
-          : hexToBytes(privkey);
+        if (this.isNip49Format) {
+          privKeyBytes = await nip49.decrypt(
+            this.encryptedPrivKey,
+            passphrase
+          );
+        } else {
+          const privkey = CryptoJS.AES.decrypt(
+            this.encryptedPrivKey,
+            passphrase
+          ).toString(CryptoJS.enc.Utf8); 
+          if (!privkey) throw new Error("Invalid passphrase");
+
+          privKeyBytes = privkey.startsWith("nsec")
+            ? (nip19.decode(privkey).data as Uint8Array)
+            : hexToBytes(privkey);
+        }
 
         if (remember) {
           this.rememberedPassphrase = passphrase;

--- a/utils/nostr/signers/nostr-nsec-signer.ts
+++ b/utils/nostr/signers/nostr-nsec-signer.ts
@@ -77,7 +77,12 @@ export class NostrNSecSigner implements NostrSigner {
     this.challengeHandler = challengeHandler;
     this.pubkey = pubkey;
     this.passphrase = passphrase;
-    this.isNip49Format = encryptedPrivKey.startsWith("ncryptsec");
+    
+    // Add debugging
+    console.log("NSEC Signer - key begins with:", encryptedPrivKey.substring(0, 10));
+    console.log("NSEC Signer - detecting NIP-49 format:", encryptedPrivKey.startsWith('ncryptsec'));
+    
+    this.isNip49Format = encryptedPrivKey.startsWith('ncryptsec');
   }
 
   static fromJSON(


### PR DESCRIPTION
## Description
This PR implements the [NIP-49 standard](https://github.com/nostr-protocol/nips/blob/master/49.md) for encrypting private keys in Shopstr, providing enhanced security through improved key derivation and encryption methods. It includes a seamless migration path for users with existing keys stored with the legacy AES encryption.

## Changes
- Added NIP-49 encryption/decryption support in NostrNSecSigner
- Created a migration utility to convert legacy AES encrypted keys to NIP-49 format
- Implemented a migration prompt modal to guide users through the upgrade process
- Fixed the migration logic to handle keys stored in both direct and signer object locations

## Implementation Details

### Key Improvements
- **Better Security**: NIP-49 uses scrypt for key derivation and XChaCha20-Poly1305 for encryption (vs simple AES)
- **Standardized Format**: All encrypted keys now use the industry-standard NIP-49 format (ncryptsec prefix)
- **Seamless Migration**: Users are prompted once to enter their passphrase for migration without disrupting their experience

### Migration Logic
The migration process:
1. Detects legacy AES encrypted keys (U2FsdGVkX1 prefix)
2. Prompts users for their passphrase
3. Decrypts with the old method, then re-encrypts with NIP-49
4. Updates localStorage with the newly encrypted key
5. Sets a flag to prevent repeated migration attempts

## Testing Instructions
1. After updating, users with legacy keys will see a migration prompt when logging in
2. Enter the same passphrase used to encrypt the original key
3. Verify that login continues to work after migration
4. Check developer console(disable errors to make it easy to see in between cors errors) to see migration success message

## Security Considerations
- The migration only happens once per key
- Users maintain control of their passphrase throughout the process
- All encryption/decryption happens client-side

## Screenshots
- #### Signing in with new encryption model (no migration need)
<img width="1437" alt="Screenshot 2025-04-16 at 6 08 37 PM" src="https://github.com/user-attachments/assets/0747fd7a-4dd6-40e9-9014-6d8feb2929b4" />

- #### Signing in with current main branch
<img width="1437" alt="Screenshot 2025-04-16 at 6 12 12 PM" src="https://github.com/user-attachments/assets/e0932b2a-d402-4df9-9a8e-90b7f3aa9584" />

- #### Switching to nip49encryption(triggers migration logic)
<img width="1438" alt="Screenshot 2025-04-16 at 6 14 40 PM" src="https://github.com/user-attachments/assets/bc15dc65-f185-4b6c-a636-399b71ba1dbc" />

- #### After the migration using passphrase
<img width="1440" alt="Screenshot 2025-04-16 at 6 15 53 PM" src="https://github.com/user-attachments/assets/46d2bd6e-d4c0-4360-964f-e175e55db975" />



