### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,8 @@ jobs:
 
   publish-npm:
     name: Publish to npm
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [test, create-release]
     if: always() && (needs.test.result == 'success') && (needs.create-release.result == 'success') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta')


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/27](https://github.com/shopstr-eng/shopstr/security/code-scanning/27)

To fix the problem, we will add a `permissions` block to the `publish-npm` job in `.github/workflows/release.yml`. This block should grant the minimal necessary permissions―for npm publishing via GitHub Actions, typically `contents: read` is sufficient because no repository write operations are needed. We will insert this near the top of the `publish-npm` job (just after the `name` key, following GitHub conventions). No additional imports, methods or variable definitions are needed since this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
