### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
 
   version-and-changelog:
     name: Version Bump and Changelog
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/25](https://github.com/shopstr-eng/shopstr/security/code-scanning/25)

To address the problem, an explicit `permissions` block must be added to the `version-and-changelog` job in `.github/workflows/release.yml`. Since the job performs git pushes and creates tags, it requires `contents: write` permission. No other scopes are needed, so the permission block should follow the principle of least privilege: only grant `contents: write`. The change should be made immediately beneath the job's `name` and above `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
