### PR TITLE
Implement "Stale Listing" Support [NIP-40]

### DIFF
--- a/components/display-product-modal.tsx
+++ b/components/display-product-modal.tsx
@@ -45,6 +45,10 @@ export default function DisplayProductModal({
 
   const [showSuccessModal, setShowSuccessModal] = useState(false);
 
+  const isExpired = productData.expiration
+    ? Date.now() / 1000 > productData.expiration
+    : false;
+
   const displayDate = (timestamp: number): [string, string] => {
     if (timestamp == 0 || !timestamp) return ["", ""];
     const d = new Date(timestamp * 1000);
@@ -118,7 +122,15 @@ export default function DisplayProductModal({
             <div className="flex items-center justify-between">
               <h2 className="text-2xl font-bold text-light-text dark:text-dark-text">
                 {productData.title}
+                {isExpired && (
+                  <Chip color="warning" variant="flat" className="ml-2">Outdated</Chip>
+                )}
               </h2>
+              {productData.expiration && (
+                <p className="text-sm text-gray-500">
+                  Valid until: {new Date(productData.expiration * 1000).toLocaleDateString()}
+                </p>
+              )}
               <div>
                 {productData.status === "active" && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-300">

--- a/components/home/marketplace.tsx
+++ b/components/home/marketplace.tsx
@@ -191,6 +191,9 @@ function MarketplacePage({
           const productReviews = product.d
             ? productReviewMap.get(product.d)
             : undefined;
+          const isExpired = product.expiration
+            ? Date.now() / 1000 > product.expiration
+            : false;
 
           if (!productReviews || productReviews.size === 0) return null;
 
@@ -204,6 +207,11 @@ function MarketplacePage({
                   className="cursor-pointer hover:underline"
                 >
                   {product.title}
+                  {isExpired && (
+                    <Chip color="warning" size="sm" variant="flat" className="ml-2">
+                      Outdated
+                    </Chip>
+                  )}
                 </div>
               </h3>
               <div className="space-y-3">

--- a/components/product-form.tsx
+++ b/components/product-form.tsx
@@ -110,6 +110,7 @@ export default function ProductForm({
           Status: oldValues.status ? oldValues.status : "",
           Required: oldValues.required ? oldValues.required : "",
           Restrictions: oldValues.restrictions ? oldValues.restrictions : "",
+          Expiration: oldValues.expiration ? new Date(oldValues.expiration * 1000).toISOString().slice(0, 16) : "",
         }
       : {
           Currency: "SAT",
@@ -217,6 +218,14 @@ export default function ProductForm({
 
     if (data["Restrictions"]) {
       tags.push(["restrictions", data["Restrictions"] as string]);
+    }
+
+    if (data["Expiration"]) {
+      const dateObj = new Date(data["Expiration"] as string);
+      if (!isNaN(dateObj.getTime())) {
+        const unixTime = Math.floor(dateObj.getTime() / 1000);
+        tags.push(["valid_until", unixTime.toString()]);
+      }
     }
 
     // Add pickup locations if they exist and shipping involves pickup
@@ -1323,6 +1332,42 @@ export default function ProductForm({
                   }}
                 />
               </>
+            )}
+
+            {showOptionalTags && (
+              <Controller
+                name="Expiration"
+                control={control}
+                render={({
+                  field: { onChange, onBlur, value },
+                  fieldState: { error },
+                }) => {
+                  const isErrored = error !== undefined;
+                  const errorMessage = error?.message || "";
+                  return (
+                    <div className="mt-4">
+                      <Input
+                        type="datetime-local"
+                        min={new Date().toISOString().slice(0, 16)}
+                        variant="bordered"
+                        label="Valid Until (Optional)"
+                        labelPlacement="inside"
+                        placeholder="Select a date to mark listing as stale"
+                        isInvalid={isErrored}
+                        errorMessage={errorMessage}
+                        onChange={onChange}
+                        onBlur={onBlur}
+                        value={value as string}
+                        className="text-light-text dark:text-dark-text"
+                      />
+                      <p className="text-tiny text-gray-500 mt-1">
+                        Listing will remain visible but marked as &quot;Outdated&quot; after this date.
+                        Leave empty if product has no expiration. Buyers won&apos;t be able to purchase after expiration.
+                      </p>
+                    </div>
+                  );
+                }}
+              />
             )}
 
             <div className="mx-4 my-2 flex items-center justify-center text-center">

--- a/components/utility-components/checkout-card.tsx
+++ b/components/utility-components/checkout-card.tsx
@@ -80,6 +80,10 @@ export default function CheckoutCard({
 
   const hasVolumes = productData.volumes && productData.volumes.length > 0;
 
+  const isExpired = productData.expiration
+    ? Date.now() / 1000 > productData.expiration
+    : false;
+
   useEffect(() => {
     if (selectedVolume && productData.volumePrices) {
       const volumePrice = productData.volumePrices.get(selectedVolume);
@@ -428,7 +432,17 @@ export default function CheckoutCard({
                   </div>
                   <h2 className="mt-4 w-full text-left text-2xl font-bold text-light-text dark:text-dark-text">
                     {productData.title}
+                    {isExpired && (
+                      <Chip color="warning" variant="flat" className="ml-2">
+                        Outdated
+                      </Chip>
+                    )}
                   </h2>
+                  {productData.expiration && (
+                    <p className={`text-left text-sm mt-1 ${isExpired ? "text-red-500 font-medium" : "text-gray-500"}`}>
+                      {isExpired ? "Expired on: " : "Valid until: "} {new Date(productData.expiration * 1000).toLocaleDateString()}
+                    </p>
+                  )}
                   {productData.condition && (
                     <div className="text-left text-xs text-light-text dark:text-dark-text">
                       <span>Condition: {productData.condition}</span>
@@ -493,10 +507,12 @@ export default function CheckoutCard({
                                 ? "cursor-not-allowed opacity-50"
                                 : ""
                             }`}
+                            
                             onClick={toggleBuyNow}
                             disabled={
                               (hasSizes && !selectedSize) ||
-                              (hasVolumes && !selectedVolume)
+                              (hasVolumes && !selectedVolume) ||
+                              isExpired
                             }
                           >
                             Buy Now
@@ -513,7 +529,8 @@ export default function CheckoutCard({
                             disabled={
                               isAdded ||
                               (hasSizes && !selectedSize) ||
-                              (hasVolumes && !selectedVolume)
+                              (hasVolumes && !selectedVolume) ||
+                              isExpired
                             }
                           >
                             Add To Cart

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -24,6 +24,10 @@ export default function ProductCard({
 
   const cardHoverStyle =
     "hover:shadow-purple-500/30 dark:hover:shadow-yellow-500/30 hover:scale-[1.01]";
+  
+  const isExpired = productData.expiration
+    ? Date.now() / 1000 > productData.expiration
+    : false;
 
   const content = (
     <div
@@ -45,6 +49,11 @@ export default function ProductCard({
             <h2 className="max-w-[70%] truncate text-xl font-semibold text-light-text dark:text-dark-text">
               {productData.title}
             </h2>
+            {isExpired && (
+              <Chip color="warning" size="sm" variant="flat" className="mr-2">
+                Outdated
+              </Chip>
+            )}
             {productData.status === "active" && (
               <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-300">
                 Active

--- a/utils/parsers/product-parser-functions.ts
+++ b/utils/parsers/product-parser-functions.ts
@@ -33,6 +33,7 @@ export type ProductData = {
   required?: string;
   restrictions?: string;
   pickupLocations?: string[];
+  expiration?: number;
 };
 
 export const parseTags = (productEvent: NostrEvent) => {
@@ -162,6 +163,9 @@ export const parseTags = (productEvent: NostrEvent) => {
         if (parsedData.pickupLocations === undefined)
           parsedData.pickupLocations = [];
         parsedData.pickupLocations.push(values[0]!);
+        break;
+      case "valid_until":
+        parsedData.expiration = Number(values[0]);
         break;
       default:
         return;


### PR DESCRIPTION
This PR implements listing expiration logic inspired by NIP-40 but modified to meet specific business requirements. Instead of having Relays delete expired events (standard NIP-40 behavior), we use a custom valid_until tag. This allows the frontend to flag listings as "Outdated" while keeping the historical record visible for both merchants and buyers.

**Key Changes**

- Data Persistence: Switched from using the expiration tag (which triggers relay deletion) to valid_until. Relays persist these events indefinitely.
- Merchant UI: Added a "Valid Until" date picker to the Product Form.

**Buyer Protection:**

- Marketplace/Feed: Displays an orange "Outdated" chip if Current Time > Valid Until.
- Checkout/Modal: Disables "Buy Now" and "Add to Cart" buttons with the text "Outdated - Contact Merchant".
- Context: Displays the specific expiration date to the user.
- Maintenance: Merchants can "revive" a stale listing simply by editing it and setting a new future date.

**Testing & Verification I have tested the full lifecycle of the feature on localhost:**

- [x] Creation: Created listings with future and past dates.
- [x] Persistence: Verified listings do not disappear from the feed after expiration.
- [x] Visuals: Verified "Outdated" chips appear correctly in Grid, List, and Modal views.
- [x] Safety: Verified that expired items cannot be added to the cart or purchased (buttons are disabled).
- [x] Editing: Verified that updating the date removes the "Outdated" status immediately.

<img width="1600" height="653" alt="image" src="https://github.com/user-attachments/assets/311d08a8-be75-42fe-bac7-04f30b8b7058" />
--
<img width="1600" height="828" alt="image" src="https://github.com/user-attachments/assets/da334177-7242-474e-a64a-add52548e2bb" />
--
<img width="1599" height="898" alt="image" src="https://github.com/user-attachments/assets/4d06e18e-85e5-4f10-b447-319da023158c" />
