### PR TITLE
Lint workflow fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         id: eslint
         run: |
           npx eslint "pages/**/*.{js,ts,tsx}" "components/**/*.{js,ts,tsx}" --format json > eslint-report.json || true
-          count=$(jq '[.[].messages[]] | length' eslint-report.json)
+          count=$(jq '[.[].messages[] | select(.severity == 2)] | length' eslint-report.json)
           echo "eslint_errors=$count" >> $GITHUB_OUTPUT
 
       - name: Run Prettier


### PR DESCRIPTION
Lint workflow won't we commenting now on pr's unless there is actual error , that is it will now ignore ESLint warnings since it was kinda noisy

cc @calvadev 