### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,7 @@ jobs:
 
   notify:
     name: Notify Release
+    permissions: {}
     runs-on: ubuntu-latest
     needs: [create-release, publish-npm]
     if: always() && (needs.create-release.result == 'success')


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/28](https://github.com/shopstr-eng/shopstr/security/code-scanning/28)

To fix this problem, add a `permissions` block to the `notify` job in `.github/workflows/release.yml`. Since the `notify` job does not require any repository write operations, assigning it the minimal `permissions` — ideally `permissions: {} (no access)` — is recommended. This can be done by setting `permissions: {}` at the job level (inside `notify:`) above `runs-on: ubuntu-latest`. No changes to steps or other jobs are needed. This will ensure the job only gets the absolute minimum GitHub token permissions, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
