### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ env:
 jobs:
   test:
     name: Test on Node.js ${{ matrix.node-version }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/24](https://github.com/shopstr-eng/shopstr/security/code-scanning/24)

To fix this problem, we need to add a `permissions` block to the `test` job in the workflow file. We should set it to the least privilege necessary—since none of the commands require write access, the safest minimum is `contents: read`. We should insert this block immediately under the `test:` job definition (after line 34 / just above or below `runs-on:`), so that it's clear that this job uses reduced permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
