### PR TITLE
Add URL paste support for profile and shop images

### DIFF
--- a/components/communities/CreateCommunityForm.tsx
+++ b/components/communities/CreateCommunityForm.tsx
@@ -90,6 +90,7 @@ const CreateCommunityForm: React.FC<CreateCommunityFormProps> = ({
         <FileUploaderButton
           className={`${SHOPSTRBUTTONCLASSNAMES} w-fit`}
           imgCallbackOnUpload={(imgUrl) => setValue("image", imgUrl)}
+          allowUrlInput
         >
           Upload Image
         </FileUploaderButton>

--- a/components/communities/__tests__/CreateCommunityForm.test.tsx
+++ b/components/communities/__tests__/CreateCommunityForm.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import CreateCommunityForm from "../CreateCommunityForm";
 import { Community } from "@/utils/types/types";
+import { FileUploaderButton } from "@/components/utility-components/file-uploader";
 
 jest.mock("@heroui/react", () => ({
   Button: ({ children, ...props }: any) => (
@@ -42,24 +43,27 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("@/components/utility-components/file-uploader", () => ({
-  FileUploaderButton: ({
-    children,
-    imgCallbackOnUpload,
-    className,
-  }: {
-    children: React.ReactNode;
-    imgCallbackOnUpload: (url: string) => void;
-    className: string;
-  }) => (
-    <button
-      type="button"
-      className={className}
-      onClick={() => imgCallbackOnUpload("https://example.com/new-image.jpg")}
-    >
-      {children}
-    </button>
+  FileUploaderButton: jest.fn(
+    ({
+      children,
+      imgCallbackOnUpload,
+      className,
+    }: {
+      children: React.ReactNode;
+      imgCallbackOnUpload: (url: string) => void;
+      className: string;
+    }) => (
+      <button
+        type="button"
+        className={className}
+        onClick={() => imgCallbackOnUpload("https://example.com/new-image.jpg")}
+      >
+        {children}
+      </button>
+    )
   ),
 }));
+const mockFileUploaderButton = FileUploaderButton as jest.Mock;
 
 jest.mock("uuid", () => ({
   v4: () => "mock-uuid-1234",
@@ -72,6 +76,7 @@ describe("CreateCommunityForm", () => {
   beforeEach(() => {
     onSaveMock.mockClear();
     onCancelMock.mockClear();
+    mockFileUploaderButton.mockClear();
   });
 
   it("renders correctly in create mode with a generated UUID", () => {
@@ -86,6 +91,17 @@ describe("CreateCommunityForm", () => {
     expect(
       screen.getByRole("button", { name: /Create Community/i })
     ).toBeInTheDocument();
+  });
+
+  it("enables URL paste for the community image uploader", () => {
+    render(
+      <CreateCommunityForm existingCommunity={null} onSave={onSaveMock} />
+    );
+
+    expect(mockFileUploaderButton).toHaveBeenCalledWith(
+      expect.objectContaining({ allowUrlInput: true }),
+      undefined
+    );
   });
 
   it("pre-populates the form when editing an existing community", () => {

--- a/components/settings/__tests__/shop-profile-form.test.tsx
+++ b/components/settings/__tests__/shop-profile-form.test.tsx
@@ -140,6 +140,29 @@ describe("ShopProfileForm", () => {
     );
   });
 
+  test("updates shop image previews from pasted URLs", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ShopProfileForm />);
+
+    await user.type(
+      await screen.findByLabelText("Shop logo URL"),
+      "https://cdn.example.com/logo.png"
+    );
+    expect(screen.getByAltText("shop logo")).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/logo.png"
+    );
+
+    await user.type(
+      screen.getByLabelText("Shop banner URL"),
+      "https://cdn.example.com/banner.png"
+    );
+    expect(screen.getByAltText("Shop banner image")).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/banner.png"
+    );
+  });
+
   test("submits the form, shows loading state, and calls relevant functions", async () => {
     const user = userEvent.setup();
     let resolveCreateEvent: (value?: unknown) => void;

--- a/components/settings/__tests__/user-profile-form.test.tsx
+++ b/components/settings/__tests__/user-profile-form.test.tsx
@@ -341,6 +341,21 @@ describe("UserProfileForm", () => {
     expect(newProfileImage).toHaveAttribute("src", "https://new.image/url");
   });
 
+  test("updates the profile picture from a pasted URL", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<UserProfileForm />);
+
+    await user.type(
+      await screen.findByLabelText("Profile image URL"),
+      "https://cdn.example.com/profile.png"
+    );
+
+    expect(screen.getByAltText("user profile picture")).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/profile.png"
+    );
+  });
+
   test("updates payment preference and shopstr donation", async () => {
     mockCreateNostrProfileEvent.mockResolvedValue(mockSavedProfileEvent);
     const user = userEvent.setup();

--- a/components/settings/shop-profile-form.tsx
+++ b/components/settings/shop-profile-form.tsx
@@ -641,6 +641,51 @@ const ShopProfileForm = ({ isOnboarding = false }: ShopProfileFormProps) => {
           </div>
 
           <form onSubmit={handleSubmit(onSubmit as any)}>
+            <div className="grid gap-4 pb-4 md:grid-cols-2">
+              <Controller
+                name="picture"
+                control={control}
+                render={({ field: { onChange, onBlur, value } }) => (
+                  <Input
+                    className="text-light-text dark:text-dark-text"
+                    classNames={{
+                      label: "text-light-text dark:text-dark-text text-lg",
+                    }}
+                    variant="bordered"
+                    fullWidth={true}
+                    type="url"
+                    label="Shop logo URL"
+                    labelPlacement="outside"
+                    placeholder="https://..."
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    value={value || ""}
+                  />
+                )}
+              />
+              <Controller
+                name="banner"
+                control={control}
+                render={({ field: { onChange, onBlur, value } }) => (
+                  <Input
+                    className="text-light-text dark:text-dark-text"
+                    classNames={{
+                      label: "text-light-text dark:text-dark-text text-lg",
+                    }}
+                    variant="bordered"
+                    fullWidth={true}
+                    type="url"
+                    label="Shop banner URL"
+                    labelPlacement="outside"
+                    placeholder="https://..."
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    value={value || ""}
+                  />
+                )}
+              />
+            </div>
+
             <Controller
               name="name"
               control={control}

--- a/components/settings/user-profile-form.tsx
+++ b/components/settings/user-profile-form.tsx
@@ -350,6 +350,28 @@ const UserProfileForm = ({ isOnboarding }: UserProfileFormProps) => {
 
       <form onSubmit={handleSubmit(onSubmit as any)}>
         <Controller
+          name="picture"
+          control={control}
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              type="url"
+              className="text-light-text dark:text-dark-text pb-4"
+              classNames={{
+                label: "text-light-text dark:text-dark-text text-lg",
+              }}
+              variant="bordered"
+              fullWidth
+              label="Profile image URL"
+              labelPlacement="outside"
+              placeholder="https://..."
+              onChange={onChange}
+              onBlur={onBlur}
+              value={value || ""}
+            />
+          )}
+        />
+
+        <Controller
           name="display_name"
           control={control}
           render={({

--- a/components/utility-components/__tests__/file-uploader.test.tsx
+++ b/components/utility-components/__tests__/file-uploader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { FileUploaderButton } from "../file-uploader";
@@ -18,6 +18,23 @@ jest.mock(
       </button>
     ),
     Progress: (props: any) => <div data-testid="progress" {...props} />,
+    Input: ({
+      isDisabled,
+      onChange,
+      onKeyDown,
+      placeholder,
+      type,
+      value,
+    }: any) => (
+      <input
+        disabled={isDisabled}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        type={type}
+        value={value}
+      />
+    ),
   }),
   { virtual: true }
 );
@@ -32,6 +49,7 @@ jest.mock("@heroicons/react/24/outline", () => ({
   ArrowUpTrayIcon: (props: any) => (
     <svg data-testid="arrow-up-tray-icon" {...props} />
   ),
+  LinkIcon: (props: any) => <svg data-testid="link-icon" {...props} />,
   XCircleIcon: (props: any) => <svg data-testid="x-circle-icon" {...props} />,
   XMarkIcon: (props: any) => <svg data-testid="x-mark-icon" {...props} />,
 }));
@@ -74,5 +92,41 @@ describe("FileUploaderButton", () => {
     expect(root).toHaveClass("flex", "w-full", "flex-col", "gap-4");
     expect(root).not.toHaveClass("w-fit");
     expect(button).toHaveClass("inner-button-class");
+  });
+
+  test("accepts a pasted HTTPS image URL when enabled", () => {
+    const onUpload = jest.fn();
+    render(
+      <FileUploaderButton allowUrlInput imgCallbackOnUpload={onUpload}>
+        Upload Banner
+      </FileUploaderButton>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/paste an image url/i), {
+      target: { value: "  https://cdn.example.com/banner.png  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Use URL/i }));
+
+    expect(onUpload).toHaveBeenCalledWith("https://cdn.example.com/banner.png");
+    expect(screen.getByPlaceholderText(/paste an image url/i)).toHaveValue("");
+  });
+
+  test("rejects pasted non-HTTPS URLs", () => {
+    const onUpload = jest.fn();
+    render(
+      <FileUploaderButton allowUrlInput imgCallbackOnUpload={onUpload}>
+        Upload Banner
+      </FileUploaderButton>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/paste an image url/i), {
+      target: { value: "http://cdn.example.com/banner.png" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Use URL/i }));
+
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Please enter a valid image URL starting with https://.")
+    ).toBeInTheDocument();
   });
 });

--- a/components/utility-components/file-uploader.tsx
+++ b/components/utility-components/file-uploader.tsx
@@ -1,5 +1,5 @@
 import { useContext, useRef, useState } from "react";
-import { Button, Progress } from "@heroui/react";
+import { Button, Input, Progress } from "@heroui/react";
 import {
   blossomUploadImages,
   getLocalStorageData,
@@ -9,6 +9,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import {
   PhotoIcon,
   ArrowUpTrayIcon,
+  LinkIcon,
   XCircleIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
@@ -47,6 +48,7 @@ export const FileUploaderButton = ({
   imgCallbackOnUpload,
   isPlaceholder,
   isProductUpload,
+  allowUrlInput,
 }: {
   disabled?: boolean;
   isIconOnly?: boolean;
@@ -56,6 +58,7 @@ export const FileUploaderButton = ({
   imgCallbackOnUpload: (imgUrl: string) => void;
   isPlaceholder?: boolean;
   isProductUpload?: boolean;
+  allowUrlInput?: boolean;
 }) => {
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState<number | null>(null);
@@ -65,6 +68,7 @@ export const FileUploaderButton = ({
     { src: string; name: string; size: number }[]
   >([]);
   const [isDragging, setIsDragging] = useState(false);
+  const [urlInput, setUrlInput] = useState("");
 
   const hiddenFileInput = useRef<HTMLInputElement>(null);
   const dropZoneRef = useRef<HTMLDivElement>(null);
@@ -428,6 +432,25 @@ export const FileUploaderButton = ({
     : "flex w-full flex-col gap-4";
   const dropZoneWidthClassName = containerClassName ? "w-fit" : "w-full";
 
+  const handleUrlSubmit = () => {
+    const trimmed = urlInput.trim();
+    if (!trimmed) return;
+
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.protocol !== "https:") {
+        throw new Error("Image URL must use HTTPS");
+      }
+    } catch {
+      setFailureText("Please enter a valid image URL starting with https://.");
+      setShowFailureModal(true);
+      return;
+    }
+
+    imgCallbackOnUpload(trimmed);
+    setUrlInput("");
+  };
+
   return (
     <div className={wrapperClassName}>
       {/* Drag and Drop Zone */}
@@ -511,6 +534,37 @@ export const FileUploaderButton = ({
           disabled={disabled || loading}
         />
       </div>
+
+      {allowUrlInput && (
+        <div className="flex w-full items-center gap-2">
+          <Input
+            type="url"
+            placeholder="Or paste an image URL..."
+            value={urlInput}
+            onChange={(e) => setUrlInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleUrlSubmit();
+              }
+            }}
+            variant="bordered"
+            size="sm"
+            className="text-light-text dark:text-dark-text flex-1"
+            startContent={<LinkIcon className="text-default-400 h-4 w-4" />}
+            isDisabled={disabled || loading}
+          />
+          <Button
+            type="button"
+            size="sm"
+            className="bg-shopstr-purple dark:bg-shopstr-yellow shrink-0 text-white dark:text-black"
+            onClick={handleUrlSubmit}
+            isDisabled={!urlInput.trim() || disabled || loading}
+          >
+            Use URL
+          </Button>
+        </div>
+      )}
 
       {/* Progress Bar */}
       <AnimatePresence>

--- a/pages/settings/user-profile.tsx
+++ b/pages/settings/user-profile.tsx
@@ -318,6 +318,51 @@ const UserProfilePage = () => {
               )}
 
               <form onSubmit={handleSubmit(onSubmit as any)}>
+                <div className="grid gap-4 pb-4 md:grid-cols-2">
+                  <Controller
+                    name="picture"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <Input
+                        className="text-light-text dark:text-dark-text"
+                        classNames={{
+                          label: "text-light-text dark:text-dark-text text-lg",
+                        }}
+                        variant="bordered"
+                        fullWidth={true}
+                        type="url"
+                        label="Profile image URL"
+                        labelPlacement="outside"
+                        placeholder="https://..."
+                        onChange={onChange}
+                        onBlur={onBlur}
+                        value={value || ""}
+                      />
+                    )}
+                  />
+                  <Controller
+                    name="banner"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <Input
+                        className="text-light-text dark:text-dark-text"
+                        classNames={{
+                          label: "text-light-text dark:text-dark-text text-lg",
+                        }}
+                        variant="bordered"
+                        fullWidth={true}
+                        type="url"
+                        label="Profile banner URL"
+                        labelPlacement="outside"
+                        placeholder="https://..."
+                        onChange={onChange}
+                        onBlur={onBlur}
+                        value={value || ""}
+                      />
+                    )}
+                  />
+                </div>
+
                 <Controller
                   name="display_name"
                   control={control}


### PR DESCRIPTION
## Fixing #215

This PR now focuses on the remaining part of the issue: allowing users to paste an already-hosted image URL instead of forcing a Blossom re-upload.

The original Blossom upload crash is already fixed on current `main`, so this branch intentionally preserves the upstream upload handling and does not replace `utils/nostr/nostr-helper-functions.ts`.

## Changes

- Adds optional URL paste support to `FileUploaderButton` for normal image upload controls.
- Validates pasted uploader URLs as HTTPS before accepting them.
- Adds direct URL fields for shop logo/banner and user profile/banner settings where the upload control is icon-only or compact.
- Enables URL paste for community image uploads.
- Adds focused coverage for the shared uploader, shop profile form, user profile form, and community form.