### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,8 @@ jobs:
 
   create-release:
     name: Create GitHub Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [test, version-and-changelog]
     if: always() && (needs.test.result == 'success') && (github.event_name == 'push' || needs.version-and-changelog.result == 'success')


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/26](https://github.com/shopstr-eng/shopstr/security/code-scanning/26)

To fix the problem, you should add a `permissions` block to the `create-release` job in `.github/workflows/release.yml`. This block should grant the minimal set of permissions necessary for the job to successfully create a GitHub release and upload assets. For GitHub releases and asset uploads, the job requires `contents: write`. You should insert the permissions block directly under `name: Create GitHub Release` (line 158), on the same level as `runs-on`. No new imports or code changes are needed outside this block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
