### PR TITLE
feat: stale workflow added

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,64 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Token for the repository
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues configuration
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity. 
+            It will be closed if no further activity occurs within 7 days. 
+            If this issue is still relevant, please leave a comment to keep it open.
+            Thank you for your contributions! 🙏
+          
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity. 
+            If you believe this issue is still relevant, please feel free to reopen it or create a new issue with updated information.
+            Thank you for your understanding! 🚀
+          
+          # Pull requests configuration  
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs within 7 days.
+            If this PR is still relevant, please leave a comment or push new commits to keep it open.
+            Thank you for your contribution! 🙏
+          
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+            If you would like to continue working on this, please feel free to reopen it or create a new PR.
+            Thank you for your contribution! 🚀
+          
+          # Timing configuration
+          days-before-stale: 45      # Mark as stale after 30 days of inactivity
+          days-before-close: 10       # Close after 7 additional days of being stale
+
+          # Labels
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,bug,enhancement,help-wanted,good-first-issue'
+          exempt-pr-labels: 'pinned,security,work-in-progress,wip'
+
+          # Additional options
+          operations-per-run: 100    # Max operations per run to avoid API limits
+          remove-stale-when-updated: true  # Remove stale label when there's new activity
+          debug-only: false          # Set to true for testing without actually closing
+
+          # Only process issues/PRs (set to false to disable either)
+          enable-statistics: true
+          only-labels: ''            # Only process items with these labels (empty = all)
+          any-of-labels: ''          # Process items with any of these labels

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,64 +1,56 @@
-name: 'Close stale issues and PRs'
+name: Close inactive issues and PRs
 
 on:
   schedule:
-    # Run daily at 00:00 UTC
-    - cron: '0 0 * * *'
-  workflow_dispatch: # Allow manual trigger
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
+    name: Mark and close inactive issues and PRs
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - name: Update inactive issues and pull requests
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
-          # Token for the repository
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 21
+          days-before-close: 7
 
-          # Issues configuration
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "bug,documentation,enhancement,good first issue,help wanted,hold,priority"
+          exempt-pr-labels: "hold,merge-ready,priority"
+          exempt-draft-pr: true
+          exempt-all-milestones: true
+
           stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had recent activity. 
-            It will be closed if no further activity occurs within 7 days. 
+            This issue has been automatically marked as stale because it has not had recent activity for 3 weeks.
+            It will be closed if no further activity occurs within 7 days.
             If this issue is still relevant, please leave a comment to keep it open.
-            Thank you for your contributions! 🙏
-          
+            Thank you for your contributions!
+
           close-issue-message: |
-            This issue has been automatically closed due to inactivity. 
-            If you believe this issue is still relevant, please feel free to reopen it or create a new issue with updated information.
-            Thank you for your understanding! 🚀
-          
-          # Pull requests configuration  
+            This issue has been automatically closed because it remained inactive for 1 week after being marked as stale.
+            If you believe this issue is still relevant, please reopen it or create a new issue with updated information.
+            Thank you for your understanding!
+
           stale-pr-message: |
-            This pull request has been automatically marked as stale because it has not had recent activity.
+            This pull request has been automatically marked as stale because it has not had recent activity for 3 weeks.
             It will be closed if no further activity occurs within 7 days.
             If this PR is still relevant, please leave a comment or push new commits to keep it open.
-            Thank you for your contribution! 🙏
-          
+            Thank you for your contribution!
+
           close-pr-message: |
-            This pull request has been automatically closed due to inactivity.
-            If you would like to continue working on this, please feel free to reopen it or create a new PR.
-            Thank you for your contribution! 🚀
-          
-          # Timing configuration
-          days-before-stale: 45      # Mark as stale after 30 days of inactivity
-          days-before-close: 10       # Close after 7 additional days of being stale
+            This pull request has been automatically closed because it remained inactive for 1 week after being marked as stale.
+            If you would like to continue working on this, please reopen it or create a new PR.
+            Thank you for your contribution!
 
-          # Labels
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-          exempt-issue-labels: 'pinned,security,bug,enhancement,help-wanted,good-first-issue'
-          exempt-pr-labels: 'pinned,security,work-in-progress,wip'
-
-          # Additional options
-          operations-per-run: 100    # Max operations per run to avoid API limits
-          remove-stale-when-updated: true  # Remove stale label when there's new activity
-          debug-only: false          # Set to true for testing without actually closing
-
-          # Only process issues/PRs (set to false to disable either)
+          close-issue-reason: not_planned
+          operations-per-run: 100
+          remove-stale-when-updated: true
           enable-statistics: true
-          only-labels: ''            # Only process items with these labels (empty = all)
-          any-of-labels: ''          # Process items with any of these labels


### PR DESCRIPTION
Resolves: #189 

This pull request introduces automated management of stale issues and pull requests using GitHub Actions. The new workflow will periodically mark inactive issues and PRs as stale, notify contributors, and close them after a set period if there is no further activity. This helps keep the repository clean and focused on active contributions.

Repository automation:

* Added `.github/workflows/stale.yml` to automatically mark issues and pull requests as stale after 45 days of inactivity, and close them 10 days later if no activity occurs. Custom messages are provided for both marking as stale and closing, and labels are managed accordingly. Exemptions for certain labels are included to prevent important items from being closed automatically.