### PR TITLE
Added P2PK Time-Locked Cashu Tokens

### DIFF
--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useContext, useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import {
@@ -72,7 +71,6 @@ import {
   ShippingFormData,
   ContactFormData,
   CombinedFormData,
-  GetInfoResponse,
 } from "@/utils/types/types";
 
 export default function CartInvoiceCard({
@@ -1159,7 +1157,7 @@ export default function CartInvoiceCard({
 
       if (sellerAmount > 0) {
         const mint = new CashuMint(mints[0]!);
-        const info = (await mint.getInfo()) as unknown as GetInfoResponse;
+        const info = (await mint.getInfo()) as any;
         // NUT-11 support is advertised in `methods["11"].supported`
         if (!info.methods?.["11"]?.supported) {
           throw new Error("Mint does not support P2PK (NUT-11)");
@@ -1781,15 +1779,15 @@ export default function CartInvoiceCard({
       );
 
       const pubkey = products[0]!.pubkey;
-      const shopProfile = profileContext.profileData.get(pubkey);
-      const p2pk = shopProfile?.content?.p2pk;
+      const sellerProfile = profileContext.profileData.get(pubkey);
+      const p2pk = sellerProfile?.content?.p2pk;
 
       const tags = p2pk?.tags || [];
       const p2pkOptions = p2pk?.enabled
         ? {
             pubkey:     p2pk.pubkey,
-            locktime:   Math.floor(Date.now() / 1000) + (p2pk?.locktime_days || 0) * 86400,
-            refundKeys: p2pk.refund_pubkeys,
+            locktime:   p2pk.locktime,
+            refundKeys: p2pk.refund || [],
             sigflag:    tags.find((t: any) => t[0] === "sigflag")?.[1],
             nSigs:      Number(tags.find((t: any) => t[0] === "n_sigs")?.[1]),
             pubkeys:    tags.filter((t: any) => t[0] === "pubkeys").map((t: any) => t[1]),

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useContext, useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import {
@@ -1158,7 +1159,8 @@ export default function CartInvoiceCard({
       if (sellerAmount > 0) {
         const mint = new CashuMint(mints[0]!);
         const info = await mint.getInfo();
-        if (!info.supported_nuts?.includes(11)) {
+        // NUT-11 support is advertised in `methods["11"].supported`
+        if (!info.methods?.["11"]?.supported) {
           throw new Error("Mint does not support P2PK (NUT-11)");
         }
         const { keep, send } = await wallet.send(

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -176,7 +176,7 @@ export default function CartInvoiceCard({
       const firstSellerProfile = profileContext.profileData.get(
         firstProduct.pubkey
       );
-      const p2pk = firstSellerProfile?.content?.p2pk;
+      const _p2pk = firstSellerProfile?.content?.p2pk;
       let commonFiatOptions = firstSellerProfile?.content?.fiat_options || [];
 
       for (let i = 1; i < products.length; i++) {

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -176,7 +176,6 @@ export default function CartInvoiceCard({
       const firstSellerProfile = profileContext.profileData.get(
         firstProduct.pubkey
       );
-      const _p2pk = firstSellerProfile?.content?.p2pk;
       let commonFiatOptions = firstSellerProfile?.content?.fiat_options || [];
 
       for (let i = 1; i < products.length; i++) {

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -1160,7 +1160,7 @@ export default function CartInvoiceCard({
         const mint = new CashuMint(mints[0]!);
         const info = await mint.getInfo();
         // NUT-11 support is advertised in `methods["11"].supported`
-        if (!info.methods?.["11"]?.supported) {
+        if (!info.nuts?.some(nut => nut.nut === 11)) {
           throw new Error("Mint does not support P2PK (NUT-11)");
         }
         const { keep, send } = await wallet.send(

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -72,6 +72,7 @@ import {
   ShippingFormData,
   ContactFormData,
   CombinedFormData,
+  GetInfoResponse,
 } from "@/utils/types/types";
 
 export default function CartInvoiceCard({
@@ -1158,9 +1159,9 @@ export default function CartInvoiceCard({
 
       if (sellerAmount > 0) {
         const mint = new CashuMint(mints[0]!);
-        const info = await mint.getInfo();
+        const info = (await mint.getInfo()) as GetInfoResponse;
         // NUT-11 support is advertised in `methods["11"].supported`
-        if (!info.nuts?.some(nut => nut.nut === 11)) {
+        if (!info.methods?.["11"]?.supported) {
           throw new Error("Mint does not support P2PK (NUT-11)");
         }
         const { keep, send } = await wallet.send(

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -1739,6 +1739,10 @@ export default function CartInvoiceCard({
         throw new Error("Wallet context not available");
       }
 
+      if (!products || products.length === 0) {
+        throw new Error("No products available");
+      }
+
       if (
         shippingName ||
         shippingAddress ||
@@ -1775,15 +1779,20 @@ export default function CartInvoiceCard({
         (p: Proof) =>
           mintKeySetIds?.some((keysetId: MintKeyset) => keysetId.id === p.id)
       );
-      const tags = shopProfile.content.p2pk.tags || []; 
+
+      const pubkey = products[0]!.pubkey;
+      const shopProfile = profileContext.profileData.get(pubkey);
+      const p2pk = shopProfile?.content?.p2pk;
+
+      const tags = p2pk?.tags || [];
       const p2pkOptions = p2pk?.enabled
         ? {
             pubkey:     p2pk.pubkey,
-            locktime:   Math.floor(Date.now()/1000) + p2pk.locktime_days*86400,
+            locktime:   Math.floor(Date.now() / 1000) + (p2pk?.locktime_days || 0) * 86400,
             refundKeys: p2pk.refund_pubkeys,
-            sigflag:    tags.find(t=>t[0]==="sigflag")?.[1],
-            nSigs:      Number(tags.find(t=>t[0]==="n_sigs")?.[1]),
-            pubkeys:    tags.filter(t=>t[0]==="pubkeys").map(t=>t[1]),
+            sigflag:    tags.find((t: any) => t[0] === "sigflag")?.[1],
+            nSigs:      Number(tags.find((t: any) => t[0] === "n_sigs")?.[1]),
+            pubkeys:    tags.filter((t: any) => t[0] === "pubkeys").map((t: any) => t[1]),
           }
         : undefined;
       

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -1159,7 +1159,7 @@ export default function CartInvoiceCard({
 
       if (sellerAmount > 0) {
         const mint = new CashuMint(mints[0]!);
-        const info = (await mint.getInfo()) as GetInfoResponse;
+        const info = (await mint.getInfo()) as unknown as GetInfoResponse;
         // NUT-11 support is advertised in `methods["11"].supported`
         if (!info.methods?.["11"]?.supported) {
           throw new Error("Mint does not support P2PK (NUT-11)");

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -134,7 +134,9 @@ export default function CartInvoiceCard({
   const [showFailureModal, setShowFailureModal] = useState(false);
   const [failureText, setFailureText] = useState("");
   const [requiredInfo, setRequiredInfo] = useState("");
-
+  
+  const { pubkey: buyerPubkey } = useContext(SignerContext);
+  
   useEffect(() => {
     if (products && products.length > 0) {
       const requiredFields = products
@@ -1777,7 +1779,7 @@ export default function CartInvoiceCard({
         (p: Proof) =>
           mintKeySetIds?.some((keysetId: MintKeyset) => keysetId.id === p.id)
       );
-
+       
       const pubkey = products[0]!.pubkey;
       const sellerProfile = profileContext.profileData.get(pubkey);
       const p2pk = sellerProfile?.content?.p2pk;
@@ -1787,7 +1789,10 @@ export default function CartInvoiceCard({
         ? {
             pubkey:     p2pk.pubkey,
             locktime:   p2pk.locktime,
-            refundKeys: p2pk.refund || [],
+            refundKeys: [
+              ...(p2pk.refund || []),
+              buyerPubkey!
+            ],
             sigflag:    tags.find((t: any) => t[0] === "sigflag")?.[1],
             nSigs:      Number(tags.find((t: any) => t[0] === "n_sigs")?.[1]),
             pubkeys:    tags.filter((t: any) => t[0] === "pubkeys").map((t: any) => t[1]),

--- a/components/product-invoice-card.tsx
+++ b/components/product-invoice-card.tsx
@@ -36,7 +36,7 @@ import {
   CashuWallet,
   getEncodedToken,
   MintKeyset,
-  Proof,
+  Proof, 
 } from "@cashu/cashu-ts";
 import {
   constructGiftWrappedEvent,
@@ -1526,16 +1526,16 @@ export default function ProductInvoiceCard({
       );
 
       const pubkey = productData.pubkey;
-      const shopProfile = profileContext.profileData.get(pubkey);
-      const p2pk = shopProfile?.content?.p2pk;
+      const sellerProfile = profileContext.profileData.get(pubkey);
+      const p2pk = sellerProfile?.content?.p2pk;
 
       const tags = p2pk?.tags || [];
       // build p2pk options only if enabled
       const p2pkOptions = p2pk?.enabled
         ? {
-            pubkey:       p2pk.pubkey,
-            locktime:     Math.floor(Date.now()/1000) + p2pk.locktime_days * 86400,
-            refundKeys:   p2pk.refund_pubkeys,
+            pubkey:     p2pk.pubkey,
+            locktime:   p2pk.locktime,
+            refundKeys: p2pk.refund || [],
             sigflag:    tags.find((t: any) => t[0] === "sigflag")?.[1],
             nSigs:      Number(tags.find((t: any) => t[0] === "n_sigs")?.[1]),
             pubkeys:    tags.filter((t: any) => t[0] === "pubkeys").map((t: any) => t[1]),

--- a/components/product-invoice-card.tsx
+++ b/components/product-invoice-card.tsx
@@ -162,7 +162,7 @@ export default function ProductInvoiceCard({
 
   useEffect(() => {
     const sellerProfile = profileContext.profileData.get(productData.pubkey);
-    const p2pk = sellerProfile?.content?.p2pk;
+    const _p2pk = sellerProfile?.content?.p2pk;
     const fiatOptions = sellerProfile?.content?.fiat_options || [];
     setFiatPaymentOptions(fiatOptions);
   }, [productData.pubkey, profileContext.profileData]);

--- a/components/product-invoice-card.tsx
+++ b/components/product-invoice-card.tsx
@@ -162,7 +162,6 @@ export default function ProductInvoiceCard({
 
   useEffect(() => {
     const sellerProfile = profileContext.profileData.get(productData.pubkey);
-    const _p2pk = sellerProfile?.content?.p2pk;
     const fiatOptions = sellerProfile?.content?.fiat_options || [];
     setFiatPaymentOptions(fiatOptions);
   }, [productData.pubkey, profileContext.profileData]);
@@ -1005,7 +1004,7 @@ export default function ProductInvoiceCard({
     if (sellerAmount > 0) {
       const mint = new CashuMint(mints[0]!);
       const info = await mint.getInfo();
-      if (!info.supported_nuts?.includes(11)) {
+      if (!info.nuts?.[11]) {
         throw new Error("Mint does not support P2PK (NUT-11)");
       }
       const { keep, send } = await wallet.send(sellerAmount, remainingProofs, {
@@ -1525,15 +1524,21 @@ export default function ProductInvoiceCard({
         (p: Proof) =>
           mintKeySetIds?.some((keysetId: MintKeyset) => keysetId.id === p.id)
       );
+
+      const pubkey = productData.pubkey;
+      const shopProfile = profileContext.profileData.get(pubkey);
+      const p2pk = shopProfile?.content?.p2pk;
+
+      const tags = p2pk?.tags || [];
       // build p2pk options only if enabled
       const p2pkOptions = p2pk?.enabled
         ? {
             pubkey:       p2pk.pubkey,
             locktime:     Math.floor(Date.now()/1000) + p2pk.locktime_days * 86400,
             refundKeys:   p2pk.refund_pubkeys,
-            sigflag:    tags.find(t=>t[0]==="sigflag")?.[1],
-            nSigs:      Number(tags.find(t=>t[0]==="n_sigs")?.[1]),
-            pubkeys:    tags.filter(t=>t[0]==="pubkeys").map(t=>t[1]),
+            sigflag:    tags.find((t: any) => t[0] === "sigflag")?.[1],
+            nSigs:      Number(tags.find((t: any) => t[0] === "n_sigs")?.[1]),
+            pubkeys:    tags.filter((t: any) => t[0] === "pubkeys").map((t: any) => t[1]),
           }
         : undefined;
       

--- a/components/product-invoice-card.tsx
+++ b/components/product-invoice-card.tsx
@@ -146,6 +146,8 @@ export default function ProductInvoiceCard({
     reset: contactReset,
   } = useForm();
 
+  const { pubkey: buyerPubkey } = useContext(SignerContext);
+
   useEffect(() => {
     const fetchKeys = async () => {
       const { nsec: nsecForSender, npub: npubForSender } = await generateKeys();
@@ -1524,7 +1526,7 @@ export default function ProductInvoiceCard({
         (p: Proof) =>
           mintKeySetIds?.some((keysetId: MintKeyset) => keysetId.id === p.id)
       );
-
+      
       const pubkey = productData.pubkey;
       const sellerProfile = profileContext.profileData.get(pubkey);
       const p2pk = sellerProfile?.content?.p2pk;
@@ -1535,7 +1537,10 @@ export default function ProductInvoiceCard({
         ? {
             pubkey:     p2pk.pubkey,
             locktime:   p2pk.locktime,
-            refundKeys: p2pk.refund || [],
+            refundKeys: [
+              ...(p2pk.refund || []),
+              buyerPubkey! 
+            ],
             sigflag:    tags.find((t: any) => t[0] === "sigflag")?.[1],
             nSigs:      Number(tags.find((t: any) => t[0] === "n_sigs")?.[1]),
             pubkeys:    tags.filter((t: any) => t[0] === "pubkeys").map((t: any) => t[1]),

--- a/components/utility-components/checkout-card.tsx
+++ b/components/utility-components/checkout-card.tsx
@@ -48,7 +48,7 @@ export default function CheckoutCard({
 }) {
   const { pubkey: userPubkey, isLoggedIn } = useContext(SignerContext);
   const { shopData } = useContext(ShopMapContext);
-  const ShopProfile: ShopProfile | undefined = shopData.get(productData.pubkey);
+  const shopProfile: ShopProfile | undefined = shopData.get(productData.pubkey);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const router = useRouter();

--- a/components/utility-components/checkout-card.tsx
+++ b/components/utility-components/checkout-card.tsx
@@ -47,6 +47,8 @@ export default function CheckoutCard({
   uniqueKey?: string;
 }) {
   const { pubkey: userPubkey, isLoggedIn } = useContext(SignerContext);
+  const { shopData } = useContext(ShopMapContext);
+  const ShopProfile: ShopProfile | undefined = shopData.get(productData.pubkey);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const router = useRouter();
@@ -79,7 +81,6 @@ export default function CheckoutCard({
   const [cart, setCart] = useState<ProductData[]>([]);
 
   const reviewsContext = useContext(ReviewsContext);
-  const shopMapContext = useContext(ShopMapContext);
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded);
@@ -122,20 +123,11 @@ export default function CheckoutCard({
 
   useEffect(() => {
     setIsFetchingShop(true);
-    if (
-      productData.pubkey &&
-      shopMapContext.shopData.has(productData.pubkey) &&
-      typeof shopMapContext.shopData.get(productData.pubkey) != "undefined"
-    ) {
-      const shopProfile: ShopProfile | undefined = shopMapContext.shopData.get(
-        productData.pubkey
-      );
-      if (shopProfile) {
-        setShopBannerURL(shopProfile.content.ui.banner);
-      }
+    if (shopProfile) {
+      setShopBannerURL(shopProfile.content.ui.banner);
     }
     setIsFetchingShop(false);
-  }, [productData.pubkey, shopMapContext, shopBannerURL]);
+  }, [shopProfile]);
 
   useEffect(() => {
     setIsFetchingReviews(true);
@@ -379,7 +371,7 @@ export default function CheckoutCard({
                       pubkey={productData.pubkey}
                       dropDownKeys={
                         productData.pubkey === userPubkey
-                          ? ["shop_profile"]
+                          ? ["shop_settings"]
                           : ["shop", "inquiry", "copy_npub"]
                       }
                     />
@@ -650,6 +642,18 @@ export default function CheckoutCard({
               </p>
             </div>
           </div>
+          
+          {/* ── P2PK Lock Notice ── */}
+          {shopProfile?.content.p2pk?.enabled && (() => {
+            const now = Math.floor(Date.now() / 1000);
+            const days = Math.max(0, Math.ceil((shopProfile.content.p2pk.locktime - now) / 86400));
+            return (
+              <div className="…">
+                🔒 Funds locked to <code>{shopProfile.content.p2pk.pubkey.slice(0,8)}…</code> for {days} day{days !== 1 ? "s" : ""}
+              </div>
+            );
+          })()}
+          
           <div className="flex flex-col items-center">
             <ProductInvoiceCard
               productData={productData}

--- a/components/utility-components/checkout-card.tsx
+++ b/components/utility-components/checkout-card.tsx
@@ -18,12 +18,13 @@ import {
   FaceSmileIcon,
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
-import { ReviewsContext } from "@/utils/context/context";
+import { ReviewsContext, ProfileMapContext } from "@/utils/context/context";
 import FailureModal from "../utility-components/failure-modal";
 import SuccessModal from "../utility-components/success-modal";
 import SignInModal from "../sign-in/SignInModal";
 import currencySelection from "../../public/currencySelection.json";
 import { SignerContext } from "@/components/utility-components/nostr-context-provider";
+import { ProfileData } from "@/utils/types/types";
 
 const SUMMARY_CHARACTER_LIMIT = 100;
 
@@ -45,8 +46,8 @@ export default function CheckoutCard({
   uniqueKey?: string;
 }) {
   const { pubkey: userPubkey, isLoggedIn } = useContext(SignerContext);
-  const { shopData } = useContext(ShopMapContext);
-  const shopProfile: ShopProfile | undefined = shopData.get(productData.pubkey);
+  const profileMap = useContext(ProfileMapContext).profileData;
+  const sellerProfile: ProfileData | undefined = profileMap.get(productData.pubkey);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const router = useRouter();
@@ -621,13 +622,12 @@ export default function CheckoutCard({
             </div>
           </div>
           
-          {/* ── P2PK Lock Notice ── */}
-          {shopProfile?.content.p2pk?.enabled && (() => {
+          {sellerProfile?.content.p2pk?.enabled && (() => {
             const now = Math.floor(Date.now() / 1000);
-            const days = Math.max(0, Math.ceil((shopProfile.content.p2pk.locktime - now) / 86400));
+            const days = Math.max(0, Math.ceil((sellerProfile.content.p2pk!.locktime - now) / 86400));
             return (
               <div className="…">
-                🔒 Funds locked to <code>{shopProfile.content.p2pk.pubkey.slice(0,8)}…</code> for {days} day{days !== 1 ? "s" : ""}
+                🔒 Funds locked to <code>{sellerProfile.content.p2pk!.pubkey.slice(0,8)}…</code> for {days} day{days !== 1 ? "s" : ""}
               </div>
             );
           })()}

--- a/components/utility-components/checkout-card.tsx
+++ b/components/utility-components/checkout-card.tsx
@@ -371,7 +371,7 @@ export default function CheckoutCard({
                       pubkey={productData.pubkey}
                       dropDownKeys={
                         productData.pubkey === userPubkey
-                          ? ["shop_settings"]
+                          ? ["shop_profile"]
                           : ["shop", "inquiry", "copy_npub"]
                       }
                     />

--- a/components/utility-components/claim-button.tsx
+++ b/components/utility-components/claim-button.tsx
@@ -47,8 +47,8 @@ function parseP2PK(proof: Proof) {
     if (kind !== "P2PK") return null;
     const locktime = Number(tags.find((t: any[]) => t[0] === "locktime")?.[1] || 0);
     const refundKeys = tags
-      .filter((t) => t[0] === "refund")
-      .map((t) => t[1]);
+      .filter((t: any[]) => t[0] === "refund")
+      .map((t: any[]) => t[1]);
     return { pubkey, locktime, refundKeys };
   } catch {
     return null;
@@ -75,7 +75,7 @@ export default function ClaimButton({ token }: { token: string }) {
   const [p2pkInfo, setP2pkInfo] = useState<{ pubkey: string; locktime: number; refundKeys: string[] } | null>(null);
   useEffect(() => {
     if (proofs.length > 0) {
-      const info = parseP2PK(proofs[0]);
+      const info = parseP2PK(proofs[0]!);
       setP2pkInfo(info);
     }
   }, [proofs]);
@@ -346,9 +346,8 @@ export default function ClaimButton({ token }: { token: string }) {
           locktime: 0,
           refundKeys: p2pkInfo.refundKeys,
         },
-      }
+      } as any
     );
-    const _refundToken = getEncodedToken({ mint: tokenMint, proofs: send });
     setIsRedeemed(true);
   } catch (err) {
     console.error("Refund failed", err);

--- a/components/utility-components/claim-button.tsx
+++ b/components/utility-components/claim-button.tsx
@@ -336,7 +336,7 @@ export default function ClaimButton({ token }: { token: string }) {
   if (!wallet || !p2pkInfo?.refundKeys) return;
   setIsRedeeming(true);
   try {
-    const { send } = await wallet.send(
+    await wallet.send(
       tokenAmount,
       proofs,
       {

--- a/components/utility-components/claim-button.tsx
+++ b/components/utility-components/claim-button.tsx
@@ -348,7 +348,7 @@ export default function ClaimButton({ token }: { token: string }) {
         },
       }
     );
-    const refundToken = getEncodedToken({ mint: tokenMint, proofs: send });
+    const _refundToken = getEncodedToken({ mint: tokenMint, proofs: send });
     setIsRedeemed(true);
   } catch (err) {
     console.error("Refund failed", err);

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -11,8 +11,8 @@ import { ProductData } from "@/utils/parsers/product-parser-functions";
 import { ProfileWithDropdown } from "./profile/profile-dropdown";
 import { useRouter } from "next/router";
 import { SignerContext } from "@/components/utility-components/nostr-context-provider";
-import { ShopMapContext } from "@/utils/context/context";
-import { ShopProfile } from "../../utils/types/types";
+import { ProfileMapContext } from "@/utils/context/context";
+import { ProfileData } from "@/utils/types/types";
 
 export default function ProductCard({
   productData,
@@ -27,9 +27,12 @@ export default function ProductCard({
 }) {
   const router = useRouter();
   const { pubkey: userPubkey } = useContext(SignerContext);
-  const shopMap = useContext(ShopMapContext).shopData;
-  const shopProfile: ShopProfile | undefined = shopMap.get(productData.pubkey);
-  const p2pk = shopProfile?.content.p2pk;
+
+  const profileMap = useContext(ProfileMapContext).profileData;
+  const sellerProfile: ProfileData | undefined = profileMap.get(
+    productData.pubkey
+  );
+  const p2pk = sellerProfile?.content.p2pk;
 
   if (!productData) return null;
 
@@ -90,7 +93,8 @@ export default function ProductCard({
           <div className="mx-4 mt-4 flex items-center text-sm text-neutral-500 dark:text-neutral-300">
             <InformationCircleIcon className="mr-2 h-5 w-5" />
             <p>
-              Once purchased, the seller will receive a DM with your order details.
+              Once purchased, the seller will receive a DM with your order
+              details.
             </p>
           </div>
         </CardBody>
@@ -153,6 +157,7 @@ export default function ProductCard({
                 <CompactPriceDisplay monetaryInfo={productData} />
               </div>
             )}
+
             {/* ── P2PK indicator ── */}
             {p2pk?.enabled && (() => {
               const now = Math.floor(Date.now() / 1000);

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -11,6 +11,8 @@ import { ProductData } from "@/utils/parsers/product-parser-functions";
 import { ProfileWithDropdown } from "./profile/profile-dropdown";
 import { useRouter } from "next/router";
 import { SignerContext } from "@/components/utility-components/nostr-context-provider";
+import { ShopMapContext } from "@/utils/context/context";
+import { ShopProfile } from "../../utils/types/types";
 
 export default function ProductCard({
   productData,
@@ -25,19 +27,21 @@ export default function ProductCard({
 }) {
   const router = useRouter();
   const { pubkey: userPubkey } = useContext(SignerContext);
+  const shopMap = useContext(ShopMapContext).shopData;
+  const shopProfile: ShopProfile | undefined = shopMap.get(productData.pubkey);
+  const p2pk = shopProfile?.content.p2pk;
+
   if (!productData) return null;
 
   const cardHoverStyle =
     "hover:shadow-purple-500/30 dark:hover:shadow-yellow-500/30 hover:scale-[1.01]";
 
-  if (isReview)
+  if (isReview) {
     return (
       <Card className="mx-2 my-3 w-full rounded-2xl bg-white shadow-lg dark:bg-neutral-900">
         <CardBody
           className="cursor-pointer p-6"
-          onClick={() => {
-            onProductClick && onProductClick(productData);
-          }}
+          onClick={() => onProductClick?.(productData)}
         >
           <div className="flex w-full justify-between pb-4">
             <ProfileWithDropdown
@@ -86,14 +90,14 @@ export default function ProductCard({
           <div className="mx-4 mt-4 flex items-center text-sm text-neutral-500 dark:text-neutral-300">
             <InformationCircleIcon className="mr-2 h-5 w-5" />
             <p>
-              Once purchased, the seller will receive a DM with your order
-              details.
+              Once purchased, the seller will receive a DM with your order details.
             </p>
           </div>
         </CardBody>
         {footerContent && <CardFooter>{footerContent}</CardFooter>}
       </Card>
     );
+  }
 
   return (
     <div
@@ -102,17 +106,13 @@ export default function ProductCard({
       <div className="w-80 overflow-hidden rounded-2xl">
         <div
           className="cursor-pointer"
-          onClick={() => {
-            onProductClick && onProductClick(productData);
-          }}
+          onClick={() => onProductClick?.(productData)}
         >
-          <div>
-            <ImageCarousel
-              images={productData.images}
-              classname="w-full h-[300px] rounded-t-2xl"
-              showThumbs={false}
-            />
-          </div>
+          <ImageCarousel
+            images={productData.images}
+            classname="w-full h-[300px] rounded-t-2xl"
+            showThumbs={false}
+          />
           <div className="flex flex-col p-4">
             {router.pathname !== "/" && (
               <div className="mb-2 flex items-center justify-between">
@@ -153,6 +153,16 @@ export default function ProductCard({
                 <CompactPriceDisplay monetaryInfo={productData} />
               </div>
             )}
+            {/* ── P2PK indicator ── */}
+            {p2pk?.enabled && (() => {
+              const now = Math.floor(Date.now() / 1000);
+              const days = Math.max(0, Math.ceil((p2pk.locktime - now) / 86400));
+              return (
+                <div className="mt-2 text-xs italic text-gray-600 dark:text-gray-400">
+                  🔒 Locked for {days} day{days !== 1 ? "s" : ""}
+                </div>
+              );
+            })()}
           </div>
         </div>
       </div>

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useRouter } from "next/router";
 import { Button } from "@nextui-org/react";
 import {
@@ -18,6 +18,7 @@ import { DisplayCostBreakdown } from "../../components/utility-components/displa
 import CartInvoiceCard from "../../components/cart-invoice-card";
 import { fiat } from "@getalby/lightning-tools";
 import currencySelection from "../../public/currencySelection.json";
+import { ProfileMapContext } from "@/utils/context/context";
 
 interface QuantitySelectorProps {
   value: number;
@@ -70,6 +71,7 @@ function QuantitySelector({
 
 export default function Component() {
   const [products, setProducts] = useState<ProductData[]>([]);
+  const profileContext = useContext(ProfileMapContext);
   const [satPrices, setSatPrices] = useState<{ [key: string]: number | null }>(
     {}
   );
@@ -363,6 +365,25 @@ export default function Component() {
                                   : "Price unavailable"
                                 : "Loading..."}
                             </p>
+                            {(() => {
+                              const sellerProfile = profileContext.profileData.get(
+                                product.pubkey
+                              );
+                              if (sellerProfile?.content.p2pk?.enabled) {
+                                const now = Math.floor(Date.now() / 1000);
+                                const locktime = sellerProfile.content.p2pk.locktime;
+                                const days = Math.max(
+                                  0,
+                                  Math.ceil((locktime - now) / 86400)
+                                );
+                                return (
+                                  <p className="mt-1 text-xs italic text-gray-500 dark:text-gray-400">
+                                    🔒 Locked for {days} day{days !== 1 ? "s" : ""}
+                                  </p>
+                                );
+                              }
+                              return null;
+                            })()}
                           </div>
                           {product.quantity && (
                             <div className="mt-2">
@@ -460,6 +481,25 @@ export default function Component() {
                     className="mb-6 rounded-lg border border-gray-300 p-4 shadow-sm dark:border-gray-700"
                   >
                     <h2 className="mb-4 text-xl font-bold">{product.title}</h2>
+                    {(() => {
+                      const sellerProfile = profileContext.profileData.get(
+                        product.pubkey
+                      );
+                      if (sellerProfile?.content.p2pk?.enabled) {
+                        const now = Math.floor(Date.now() / 1000);
+                        const locktime = sellerProfile.content.p2pk.locktime;
+                        const days = Math.max(
+                          0,
+                          Math.ceil((locktime - now) / 86400)
+                        );
+                        return (
+                          <p className="mb-2 text-sm italic text-gray-500 dark:text-gray-400">
+                            🔒 Locked for {days} day{days !== 1 ? "s" : ""}
+                          </p>
+                        );
+                      }
+                      return null;
+                    })()}
                     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                       {product.selectedSize && (
                         <p className="text-base">

--- a/pages/faq/index.tsx
+++ b/pages/faq/index.tsx
@@ -51,6 +51,11 @@ export default function Faq() {
           content:
             "Sellers can offer different shipping options including free shipping, local pickup, or an added shipping cost. The shipping method and any restrictions should be clearly specified in each listing and fulfillment will be handled by the merchant themselves.",
         },
+        {
+          title: "What is P2PK Time-Lock, and how do I enable it on my merchant profile?",
+          content:
+            "P2PK (Pay‐to‐Pubkey Key) Time‐Lock allows merchants to lock the Cashu tokens they receive until a specified future timestamp. By enabling P2PK in your profile, your shop’s payments are held in escrow until the lock expires. This protects both buyers and sellers: buyers know the funds are locked until goods are delivered, and sellers can still refund automatically via the configured “refund pubkeys” if a buyer never claims before the lock expires. To enable it, go to your Profile Settings, check “Enable Time‐Locked Payment (P2PK)”, pick a expire date/time, and optionally set refund pubkeys. Once active, any incoming Cashu payments for your listings will display a 🔒 “Locked for X day(s)” notice until they become redeemable after the lock time.",
+        },
       ],
     },
     {

--- a/pages/settings/shop-profile.tsx
+++ b/pages/settings/shop-profile.tsx
@@ -1,6 +1,14 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState, useContext, useMemo } from "react";
 import { useForm, Controller } from "react-hook-form";
-import { Button, Textarea, Input, Image } from "@nextui-org/react";
+import {
+  Button,
+  Textarea,
+  Input,
+  Image,
+  Switch,
+  Select,
+  SelectItem,
+} from "@nextui-org/react";
 
 import { SettingsBreadCrumbs } from "@/components/settings/settings-bread-crumbs";
 import { ShopMapContext } from "@/utils/context/context";
@@ -12,226 +20,471 @@ import {
 import { createNostrShopEvent } from "@/utils/nostr/nostr-helper-functions";
 import { FileUploaderButton } from "@/components/utility-components/file-uploader";
 import ShopstrSpinner from "@/components/utility-components/shopstr-spinner";
+import { nip19 } from "nostr-tools";
 
 const ShopProfilePage = () => {
   const { nostr } = useContext(NostrContext);
-  const [isUploadingShopProfile, setIsUploadingShopProfile] = useState(false);
-  const [isFetchingShop, setIsFetchingShop] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
 
   const { signer, pubkey: userPubkey } = useContext(SignerContext);
-
   const shopContext = useContext(ShopMapContext);
-  const { handleSubmit, control, reset, watch, setValue } = useForm({
+
+  const {
+    handleSubmit,
+    control,
+    reset,
+    watch,
+    setValue,
+  } = useForm({
     defaultValues: {
       banner: "",
       picture: "",
       name: "",
       about: "",
+      p2pkEnabled: false,
+      p2pkPubkey: "",
+      locktime: "",
+      refund_pubkeys: "",
+      p2pkSigflag: "SIG_INPUTS",
+      p2pkNsigs: 1,
+      p2pkPubkeys: "",
     },
   });
 
   const watchBanner = watch("banner");
   const watchPicture = watch("picture");
+  const watchP2pkEnabled = watch("p2pkEnabled");
   const defaultImage = "/shopstr-2000x2000.png";
 
-  useEffect(() => {
-    setIsFetchingShop(true);
-    const shopMap = shopContext.shopData;
-
-    const shop = shopMap.has(userPubkey!)
-      ? shopMap.get(userPubkey!)
-      : undefined;
-    if (shop) {
-      const mappedContent = {
-        name: shop.content.name,
-        about: shop.content.about,
-        picture: shop.content.ui.picture,
-        banner: shop.content.ui.banner,
-      };
-      reset(mappedContent);
+  // helper to convert npub or hex to hex
+  const convertToHex = (key: string): string | null => {
+    if (!key) return "";
+    if (/^[0-9A-Fa-f]{64}$/.test(key)) return key;
+    if (key.startsWith("npub")) {
+      try {
+        const { data } = nip19.decode(key);
+        return data as string;
+      } catch {
+        return null;
+      }
     }
-    setIsFetchingShop(false);
-  }, [shopContext, userPubkey, userPubkey]);
+    return null;
+  };
 
-  const onSubmit = async (data: { [x: string]: string }) => {
-    setIsUploadingShopProfile(true);
-    const transformedData = {
-      name: data.name || "",
-      about: data.about || "",
+  const pubkeyValidator = (value: string) => {
+    if (!value) return true;
+    return convertToHex(value)
+      ? true
+      : "Invalid pubkey (must be npub… or 64-char hex)";
+  };
+  const pubkeysValidator = (value: string) => {
+    if (!value) return true;
+    const parts = value.split(",").map((s) => s.trim()).filter(Boolean);
+    for (const p of parts) {
+      if (!convertToHex(p)) return "Invalid pubkey in list";
+    }
+    return true;
+  };
+
+  useEffect(() => {
+    setIsFetching(true);
+    const shop = shopContext.shopData.get(userPubkey!);
+    if (shop) {
+      const defaults: any = {
+        banner: shop.content.ui?.banner || "",
+        picture: shop.content.ui?.picture || "",
+        name: shop.content.name || "",
+        about: shop.content.about || "",
+        p2pkEnabled: false,
+        p2pkPubkey: "",
+        locktime: "",
+        refund_pubkeys: (shop.content.p2pk?.refund_pubkeys || []).join(","),
+        p2pkSigflag: "SIG_INPUTS",
+        p2pkNsigs: 1,
+        p2pkPubkeys: "",
+      };
+
+      if (shop.content.p2pk) {
+        defaults.p2pkEnabled = !!shop.content.p2pk.enabled;
+        defaults.p2pkPubkey = shop.content.p2pk.pubkey || "";
+
+        if (shop.content.p2pk.locktime) {
+          const dt = new Date(shop.content.p2pk.locktime * 1000);
+          defaults.locktime = dt.toISOString().slice(0, 16);
+        }
+
+        const tags = shop.content.p2pk.tags || [];
+        const sf = tags.find((t) => t[0] === "sigflag");
+        const ns = tags.find((t) => t[0] === "n_sigs");
+        const pks = tags.filter((t) => t[0] === "pubkeys").map((t) => t[1]);
+        if (sf) defaults.p2pkSigflag = sf[1];
+        if (ns) defaults.p2pkNsigs = parseInt(ns[1], 10);
+        if (pks.length) defaults.p2pkPubkeys = pks.join(",");
+      }
+
+      reset(defaults);
+    }
+    setIsFetching(false);
+  }, [shopContext, userPubkey, reset]);
+
+  const onSubmit = async (data: any) => {
+    setIsUploading(true);
+
+    const transformed: any = {
+      name: data.name,
+      about: data.about,
       ui: {
-        picture: data.picture || "",
-        banner: data.banner || "",
+        banner: data.banner,
+        picture: data.picture,
         theme: "",
         darkMode: false,
       },
       merchants: [userPubkey!],
     };
-    await createNostrShopEvent(
-      nostr!,
-      signer!,
-      userPubkey!,
-      JSON.stringify(transformedData)
-    );
-    shopContext.updateShopData({
-      pubkey: userPubkey!,
-      content: transformedData,
-      created_at: 0,
-    });
-    setIsUploadingShopProfile(false);
+
+    if (data.p2pkEnabled) {
+      const mainHex = convertToHex(data.p2pkPubkey);
+      if (!mainHex) {
+        setIsUploading(false);
+        return;
+      }
+
+      const lockUnix = Math.floor(new Date(data.locktime).getTime() / 1000);
+      const tags: string[][] = [
+        ["sigflag", data.p2pkSigflag],
+        ["n_sigs", data.p2pkNsigs.toString()],
+        ["locktime", lockUnix.toString()],
+      ];
+
+      data.p2pkPubkeys
+        .split(",")
+        .map((s: string) => s.trim())
+        .filter(Boolean)
+        .forEach((pk: string) => {
+          const hx = convertToHex(pk);
+          if (hx) tags.push(["pubkeys", hx]);
+        });
+
+      data.refund_pubkeys
+        .split(",")
+        .map((s: string) => s.trim())
+        .filter(Boolean)
+        .map(convertToHex)
+        .filter((h: string | null): h is string => !!h)
+        .forEach((hx) => {
+          tags.push(["refund", hx]);
+        });
+
+      transformed.p2pk = {
+        enabled: true,
+        pubkey: mainHex,
+        locktime: lockUnix,
+        refund_pubkeys: data.refund_pubkeys
+          .split(",")
+          .map((s: string) => s.trim())
+          .filter(Boolean)
+          .map(convertToHex)
+          .filter((h): h is string => !!h),
+        tags,
+      };
+    }
+
+    try {
+      await createNostrShopEvent(
+        nostr!,
+        signer!,
+        userPubkey!,
+        JSON.stringify(transformed)
+      );
+      shopContext.updateShopData({
+        pubkey: userPubkey!,
+        content: transformed,
+        created_at: Math.floor(Date.now() / 1000),
+      });
+    } catch (e) {
+      console.error("Error saving shop settings", e);
+    }
+
+    setIsUploading(false);
   };
 
+  const buttonClass = useMemo(
+    () => `mb-10 w-full ${SHOPSTRBUTTONCLASSNAMES}`,
+    []
+  );
+
   return (
-    <>
-      <div className="flex min-h-screen flex-col bg-light-bg pt-24 dark:bg-dark-bg md:pb-20">
-        <div className="mx-auto h-full w-full px-4 lg:w-1/2">
-          <SettingsBreadCrumbs />
-          {isFetchingShop ? (
-            <ShopstrSpinner />
-          ) : (
-            <>
-              <div className="mb-20 h-40 rounded-lg bg-light-fg dark:bg-dark-fg">
-                <div className="relative flex h-40 items-center justify-center rounded-lg bg-shopstr-purple-light dark:bg-dark-fg">
-                  {watchBanner && (
-                    <Image
-                      alt={"Shop banner image"}
-                      src={watchBanner}
-                      className="h-40 w-full rounded-lg object-cover object-fill"
-                    />
-                  )}
+    <div className="flex min-h-screen flex-col bg-light-bg pt-24 dark:bg-dark-bg md:pb-20">
+      <div className="mx-auto w-full lg:w-1/2 px-4">
+        <SettingsBreadCrumbs />
+        {isFetching ? (
+          <ShopstrSpinner />
+        ) : (
+          <>
+            {/* Banner + Logo */}
+            <div className="mb-20 h-40 rounded-lg bg-light-fg dark:bg-dark-fg">
+              <div className="relative flex h-40 items-center justify-center rounded-lg bg-shopstr-purple-light dark:bg-dark-fg">
+                {watchBanner && (
+                  <Image
+                    src={watchBanner}
+                    alt="Banner"
+                    className="h-40 w-full object-cover rounded-lg"
+                  />
+                )}
+                <FileUploaderButton
+                  className={`absolute bottom-5 right-5 z-20 border-2 border-white bg-shopstr-purple shadow-md ${SHOPSTRBUTTONCLASSNAMES}`}
+                  imgCallbackOnUpload={(url) => setValue("banner", url)}
+                >
+                  Upload Banner
+                </FileUploaderButton>
+              </div>
+              <div className="flex items-center justify-center">
+                <div className="relative z-50 mt-[-3rem] h-24 w-24">
                   <FileUploaderButton
-                    className={`absolute bottom-5 right-5 z-20 border-2 border-white bg-shopstr-purple shadow-md ${SHOPSTRBUTTONCLASSNAMES}`}
-                    imgCallbackOnUpload={(imgUrl) => setValue("banner", imgUrl)}
-                  >
-                    Upload Banner
-                  </FileUploaderButton>
-                </div>
-                <div className="flex items-center justify-center">
-                  <div className="relative z-50 mt-[-3rem] h-24 w-24">
-                    <div className="">
-                      <FileUploaderButton
-                        isIconOnly={true}
-                        className={`absolute bottom-[-0.5rem] right-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
-                        imgCallbackOnUpload={(imgUrl) =>
-                          setValue("picture", imgUrl)
-                        }
-                      />
-                      {watchPicture ? (
-                        <Image
-                          src={watchPicture}
-                          alt="shop logo"
-                          className="rounded-full"
-                        />
-                      ) : (
-                        <Image
-                          src={defaultImage}
-                          alt="shop logo"
-                          className="rounded-full"
-                        />
-                      )}
-                    </div>
-                  </div>
+                    isIconOnly
+                    className={`absolute bottom-[-0.5rem] right-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
+                    imgCallbackOnUpload={(url) => setValue("picture", url)}
+                  />
+                  <Image
+                    src={watchPicture || defaultImage}
+                    alt="Logo"
+                    className="rounded-full"
+                  />
                 </div>
               </div>
+            </div>
 
-              <form onSubmit={handleSubmit(onSubmit as any)}>
-                <Controller
-                  name="name"
-                  control={control}
-                  rules={{
-                    maxLength: {
-                      value: 50,
-                      message: "This input exceed maxLength of 50.",
-                    },
-                  }}
-                  render={({
-                    field: { onChange, onBlur, value },
-                    fieldState: { error },
-                  }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
-                    return (
+            <form onSubmit={handleSubmit(onSubmit as any)}>
+              {/* Shop Name */}
+              <Controller
+                name="name"
+                control={control}
+                rules={{
+                  maxLength: { value: 50, message: "This input exceed maxLength of 50." },
+                }}
+                render={({ field, fieldState: { error } }) => (
+                  <Input
+                    {...field}
+                    fullWidth
+                    variant="bordered"
+                    label="Shop Name"
+                    placeholder="Add your shop's name . . ."
+                    isInvalid={!!error}
+                    errorMessage={error?.message}
+                    className="pb-4 text-light-text dark:text-dark-text"
+                    classNames={{
+                      label: "text-light-text dark:text-dark-text text-lg",
+                    }}
+                  />
+                )}
+              />
+
+              {/* About */}
+              <Controller
+                name="about"
+                control={control}
+                rules={{
+                  maxLength: { value: 500, message: "This input exceed maxLength of 500." },
+                }}
+                render={({ field, fieldState: { error } }) => (
+                  <Textarea
+                    {...field}
+                    fullWidth
+                    variant="bordered"
+                    label="About"
+                    placeholder="Add something about your shop . . ."
+                    isInvalid={!!error}
+                    errorMessage={error?.message}
+                    className="pb-4 text-light-text dark:text-dark-text"
+                    classNames={{
+                      label: "text-light-text dark:text-dark-text text-lg",
+                    }}
+                  />
+                )}
+              />
+
+              {/* Enable Time-Locked Payments */}
+              <Controller
+                name="p2pkEnabled"
+                control={control}
+                render={({ field }) => (
+                  <Switch
+                    {...field}
+                    isSelected={field.value}
+                    onChange={(val) => field.onChange(val)}
+                    className="mb-4"
+                  >
+                    Enable Time-Locked Payments
+                  </Switch>
+                )}
+              />
+
+              {watchP2pkEnabled && (
+                <>
+                  {/* Lock-to Pubkey */}
+                  <Controller
+                    name="p2pkPubkey"
+                    control={control}
+                    rules={{
+                      required: "Required",
+                      validate: pubkeyValidator,
+                    }}
+                    render={({ field, fieldState: { error } }) => (
                       <Input
-                        className="pb-4 text-light-text dark:text-dark-text"
-                        classNames={{
-                          label: "text-light-text dark:text-dark-text text-lg",
-                        }}
+                        {...field}
+                        fullWidth
                         variant="bordered"
-                        fullWidth={true}
-                        label="Shop Name"
-                        labelPlacement="outside"
-                        isInvalid={isErrored}
-                        errorMessage={errorMessage}
-                        placeholder="Add your shop's name . . ."
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
-                        value={value}
+                        label="Lock-to Pubkey"
+                        placeholder="npub…, or hex"
+                        isInvalid={!!error}
+                        errorMessage={error?.message}
+                        className="mb-4"
                       />
-                    );
-                  }}
-                />
+                    )}
+                  />
 
-                <Controller
-                  name="about"
-                  control={control}
-                  rules={{
-                    maxLength: {
-                      value: 500,
-                      message: "This input exceed maxLength of 500.",
-                    },
-                  }}
-                  render={({
-                    field: { onChange, onBlur, value },
-                    fieldState: { error },
-                  }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
-                    return (
+                  {/* DateTime Picker */}
+                  <div className="mb-4">
+                    <label className="block mb-1 text-light-text dark:text-dark-text">
+                      Lock Expires (local time)
+                    </label>
+                    <Controller
+                      name="locktime"
+                      control={control}
+                      rules={{
+                        required: "Pick a date & time",
+                        validate: (v) =>
+                          new Date(v).getTime() > Date.now() ||
+                          "Must be in the future",
+                      }}
+                      render={({ field, fieldState: { error } }) => (
+                        <>
+                          <input
+                            {...field}
+                            type="datetime-local"
+                            className="w-full rounded border border-default px-3 py-2 text-light-text dark:text-dark-text bg-light-bg dark:bg-dark-bg"
+                          />
+                          {error && (
+                            <p className="text-danger text-sm mt-1">
+                              {error.message}
+                            </p>
+                          )}
+                        </>
+                      )}
+                    />
+                  </div>
+
+                  {/* Refund Pubkeys */}
+                  <Controller
+                    name="refund_pubkeys"
+                    control={control}
+                    rules={{ validate: pubkeysValidator }}
+                    render={({ field, fieldState: { error } }) => (
                       <Textarea
-                        className="pb-4 text-light-text dark:text-dark-text"
-                        classNames={{
-                          label: "text-light-text dark:text-dark-text text-lg",
-                        }}
+                        {...field}
+                        fullWidth
                         variant="bordered"
-                        fullWidth={true}
-                        placeholder="Add something about your shop . . ."
-                        isInvalid={isErrored}
-                        errorMessage={errorMessage}
-                        label="About"
-                        labelPlacement="outside"
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
-                        value={value}
+                        label="Refund Pubkeys (CSV)"
+                        placeholder="npub…,npub… or hex"
+                        isInvalid={!!error}
+                        errorMessage={error?.message}
+                        className="mb-4"
                       />
-                    );
-                  }}
-                />
+                    )}
+                  />
 
-                <Button
-                  className={`mb-10 w-full ${SHOPSTRBUTTONCLASSNAMES}`}
-                  type="submit"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault(); // Prevent default to avoid submitting the form again
-                      handleSubmit(onSubmit as any)(); // Programmatic submit
-                    }
-                  }}
-                  isDisabled={isUploadingShopProfile}
-                  isLoading={isUploadingShopProfile}
-                >
-                  Save Shop
-                </Button>
-              </form>
-            </>
-          )}
-        </div>
+                  {/* Signature Flag */}
+                  <Controller
+                    name="p2pkSigflag"
+                    control={control}
+                    rules={{ required: "Required" }}
+                    render={({ field, fieldState: { error } }) => (
+                      <Select
+                        {...field}
+                        fullWidth
+                        label="Signature Flag"
+                        selectedKeys={new Set([field.value])}
+                        onSelectionChange={(keys) =>
+                          field.onChange(Array.from(keys)[0])
+                        }
+                        isInvalid={!!error}
+                        errorMessage={error?.message}
+                        className="mb-4"
+                      >
+                        <SelectItem key="SIG_INPUTS" value="SIG_INPUTS">
+                          Inputs Only
+                        </SelectItem>
+                        <SelectItem key="SIG_ALL" value="SIG_ALL">
+                          Inputs & Outputs
+                        </SelectItem>
+                      </Select>
+                    )}
+                  />
+
+                  {/* Required Signatures */}
+                  <Controller
+                    name="p2pkNsigs"
+                    control={control}
+                    rules={{
+                      required: "Required",
+                      min: { value: 1, message: "Min 1" },
+                      validate: (v) => {
+                        const extra = `${watch("p2pkPubkeys")}`
+                          .split(",")
+                          .filter(Boolean).length;
+                        return v <= extra + 1 || "Too many";
+                      },
+                    }}
+                    render={({ field, fieldState: { error } }) => (
+                      <Input
+                        {...field}
+                        type="number"
+                        fullWidth
+                        variant="bordered"
+                        label="Required Signatures"
+                        isInvalid={!!error}
+                        errorMessage={error?.message}
+                        className="mb-4"
+                      />
+                    )}
+                  />
+
+                  {/* Additional Pubkeys */}
+                  <Controller
+                    name="p2pkPubkeys"
+                    control={control}
+                    rules={{ validate: pubkeysValidator }}
+                    render={({ field, fieldState: { error } }) => (
+                      <Textarea
+                        {...field}
+                        fullWidth
+                        variant="bordered"
+                        label="Additional Pubkeys (CSV)"
+                        placeholder="npub…,npub… or hex"
+                        isInvalid={!!error}
+                        errorMessage={error?.message}
+                        className="mb-4"
+                      />
+                    )}
+                  />
+                </>
+              )}
+
+              {/* Save Shop */}
+              <Button
+                className={buttonClass}
+                type="submit"
+                isLoading={isUploading}
+                isDisabled={isUploading}
+              >
+                Save Shop
+              </Button>
+            </form>
+          </>
+        )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/pages/settings/shop-profile.tsx
+++ b/pages/settings/shop-profile.tsx
@@ -1,14 +1,6 @@
-import React, { useEffect, useState, useContext, useMemo } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useForm, Controller } from "react-hook-form";
-import {
-  Button,
-  Textarea,
-  Input,
-  Image,
-  Switch,
-  Select,
-  SelectItem,
-} from "@nextui-org/react";
+import { Button, Textarea, Input, Image } from "@nextui-org/react";
 
 import { SettingsBreadCrumbs } from "@/components/settings/settings-bread-crumbs";
 import { ShopMapContext } from "@/utils/context/context";
@@ -20,477 +12,226 @@ import {
 import { createNostrShopEvent } from "@/utils/nostr/nostr-helper-functions";
 import { FileUploaderButton } from "@/components/utility-components/file-uploader";
 import ShopstrSpinner from "@/components/utility-components/shopstr-spinner";
-import { nip19 } from "nostr-tools";
 
 const ShopProfilePage = () => {
   const { nostr } = useContext(NostrContext);
-  const [isUploading, setIsUploading] = useState(false);
-  const [isFetching, setIsFetching] = useState(false);
+  const [isUploadingShopProfile, setIsUploadingShopProfile] = useState(false);
+  const [isFetchingShop, setIsFetchingShop] = useState(false);
 
   const { signer, pubkey: userPubkey } = useContext(SignerContext);
-  const shopContext = useContext(ShopMapContext);
 
-  const {
-    handleSubmit,
-    control,
-    reset,
-    watch,
-    setValue,
-  } = useForm({
+  const shopContext = useContext(ShopMapContext);
+  const { handleSubmit, control, reset, watch, setValue } = useForm({
     defaultValues: {
       banner: "",
       picture: "",
       name: "",
       about: "",
-      p2pkEnabled: false,
-      p2pkPubkey: "",
-      locktime: "",
-      refund_pubkeys: "",
-      p2pkSigflag: "SIG_INPUTS",
-      p2pkNsigs: 1,
-      p2pkPubkeys: "",
     },
   });
 
   const watchBanner = watch("banner");
   const watchPicture = watch("picture");
-  const watchP2pkEnabled = watch("p2pkEnabled");
   const defaultImage = "/shopstr-2000x2000.png";
 
-  // helper to convert npub or hex to hex
-  const convertToHex = (key: string): string | null => {
-    if (!key) return "";
-    if (/^[0-9A-Fa-f]{64}$/.test(key)) return key;
-    if (key.startsWith("npub")) {
-      try {
-        const { data } = nip19.decode(key);
-        return data as string;
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  };
-
-  const pubkeyValidator = (value: string) => {
-    if (!value) return true;
-    return convertToHex(value)
-      ? true
-      : "Invalid pubkey (must be npub… or 64-char hex)";
-  };
-  const pubkeysValidator = (value: string) => {
-    if (!value) return true;
-    const parts = value.split(",").map((s) => s.trim()).filter(Boolean);
-    for (const p of parts) {
-      if (!convertToHex(p)) return "Invalid pubkey in list";
-    }
-    return true;
-  };
-
   useEffect(() => {
-    setIsFetching(true);
-    const shop = shopContext.shopData.get(userPubkey!);
+    setIsFetchingShop(true);
+    const shopMap = shopContext.shopData;
+
+    const shop = shopMap.has(userPubkey!)
+      ? shopMap.get(userPubkey!)
+      : undefined;
     if (shop) {
-      const defaults: any = {
-        banner: shop.content.ui?.banner || "",
-        picture: shop.content.ui?.picture || "",
-        name: shop.content.name || "",
-        about: shop.content.about || "",
-        p2pkEnabled: false,
-        p2pkPubkey: "",
-        locktime: "",
-        refund_pubkeys: (shop.content.p2pk?.refund || []).join(","),
-        p2pkSigflag: "SIG_INPUTS",
-        p2pkNsigs: 1,
-        p2pkPubkeys: "",
+      const mappedContent = {
+        name: shop.content.name,
+        about: shop.content.about,
+        picture: shop.content.ui.picture,
+        banner: shop.content.ui.banner,
       };
-
-      if (shop.content.p2pk) {
-        defaults.p2pkEnabled = !!shop.content.p2pk.enabled;
-        defaults.p2pkPubkey = shop.content.p2pk.pubkey || "";
-
-        if (shop.content.p2pk.locktime) {
-          const dt = new Date(shop.content.p2pk.locktime * 1000);
-          defaults.locktime = dt.toISOString().slice(0, 16);
-        }
-
-        const tags = shop.content.p2pk.tags || [];
-        const sf = tags.find((t) => t[0] === "sigflag");
-        const ns = tags.find((t) => t[0] === "n_sigs");
-        const pks = tags.filter((t) => t[0] === "pubkeys").map((t) => t[1]);
-        if (sf) defaults.p2pkSigflag = sf[1];
-        if (ns) defaults.p2pkNsigs = parseInt(ns[1], 10);
-        if (pks.length) defaults.p2pkPubkeys = pks.join(",");
-      }
-
-      reset(defaults);
+      reset(mappedContent);
     }
-    setIsFetching(false);
-  }, [shopContext, userPubkey, reset]);
+    setIsFetchingShop(false);
+  }, [shopContext, userPubkey, userPubkey]);
 
-  const onSubmit = async (data: any) => {
-    setIsUploading(true);
-
-    const transformed: any = {
-      name: data.name,
-      about: data.about,
+  const onSubmit = async (data: { [x: string]: string }) => {
+    setIsUploadingShopProfile(true);
+    const transformedData = {
+      name: data.name || "",
+      about: data.about || "",
       ui: {
-        banner: data.banner,
-        picture: data.picture,
+        picture: data.picture || "",
+        banner: data.banner || "",
         theme: "",
         darkMode: false,
       },
       merchants: [userPubkey!],
     };
-
-    if (data.p2pkEnabled) {
-      const mainHex = convertToHex(data.p2pkPubkey);
-      if (!mainHex) {
-        setIsUploading(false);
-        return;
-      }
-
-      const lockUnix = Math.floor(new Date(data.locktime).getTime() / 1000);
-      const tags: string[][] = [
-        ["sigflag", data.p2pkSigflag],
-        ["n_sigs", data.p2pkNsigs.toString()],
-        ["locktime", lockUnix.toString()],
-      ];
-
-      data.p2pkPubkeys
-        .split(",")
-        .map((s: string) => s.trim())
-        .filter(Boolean)
-        .forEach((pk: string) => {
-          const hx = convertToHex(pk);
-          if (hx) tags.push(["pubkeys", hx]);
-        });
-
-      data.refund_pubkeys
-        .split(",")
-        .map((s: string) => s.trim())
-        .filter(Boolean)
-        .map(convertToHex)
-        .filter((h: string | null): h is string => !!h)
-        .forEach((hx: string) => {
-          tags.push(["refund", hx]);
-        });
-
-      transformed.p2pk = {
-        enabled: true,
-        pubkey: mainHex,
-        locktime: lockUnix,
-        refund: data.refund_pubkeys
-          .split(",")
-          .map((s: string) => s.trim())
-          .filter(Boolean)
-          .map(convertToHex)
-          .filter((h: string | null): h is string => !!h),
-        tags,
-      };
-    }
-
-    try {
-      await createNostrShopEvent(
-        nostr!,
-        signer!,
-        userPubkey!,
-        JSON.stringify(transformed)
-      );
-      shopContext.updateShopData({
-        pubkey: userPubkey!,
-        content: transformed,
-        created_at: Math.floor(Date.now() / 1000),
-      });
-    } catch (e) {
-      console.error("Error saving shop settings", e);
-    }
-
-    setIsUploading(false);
+    await createNostrShopEvent(
+      nostr!,
+      signer!,
+      userPubkey!,
+      JSON.stringify(transformedData)
+    );
+    shopContext.updateShopData({
+      pubkey: userPubkey!,
+      content: transformedData,
+      created_at: 0,
+    });
+    setIsUploadingShopProfile(false);
   };
 
-  const buttonClass = useMemo(
-    () => `mb-10 w-full ${SHOPSTRBUTTONCLASSNAMES}`,
-    []
-  );
-
   return (
-    <div className="flex min-h-screen flex-col bg-light-bg pt-24 dark:bg-dark-bg md:pb-20">
-      <div className="mx-auto w-full lg:w-1/2 px-4">
-        <SettingsBreadCrumbs />
-        {isFetching ? (
-          <ShopstrSpinner />
-        ) : (
-          <>
-            {/* Banner + Logo */}
-            <div className="mb-20 h-40 rounded-lg bg-light-fg dark:bg-dark-fg">
-              <div className="relative flex h-40 items-center justify-center rounded-lg bg-shopstr-purple-light dark:bg-dark-fg">
-                {watchBanner && (
-                  <Image
-                    src={watchBanner}
-                    alt="Banner"
-                    className="h-40 w-full object-cover rounded-lg"
-                  />
-                )}
-                <FileUploaderButton
-                  className={`absolute bottom-5 right-5 z-20 border-2 border-white bg-shopstr-purple shadow-md ${SHOPSTRBUTTONCLASSNAMES}`}
-                  imgCallbackOnUpload={(url) => setValue("banner", url)}
-                >
-                  Upload Banner
-                </FileUploaderButton>
-              </div>
-              <div className="flex items-center justify-center">
-                <div className="relative z-50 mt-[-3rem] h-24 w-24">
+    <>
+      <div className="flex min-h-screen flex-col bg-light-bg pt-24 dark:bg-dark-bg md:pb-20">
+        <div className="mx-auto h-full w-full px-4 lg:w-1/2">
+          <SettingsBreadCrumbs />
+          {isFetchingShop ? (
+            <ShopstrSpinner />
+          ) : (
+            <>
+              <div className="mb-20 h-40 rounded-lg bg-light-fg dark:bg-dark-fg">
+                <div className="relative flex h-40 items-center justify-center rounded-lg bg-shopstr-purple-light dark:bg-dark-fg">
+                  {watchBanner && (
+                    <Image
+                      alt={"Shop banner image"}
+                      src={watchBanner}
+                      className="h-40 w-full rounded-lg object-cover object-fill"
+                    />
+                  )}
                   <FileUploaderButton
-                    isIconOnly
-                    className={`absolute bottom-[-0.5rem] right-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
-                    imgCallbackOnUpload={(url) => setValue("picture", url)}
-                  />
-                  <Image
-                    src={watchPicture || defaultImage}
-                    alt="Logo"
-                    className="rounded-full"
-                  />
+                    className={`absolute bottom-5 right-5 z-20 border-2 border-white bg-shopstr-purple shadow-md ${SHOPSTRBUTTONCLASSNAMES}`}
+                    imgCallbackOnUpload={(imgUrl) => setValue("banner", imgUrl)}
+                  >
+                    Upload Banner
+                  </FileUploaderButton>
+                </div>
+                <div className="flex items-center justify-center">
+                  <div className="relative z-50 mt-[-3rem] h-24 w-24">
+                    <div className="">
+                      <FileUploaderButton
+                        isIconOnly={true}
+                        className={`absolute bottom-[-0.5rem] right-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
+                        imgCallbackOnUpload={(imgUrl) =>
+                          setValue("picture", imgUrl)
+                        }
+                      />
+                      {watchPicture ? (
+                        <Image
+                          src={watchPicture}
+                          alt="shop logo"
+                          className="rounded-full"
+                        />
+                      ) : (
+                        <Image
+                          src={defaultImage}
+                          alt="shop logo"
+                          className="rounded-full"
+                        />
+                      )}
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <form onSubmit={handleSubmit(onSubmit as any)}>
-              {/* Shop Name */}
-              <Controller
-                name="name"
-                control={control}
-                rules={{
-                  maxLength: { value: 50, message: "This input exceed maxLength of 50." },
-                }}
-                render={({ field, fieldState: { error } }) => (
-                  <Input
-                    {...field}
-                    fullWidth
-                    variant="bordered"
-                    label="Shop Name"
-                    placeholder="Add your shop's name . . ."
-                    isInvalid={!!error}
-                    errorMessage={error?.message}
-                    className="pb-4 text-light-text dark:text-dark-text"
-                    classNames={{
-                      label: "text-light-text dark:text-dark-text text-lg",
-                    }}
-                  />
-                )}
-              />
-
-              {/* About */}
-              <Controller
-                name="about"
-                control={control}
-                rules={{
-                  maxLength: { value: 500, message: "This input exceed maxLength of 500." },
-                }}
-                render={({ field, fieldState: { error } }) => (
-                  <Textarea
-                    {...field}
-                    fullWidth
-                    variant="bordered"
-                    label="About"
-                    placeholder="Add something about your shop . . ."
-                    isInvalid={!!error}
-                    errorMessage={error?.message}
-                    className="pb-4 text-light-text dark:text-dark-text"
-                    classNames={{
-                      label: "text-light-text dark:text-dark-text text-lg",
-                    }}
-                  />
-                )}
-              />
-
-              {/* Enable Time-Locked Payments */}
-              <Controller
-                name="p2pkEnabled"
-                control={control}
-                render={({ field }) => (
-                  <Switch
-                    isSelected={field.value}
-                    onChange={(val) => field.onChange(val)}
-                    onBlur={field.onBlur}
-                    name={field.name}
-                    ref={field.ref}
-                    className="mb-4"
-                  >
-                    Enable Time-Locked Payments
-                  </Switch>
-                )}
-              />
-
-              {watchP2pkEnabled && (
-                <>
-                  {/* Lock-to Pubkey */}
-                  <Controller
-                    name="p2pkPubkey"
-                    control={control}
-                    rules={{
-                      required: "Required",
-                      validate: pubkeyValidator,
-                    }}
-                    render={({ field, fieldState: { error } }) => (
+              <form onSubmit={handleSubmit(onSubmit as any)}>
+                <Controller
+                  name="name"
+                  control={control}
+                  rules={{
+                    maxLength: {
+                      value: 50,
+                      message: "This input exceed maxLength of 50.",
+                    },
+                  }}
+                  render={({
+                    field: { onChange, onBlur, value },
+                    fieldState: { error },
+                  }) => {
+                    const isErrored = error !== undefined;
+                    const errorMessage: string = error?.message
+                      ? error.message
+                      : "";
+                    return (
                       <Input
-                        {...field}
-                        fullWidth
+                        className="pb-4 text-light-text dark:text-dark-text"
+                        classNames={{
+                          label: "text-light-text dark:text-dark-text text-lg",
+                        }}
                         variant="bordered"
-                        label="Lock-to Pubkey"
-                        placeholder="npub…, or hex"
-                        isInvalid={!!error}
-                        errorMessage={error?.message}
-                        className="mb-4"
+                        fullWidth={true}
+                        label="Shop Name"
+                        labelPlacement="outside"
+                        isInvalid={isErrored}
+                        errorMessage={errorMessage}
+                        placeholder="Add your shop's name . . ."
+                        // controller props
+                        onChange={onChange} // send value to hook form
+                        onBlur={onBlur} // notify when input is touched/blur
+                        value={value}
                       />
-                    )}
-                  />
+                    );
+                  }}
+                />
 
-                  {/* DateTime Picker */}
-                  <div className="mb-4">
-                    <label className="block mb-1 text-light-text dark:text-dark-text">
-                      Lock Expires (local time)
-                    </label>
-                    <Controller
-                      name="locktime"
-                      control={control}
-                      rules={{
-                        required: "Pick a date & time",
-                        validate: (v) =>
-                          new Date(v).getTime() > Date.now() ||
-                          "Must be in the future",
-                      }}
-                      render={({ field, fieldState: { error } }) => (
-                        <>
-                          <input
-                            {...field}
-                            type="datetime-local"
-                            className="w-full rounded border border-default px-3 py-2 text-light-text dark:text-dark-text bg-light-bg dark:bg-dark-bg"
-                          />
-                          {error && (
-                            <p className="text-danger text-sm mt-1">
-                              {error.message}
-                            </p>
-                          )}
-                        </>
-                      )}
-                    />
-                  </div>
-
-                  {/* Refund Pubkeys */}
-                  <Controller
-                    name="refund_pubkeys"
-                    control={control}
-                    rules={{ validate: pubkeysValidator }}
-                    render={({ field, fieldState: { error } }) => (
+                <Controller
+                  name="about"
+                  control={control}
+                  rules={{
+                    maxLength: {
+                      value: 500,
+                      message: "This input exceed maxLength of 500.",
+                    },
+                  }}
+                  render={({
+                    field: { onChange, onBlur, value },
+                    fieldState: { error },
+                  }) => {
+                    const isErrored = error !== undefined;
+                    const errorMessage: string = error?.message
+                      ? error.message
+                      : "";
+                    return (
                       <Textarea
-                        {...field}
-                        fullWidth
+                        className="pb-4 text-light-text dark:text-dark-text"
+                        classNames={{
+                          label: "text-light-text dark:text-dark-text text-lg",
+                        }}
                         variant="bordered"
-                        label="Refund Pubkeys (CSV)"
-                        placeholder="npub…,npub… or hex"
-                        isInvalid={!!error}
-                        errorMessage={error?.message}
-                        className="mb-4"
+                        fullWidth={true}
+                        placeholder="Add something about your shop . . ."
+                        isInvalid={isErrored}
+                        errorMessage={errorMessage}
+                        label="About"
+                        labelPlacement="outside"
+                        // controller props
+                        onChange={onChange} // send value to hook form
+                        onBlur={onBlur} // notify when input is touched/blur
+                        value={value}
                       />
-                    )}
-                  />
+                    );
+                  }}
+                />
 
-                  {/* Signature Flag */}
-                  <Controller
-                    name="p2pkSigflag"
-                    control={control}
-                    rules={{ required: "Required" }}
-                    render={({ field, fieldState: { error } }) => (
-                      <Select
-                        {...field}
-                        fullWidth
-                        label="Signature Flag"
-                        selectedKeys={new Set([field.value])}
-                        onSelectionChange={(keys) =>
-                          field.onChange(Array.from(keys)[0])
-                        }
-                        isInvalid={!!error}
-                        errorMessage={error?.message}
-                        className="mb-4"
-                      >
-                        <SelectItem key="SIG_INPUTS" value="SIG_INPUTS">
-                          Inputs Only
-                        </SelectItem>
-                        <SelectItem key="SIG_ALL" value="SIG_ALL">
-                          Inputs & Outputs
-                        </SelectItem>
-                      </Select>
-                    )}
-                  />
-
-                  {/* Required Signatures */}
-                  <Controller
-                    name="p2pkNsigs"
-                    control={control}
-                    rules={{
-                      required: "Required",
-                      min: { value: 1, message: "Min 1" },
-                      validate: (v) => {
-                        const extra = `${watch("p2pkPubkeys")}`
-                          .split(",")
-                          .filter(Boolean).length;
-                        return v <= extra + 1 || "Too many";
-                      },
-                    }}
-                    render={({ field, fieldState: { error } }) => (
-                      <Input
-                        type="number"
-                        fullWidth
-                        variant="bordered"
-                        label="Required Signatures"
-                        value={field.value?.toString() || ""}
-                        onChange={(e) => field.onChange(parseInt(e.target.value, 10) || 0)}
-                        onBlur={field.onBlur}
-                        name={field.name}
-                        ref={field.ref}
-                        isInvalid={!!error}
-                        errorMessage={error?.message}
-                        className="mb-4"
-                      />
-                    )}
-                  />
-
-                  {/* Additional Pubkeys */}
-                  <Controller
-                    name="p2pkPubkeys"
-                    control={control}
-                    rules={{ validate: pubkeysValidator }}
-                    render={({ field, fieldState: { error } }) => (
-                      <Textarea
-                        {...field}
-                        fullWidth
-                        variant="bordered"
-                        label="Additional Pubkeys (CSV)"
-                        placeholder="npub…,npub… or hex"
-                        isInvalid={!!error}
-                        errorMessage={error?.message}
-                        className="mb-4"
-                      />
-                    )}
-                  />
-                </>
-              )}
-
-              {/* Save Shop */}
-              <Button
-                className={buttonClass}
-                type="submit"
-                isLoading={isUploading}
-                isDisabled={isUploading}
-              >
-                Save Shop
-              </Button>
-            </form>
-          </>
-        )}
+                <Button
+                  className={`mb-10 w-full ${SHOPSTRBUTTONCLASSNAMES}`}
+                  type="submit"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault(); // Prevent default to avoid submitting the form again
+                      handleSubmit(onSubmit as any)(); // Programmatic submit
+                    }
+                  }}
+                  isDisabled={isUploadingShopProfile}
+                  isLoading={isUploadingShopProfile}
+                >
+                  Save Shop
+                </Button>
+              </form>
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/pages/settings/shop-profile.tsx
+++ b/pages/settings/shop-profile.tsx
@@ -99,7 +99,7 @@ const ShopProfilePage = () => {
         p2pkEnabled: false,
         p2pkPubkey: "",
         locktime: "",
-        refund_pubkeys: (shop.content.p2pk?.refund_pubkeys || []).join(","),
+        refund_pubkeys: (shop.content.p2pk?.refund || []).join(","),
         p2pkSigflag: "SIG_INPUTS",
         p2pkNsigs: 1,
         p2pkPubkeys: "",
@@ -172,7 +172,7 @@ const ShopProfilePage = () => {
         .filter(Boolean)
         .map(convertToHex)
         .filter((h: string | null): h is string => !!h)
-        .forEach((hx) => {
+        .forEach((hx: string) => {
           tags.push(["refund", hx]);
         });
 
@@ -180,12 +180,12 @@ const ShopProfilePage = () => {
         enabled: true,
         pubkey: mainHex,
         locktime: lockUnix,
-        refund_pubkeys: data.refund_pubkeys
+        refund: data.refund_pubkeys
           .split(",")
           .map((s: string) => s.trim())
           .filter(Boolean)
           .map(convertToHex)
-          .filter((h): h is string => !!h),
+          .filter((h: string | null): h is string => !!h),
         tags,
       };
     }
@@ -310,9 +310,11 @@ const ShopProfilePage = () => {
                 control={control}
                 render={({ field }) => (
                   <Switch
-                    {...field}
                     isSelected={field.value}
                     onChange={(val) => field.onChange(val)}
+                    onBlur={field.onBlur}
+                    name={field.name}
+                    ref={field.ref}
                     className="mb-4"
                   >
                     Enable Time-Locked Payments
@@ -438,11 +440,15 @@ const ShopProfilePage = () => {
                     }}
                     render={({ field, fieldState: { error } }) => (
                       <Input
-                        {...field}
                         type="number"
                         fullWidth
                         variant="bordered"
                         label="Required Signatures"
+                        value={field.value?.toString() || ""}
+                        onChange={(e) => field.onChange(parseInt(e.target.value, 10) || 0)}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
                         isInvalid={!!error}
                         errorMessage={error?.message}
                         className="mb-4"

--- a/pages/settings/user-profile.tsx
+++ b/pages/settings/user-profile.tsx
@@ -26,54 +26,91 @@ import { NostrNSecSigner } from "@/utils/nostr/signers/nostr-nsec-signer";
 import { createNostrProfileEvent } from "@/utils/nostr/nostr-helper-functions";
 import { FileUploaderButton } from "@/components/utility-components/file-uploader";
 import ShopstrSpinner from "@/components/utility-components/shopstr-spinner";
+import { nip19 } from "nostr-tools"; 
 
 const UserProfilePage = () => {
   const { nostr } = useContext(NostrContext);
   const [isUploadingProfile, setIsUploadingProfile] = useState(false);
   const [isFetchingProfile, setIsFetchingProfile] = useState(false);
-  const {
-    signer,
-    pubkey: userPubkey,
-    npub: userNPub,
-  } = useContext(SignerContext);
+
+  const { signer, pubkey: userPubkey, npub: userNPub } = useContext(
+    SignerContext
+  );
   const [isNPubCopied, setIsNPubCopied] = useState(false);
   const [isNSecCopied, setIsNSecCopied] = useState(false);
   const [userNSec, setUserNSec] = useState("");
   const [viewState, setViewState] = useState<"shown" | "hidden">("hidden");
 
   const profileContext = useContext(ProfileMapContext);
-  const { handleSubmit, control, reset, watch, setValue } = useForm({
+
+  const {
+    handleSubmit,
+    control,
+    reset,
+    watch,
+    setValue,
+  } = useForm({
     defaultValues: {
       banner: "",
       picture: "",
       display_name: "",
       name: "",
-      nip05: "", // Nostr address
+      nip05: "",
       about: "",
       website: "",
-      lud16: "", // Lightning address
+      lud16: "",
       payment_preference: "ecash",
-      fiat_options: [],
+      fiat_options: [] as string[],
       shopstr_donation: 2.1,
+      p2pkEnabled: false,
+      p2pkPubkey: "",
+      locktime: "",
+      refundPubkeys: "",
     },
   });
 
   const watchBanner = watch("banner");
   const watchPicture = watch("picture");
+  const watchP2pkEnabled = watch("p2pkEnabled");
+
   const defaultImage = useMemo(() => {
     return "https://robohash.org/" + userPubkey;
   }, [userPubkey]);
 
+  // Pre-fill form (including P2PK) from existing ProfileData.content
   useEffect(() => {
     if (!userPubkey) return;
     setIsFetchingProfile(true);
+
     const profileMap = profileContext.profileData;
-    const profile = profileMap.has(userPubkey)
-      ? profileMap.get(userPubkey)
-      : undefined;
+    const profile = profileMap.get(userPubkey) || undefined;
+
     if (profile) {
-      reset(profile.content);
+      reset({
+        banner: profile.content.banner  || "",
+        picture: profile.content.picture || "",
+        display_name: profile.content.display_name || "",
+        name: profile.content.name || "",
+        nip05: profile.content.nip05  || "",
+        about: profile.content.about || "",
+        website: profile.content.website || "",
+        lud16: profile.content.lud16 || "",
+        payment_preference:
+          profile.content.payment_preference || "ecash",
+        fiat_options: profile.content.fiat_options || [],
+        shopstr_donation: profile.content.shopstr_donation || 2.1,
+        p2pkEnabled: profile.content.p2pk?.enabled || false,
+        p2pkPubkey: profile.content.p2pk?.pubkey || "",
+        locktime: profile.content.p2pk?.locktime
+          ? new Date(profile.content.p2pk.locktime * 1000)
+            .toISOString()
+            .slice(0, 16)
+          : "",
+        refundPubkeys: profile.content.p2pk?.refund?.join(", ") || "",
+
+      });
     }
+
     setIsFetchingProfile(false);
 
     if (signer instanceof NostrNSecSigner) {
@@ -89,20 +126,67 @@ const UserProfilePage = () => {
     }
   }, [profileContext, userPubkey, signer, reset]);
 
-  const onSubmit = async (data: { [x: string]: string }) => {
+  const onSubmit = async (data: {
+    [key: string]: any;
+    p2pkEnabled: boolean;
+    p2pkPubkey: string;
+    locktime: string;
+    refundPubkeys: string;
+  }) => {
     if (!userPubkey) throw new Error("pubkey is undefined");
     setIsUploadingProfile(true);
+
+    const profileContent: any = {
+      banner: data.banner  || "",
+      picture: data.picture || "",
+      display_name: data.display_name || "",
+      name: data.name || "",
+      nip05: data.nip05 || "",
+      about: data.about || "",
+      website: data.website || "",
+      lud16: data.lud16 || "",
+      payment_preference: data.payment_preference || "ecash",
+      fiat_options: data.fiat_options || [],
+      shopstr_donation: data.shopstr_donation || 2.1,
+    };
+
+    if (data.p2pkEnabled) {
+      let mainHex: string;
+      if (/^[0-9A-Fa-f]{64}$/.test(data.p2pkPubkey)) {
+        mainHex = data.p2pkPubkey;
+      } else {
+        const { data: decoded } = nip19.decode(data.p2pkPubkey);
+        mainHex = decoded as string;
+      }
+
+      const unixLock = Math.floor(new Date(data.locktime).getTime() / 1000);
+      const refundArr: string[] = data.refundPubkeys
+        .split(",")
+        .map((s: string) => s.trim())
+        .filter(Boolean);
+
+      profileContent.p2pk = {
+        enabled: true,
+        pubkey: mainHex,
+        locktime: unixLock,
+        refund: refundArr,
+        tags: [],
+      };
+    }
+
     await createNostrProfileEvent(
       nostr!,
       signer!,
       userPubkey!,
-      JSON.stringify(data)
+      JSON.stringify(profileContent)
     );
+
     profileContext.updateProfileData({
       pubkey: userPubkey!,
-      content: data,
-      created_at: 0,
+      content: profileContent,
+      created_at: Math.floor(Date.now() / 1000),
     });
+
     setIsUploadingProfile(false);
   };
 
@@ -111,10 +195,12 @@ const UserProfilePage = () => {
       <div className="flex min-h-screen flex-col bg-light-bg pt-24 dark:bg-dark-bg md:pb-20">
         <div className="mx-auto h-full w-full px-4 lg:w-1/2">
           <SettingsBreadCrumbs />
+
           {isFetchingProfile ? (
             <ShopstrSpinner />
           ) : (
             <>
+              {/* ─── Banner + Avatar ─── */}
               <div className="mb-20 h-40 rounded-lg bg-light-fg dark:bg-dark-fg">
                 <div className="relative flex h-40 items-center justify-center rounded-lg bg-shopstr-purple-light dark:bg-dark-fg">
                   {watchBanner && (
@@ -133,7 +219,7 @@ const UserProfilePage = () => {
                 </div>
                 <div className="flex items-center justify-center">
                   <div className="relative z-20 mt-[-3rem] h-24 w-24">
-                    <div className="">
+                    <div>
                       <FileUploaderButton
                         isIconOnly
                         className={`absolute bottom-[-0.5rem] right-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
@@ -159,14 +245,13 @@ const UserProfilePage = () => {
                 </div>
               </div>
 
+              {/* ─── Copy NPUB ─── */}
               <div
                 className="mx-auto mb-2 flex w-full max-w-2xl cursor-pointer flex-row items-center justify-center rounded-lg border-2 border-light-fg p-2 hover:opacity-60 dark:border-dark-fg"
                 onClick={() => {
                   navigator.clipboard.writeText(userNPub!);
                   setIsNPubCopied(true);
-                  setTimeout(() => {
-                    setIsNPubCopied(false);
-                  }, 2100);
+                  setTimeout(() => setIsNPubCopied(false), 2100);
                 }}
               >
                 <span
@@ -190,7 +275,8 @@ const UserProfilePage = () => {
                 )}
               </div>
 
-              {userNSec ? (
+              {/* ─── Copy NSEC ─── */}
+              {userNSec && (
                 <div className="mx-auto mb-12 flex w-full max-w-2xl cursor-pointer flex-row items-center justify-center rounded-lg border-2 border-light-fg p-2 dark:border-dark-fg">
                   <span
                     className="lg:text-md break-all pr-2 text-[0.50rem] font-bold text-light-text dark:text-dark-text sm:text-xs md:text-sm"
@@ -214,33 +300,26 @@ const UserProfilePage = () => {
                       onClick={() => {
                         navigator.clipboard.writeText(userNSec);
                         setIsNSecCopied(true);
-                        setTimeout(() => {
-                          setIsNSecCopied(false);
-                        }, 2100);
+                        setTimeout(() => setIsNSecCopied(false), 2100);
                       }}
                     />
                   )}
                   {viewState === "shown" ? (
                     <EyeSlashIcon
                       className="h-6 w-6 flex-shrink-0 px-1 text-light-text hover:text-purple-700 dark:text-dark-text dark:hover:text-yellow-700"
-                      onClick={() => {
-                        setViewState("hidden");
-                      }}
+                      onClick={() => setViewState("hidden")}
                     />
                   ) : (
                     <EyeIcon
                       className="h-6 w-6 flex-shrink-0 px-1 text-light-text hover:text-purple-700 dark:text-dark-text dark:hover:text-yellow-700"
-                      onClick={() => {
-                        setViewState("shown");
-                      }}
+                      onClick={() => setViewState("shown")}
                     />
                   )}
                 </div>
-              ) : (
-                <div className="mb-12" />
               )}
 
               <form onSubmit={handleSubmit(onSubmit as any)}>
+                {/* ─── Display Name ─── */}
                 <Controller
                   name="display_name"
                   control={control}
@@ -248,10 +327,8 @@ const UserProfilePage = () => {
                     field: { onChange, onBlur, value },
                     fieldState: { error },
                   }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
+                    const isErrored = !!error;
+                    const errorMessage = error?.message ?? "";
                     return (
                       <Input
                         className="pb-4 text-light-text dark:text-dark-text"
@@ -259,21 +336,21 @@ const UserProfilePage = () => {
                           label: "text-light-text dark:text-dark-text text-lg",
                         }}
                         variant="bordered"
-                        fullWidth={true}
+                        fullWidth
                         label="Display name"
                         labelPlacement="outside"
                         isInvalid={isErrored}
                         errorMessage={errorMessage}
-                        placeholder="Add your display name . . ."
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
+                        placeholder="Add your display name…"
+                        onChange={onChange}
+                        onBlur={onBlur}
                         value={value}
                       />
                     );
                   }}
                 />
 
+                {/* ─── Username ─── */}
                 <Controller
                   name="name"
                   control={control}
@@ -281,10 +358,8 @@ const UserProfilePage = () => {
                     field: { onChange, onBlur, value },
                     fieldState: { error },
                   }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
+                    const isErrored = !!error;
+                    const errorMessage = error?.message ?? "";
                     return (
                       <Input
                         className="pb-4 text-light-text dark:text-dark-text"
@@ -292,21 +367,21 @@ const UserProfilePage = () => {
                           label: "text-light-text dark:text-dark-text text-lg",
                         }}
                         variant="bordered"
-                        fullWidth={true}
+                        fullWidth
                         label="Username"
                         labelPlacement="outside"
                         isInvalid={isErrored}
                         errorMessage={errorMessage}
-                        placeholder="Add your username . . ."
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
+                        placeholder="Add your username…"
+                        onChange={onChange}
+                        onBlur={onBlur}
                         value={value}
                       />
                     );
                   }}
                 />
 
+                {/* ─── About ─── */}
                 <Controller
                   name="about"
                   control={control}
@@ -314,10 +389,8 @@ const UserProfilePage = () => {
                     field: { onChange, onBlur, value },
                     fieldState: { error },
                   }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
+                    const isErrored = !!error;
+                    const errorMessage = error?.message ?? "";
                     return (
                       <Textarea
                         className="pb-4 text-light-text dark:text-dark-text"
@@ -325,21 +398,21 @@ const UserProfilePage = () => {
                           label: "text-light-text dark:text-dark-text text-lg",
                         }}
                         variant="bordered"
-                        fullWidth={true}
-                        placeholder="Add something about yourself . . ."
+                        fullWidth
+                        placeholder="Add something about yourself…"
                         isInvalid={isErrored}
                         errorMessage={errorMessage}
                         label="About"
                         labelPlacement="outside"
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
+                        onChange={onChange}
+                        onBlur={onBlur}
                         value={value}
                       />
                     );
                   }}
                 />
 
+                {/* ─── Website ─── */}
                 <Controller
                   name="website"
                   control={control}
@@ -347,10 +420,8 @@ const UserProfilePage = () => {
                     field: { onChange, onBlur, value },
                     fieldState: { error },
                   }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
+                    const isErrored = !!error;
+                    const errorMessage = error?.message ?? "";
                     return (
                       <Input
                         className="pb-4 text-light-text dark:text-dark-text"
@@ -358,20 +429,21 @@ const UserProfilePage = () => {
                           label: "text-light-text dark:text-dark-text text-lg",
                         }}
                         variant="bordered"
-                        fullWidth={true}
+                        fullWidth
                         label="Website"
                         labelPlacement="outside"
                         isInvalid={isErrored}
                         errorMessage={errorMessage}
-                        placeholder="Add your website URL . . ."
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
+                        placeholder="Add your website URL…"
+                        onChange={onChange}
+                        onBlur={onBlur}
                         value={value}
                       />
                     );
                   }}
                 />
+
+                {/* ─── NIP-05 ─── */}
                 <Controller
                   name="nip05"
                   control={control}
@@ -379,10 +451,8 @@ const UserProfilePage = () => {
                     field: { onChange, onBlur, value },
                     fieldState: { error },
                   }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
+                    const isErrored = !!error;
+                    const errorMessage = error?.message ?? "";
                     return (
                       <Input
                         className="pb-4 text-light-text dark:text-dark-text"
@@ -390,21 +460,21 @@ const UserProfilePage = () => {
                           label: "text-light-text dark:text-dark-text text-lg",
                         }}
                         variant="bordered"
-                        fullWidth={true}
+                        fullWidth
                         label="Nostr address"
                         labelPlacement="outside"
                         isInvalid={isErrored}
                         errorMessage={errorMessage}
-                        placeholder="Add your NIP-05 address . . ."
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
+                        placeholder="Add your NIP-05 address…"
+                        onChange={onChange}
+                        onBlur={onBlur}
                         value={value}
                       />
                     );
                   }}
                 />
 
+                {/* ─── Lightning Address ─── */}
                 <Controller
                   name="lud16"
                   control={control}
@@ -412,10 +482,8 @@ const UserProfilePage = () => {
                     field: { onChange, onBlur, value },
                     fieldState: { error },
                   }) => {
-                    const isErrored = error !== undefined;
-                    const errorMessage: string = error?.message
-                      ? error.message
-                      : "";
+                    const isErrored = !!error;
+                    const errorMessage = error?.message ?? "";
                     return (
                       <Input
                         className="pb-4 text-light-text dark:text-dark-text"
@@ -423,20 +491,21 @@ const UserProfilePage = () => {
                           label: "text-light-text dark:text-dark-text text-lg",
                         }}
                         variant="bordered"
-                        fullWidth={true}
+                        fullWidth
                         label="Lightning address"
                         labelPlacement="outside"
                         isInvalid={isErrored}
                         errorMessage={errorMessage}
-                        placeholder="Add your Lightning address . . ."
-                        // controller props
-                        onChange={onChange} // send value to hook form
-                        onBlur={onBlur} // notify when input is touched/blur
+                        placeholder="Add your Lightning address…"
+                        onChange={onChange}
+                        onBlur={onBlur}
                         value={value}
                       />
                     );
                   }}
                 />
+
+                {/* ─── Payment Preference ─── */}
                 <Controller
                   name="payment_preference"
                   control={control}
@@ -447,20 +516,13 @@ const UserProfilePage = () => {
                         label: "text-light-text dark:text-dark-text text-lg",
                       }}
                       variant="bordered"
-                      fullWidth={true}
+                      fullWidth
                       label="Bitcoin payment preference"
                       labelPlacement="outside"
                       selectedKeys={value ? [value] : []}
                       onChange={(e) => onChange(e.target.value)}
                       onBlur={onBlur}
                     >
-                      {/* <SelectItem
-                        key="service"
-                        value="service"
-                        className="text-light-text dark:text-dark-text"
-                      >
-                        Service
-                      </SelectItem> */}
                       <SelectItem
                         key="ecash"
                         value="ecash"
@@ -479,6 +541,7 @@ const UserProfilePage = () => {
                   )}
                 />
 
+                {/* ─── Fiat Options ─── */}
                 <Controller
                   name="fiat_options"
                   control={control}
@@ -486,8 +549,8 @@ const UserProfilePage = () => {
                     const selectedOptions = Array.isArray(value)
                       ? value
                       : value
-                        ? [value]
-                        : [];
+                      ? [value]
+                      : [];
                     return (
                       <Select
                         className="pb-4 text-light-text dark:text-dark-text"
@@ -495,7 +558,7 @@ const UserProfilePage = () => {
                           label: "text-light-text dark:text-dark-text text-lg",
                         }}
                         variant="bordered"
-                        fullWidth={true}
+                        fullWidth
                         label="Alternative payment options"
                         labelPlacement="outside"
                         selectionMode="multiple"
@@ -511,9 +574,7 @@ const UserProfilePage = () => {
                           <div className="flex flex-wrap gap-2">
                             {items.map((item) => (
                               <Chip key={item.key}>
-                                {item.key
-                                  ? (item.key as string)
-                                  : "unkown option"}
+                                {item.key ? (item.key as string) : "unknown"}
                               </Chip>
                             ))}
                           </div>
@@ -573,6 +634,7 @@ const UserProfilePage = () => {
                   }}
                 />
 
+                {/* ─── Shopstr Donation ─── */}
                 <Controller
                   name="shopstr_donation"
                   control={control}
@@ -597,13 +659,168 @@ const UserProfilePage = () => {
                   )}
                 />
 
+                {/* ─── P2PK Enabled Checkbox ─── */}
+                <Controller
+                  name="p2pkEnabled"
+                  control={control}
+                  render={({ field: { onChange, value } }) => (
+                    <div className="pb-4">
+                      <label className="text-lg text-light-text dark:text-dark-text flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={value}
+                          onChange={(e) => onChange(e.target.checked)}
+                        />
+                        Enable Time-Locked Payment (P2PK)
+                      </label>
+                    </div>
+                  )}
+                />
+
+                {watchP2pkEnabled && (
+                  <>
+                    {/* ─── P2PK Redeem Pubkey ─── */}
+                    <Controller
+                      name="p2pkPubkey"
+                      control={control}
+                      rules={{
+                        required: "Required",
+                        validate: (v: string) => {
+                          if (/^[0-9A-Fa-f]{64}$/.test(v)) return true;
+                          if (v.startsWith("npub")) {
+                            try {
+                              const { data: d } = nip19.decode(v);
+                              return /^[0-9A-Fa-f]{64}$/.test(d as string)
+                                ? true
+                                : "Decoded npub is not valid hex";
+                            } catch {
+                              return "Invalid npub";
+                            }
+                          }
+                          return "Must be 64-char hex or npub…";
+                        },
+                      }}
+                      render={({
+                        field: { onChange, onBlur, value },
+                        fieldState: { error },
+                      }) => {
+                        const isErrored = !!error;
+                        const errorMessage = error?.message ?? "";
+                        return (
+                          <Input
+                            className="pb-4 text-light-text dark:text-dark-text"
+                            classNames={{
+                              label: "text-light-text dark:text-dark-text text-lg",
+                            }}
+                            variant="bordered"
+                            fullWidth
+                            label="P2PK Redeem Pubkey (hex or npub)"
+                            labelPlacement="outside"
+                            placeholder="Enter the merchant’s P2PK pubkey"
+                            isInvalid={isErrored}
+                            errorMessage={errorMessage}
+                            onChange={onChange}
+                            onBlur={onBlur}
+                            value={value}
+                          />
+                        );
+                      }}
+                    />
+
+                    {/* ─── Lock Expires (date + time) ─── */}
+                    <Controller
+                      name="locktime"
+                      control={control}
+                      rules={{
+                        required: "Pick a date & time",               
+                        validate: (val: string) =>
+                          new Date(val).getTime() > Date.now() ||      
+                          "Must pick a future date/time",
+                      }}
+                      render={({
+                        field: { onChange, onBlur, value },
+                        fieldState: { error },
+                      }) => {
+                        const isErrored = !!error;
+                        const errorMessage = error?.message ?? "";
+                        return (
+                          <div className="mb-4">
+                            <label
+                              className="block mb-1 text-light-text dark:text-dark-text"
+                            >
+                              Lock Expires (local time)
+                            </label>
+                            <input
+                              type="datetime-local"
+                              className="w-full rounded border border-default px-3 py-2 text-light-text dark:text-dark-text bg-light-bg dark:bg-dark-bg"
+                              value={value}
+                              onChange={(e) => onChange(e.target.value)}
+                              onBlur={onBlur}
+                            />
+                            {isErrored && (
+                              <p className="text-danger text-sm mt-1">{errorMessage}</p>
+                            )}
+                          </div>
+                        );
+                      }}
+                    />
+
+                    <Controller
+                      name="refundPubkeys"
+                      control={control}
+                      rules={{
+                        validate: (v: string) => {
+                          const parts = v
+                            .split(",")
+                            .map((s) => s.trim())
+                            .filter(Boolean);
+                          for (const p of parts) {
+                            if (
+                              !/^[0-9A-Fa-f]{64}$/.test(p) &&
+                              !p.startsWith("npub")
+                            ) {
+                              return "Invalid pubkey in list";
+                            }
+                          }
+                          return true;
+                        },
+                      }}
+                      render={({
+                        field: { onChange, onBlur, value },
+                        fieldState: { error },
+                      }) => {
+                        const isErrored = !!error;
+                        const errorMessage = error?.message ?? "";
+                        return (
+                          <Textarea
+                            className="pb-4 text-light-text dark:text-dark-text"
+                            classNames={{
+                              label: "text-light-text dark:text-dark-text text-lg",
+                            }}
+                            variant="bordered"
+                            fullWidth
+                            placeholder="Comma-separated refund pubkeys (hex or npub)…"
+                            isInvalid={isErrored}
+                            errorMessage={errorMessage}
+                            label="Refund Pubkeys"
+                            labelPlacement="outside"
+                            onChange={onChange}
+                            onBlur={onBlur}
+                            value={value}
+                          />
+                        );
+                      }}
+                    />
+                  </>
+                )}
+
                 <Button
                   className={`mb-10 w-full ${SHOPSTRBUTTONCLASSNAMES}`}
                   type="submit"
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
-                      e.preventDefault(); // Prevent default to avoid submitting the form again
-                      handleSubmit(onSubmit as any)(); // Programmatic submit
+                      e.preventDefault();
+                      handleSubmit(onSubmit as any)();
                     }
                   }}
                   isDisabled={isUploadingProfile}

--- a/utils/types/types.ts
+++ b/utils/types/types.ts
@@ -32,6 +32,7 @@ export interface ShopProfile {
       pubkey: string;
       locktime: number;
       refund?: string[];
+      tags?: [string, string][];
     }
     merchants: string[];
   };

--- a/utils/types/types.ts
+++ b/utils/types/types.ts
@@ -98,3 +98,11 @@ declare global {
     nostr: any;
   }
 }
+
+export interface GetInfoResponse {
+  version: string;
+  network: string;
+  methods?: {
+    [nutId: string]: { supported: boolean };
+  };
+}

--- a/utils/types/types.ts
+++ b/utils/types/types.ts
@@ -27,6 +27,12 @@ export interface ShopProfile {
       theme: string;
       darkMode: boolean;
     };
+    p2pk?: {
+      enabled: boolean;
+      pubkey: string;
+      locktime: number;
+      refund?: string[];
+    }
     merchants: string[];
   };
   created_at: number;

--- a/utils/types/types.ts
+++ b/utils/types/types.ts
@@ -27,13 +27,6 @@ export interface ShopProfile {
       theme: string;
       darkMode: boolean;
     };
-    p2pk?: {
-      enabled: boolean;
-      pubkey: string;
-      locktime: number;
-      refund?: string[];
-      tags?: [string, string][];
-    }
     merchants: string[];
   };
   created_at: number;
@@ -51,6 +44,15 @@ export interface ProfileData {
     payment_preference?: string;
     fiat_options?: string[];
     shopstr_donation?: number;
+    display_name?: string;
+    website?: string;
+    p2pk?: {
+      enabled: boolean;
+      pubkey: string;
+      locktime: number;
+      refund?: string[];
+      tags?: [string, string][];
+    };
   };
   created_at: number;
 }


### PR DESCRIPTION
In this PR , I have implemented the p2pk time locked cashu tokens as per NUT-11.

- Generate and parse P2PK secrets with absolute UNIX locktime and refund tags in Shop Settings
- Update TS types to reflect { locktime: number; refund?: string[] }
- Round-trip the locktime → locktimeDays in the shop form
- Compute and display “Locked for X days” in product and checkout cards from the new timestamp
- Enhance claim-button to handle both on-time spends and post-expiry refunds
- Align invoice components (cart-invoice-card, product-invoice-card) with the P2PK flow