### PR TITLE
Potential fix for code scanning alert no. 35: Use of password hash with insufficient computational effort

### DIFF
--- a/utils/mcp/auth.ts
+++ b/utils/mcp/auth.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "crypto";
+import { createHash, randomBytes, pbkdf2Sync } from "crypto";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getDbPool } from "@/utils/db/db-service";
 
@@ -21,7 +21,13 @@ export interface AuthenticatedRequest extends NextApiRequest {
 }
 
 export function hashApiKey(key: string): string {
-  return createHash("sha256").update(key).digest("hex");
+  const salt = randomBytes(16);
+  const iterations = 100_000;
+  const derivedKey = pbkdf2Sync(key, salt, iterations, 32, "sha256");
+  const saltHex = salt.toString("hex");
+  const hashHex = derivedKey.toString("hex");
+  // format: algorithm$iterations$salt$hash
+  return `pbkdf2_sha256$${iterations}$${saltHex}$${hashHex}`;
 }
 
 export function generateApiKey(): { key: string; prefix: string } {


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/35](https://github.com/shopstr-eng/shopstr/security/code-scanning/35)

General fix: Replace the use of a raw, single-iteration SHA-256 hash for API keys with a password hashing scheme that is deliberately computationally expensive and, ideally, salted. For Node.js / TypeScript, a straightforward option is to use PBKDF2 from the built-in `crypto` module, which avoids adding non-standard dependencies and is explicitly designed for this purpose.

Concrete approach for this file:

1. Change `hashApiKey` to use `crypto.pbkdf2Sync` instead of `createHash("sha256")`.  
   - Generate a random salt per key (e.g., 16 bytes).  
   - Use a sufficiently large iteration count (e.g., 100,000 or higher, depending on performance requirements).  
   - Use a strong HMAC-based hash such as `sha256` within PBKDF2.  
   - Return a combined representation containing algorithm parameters, salt, and derived key (e.g., a string like `pbkdf2_sha256$iterations$saltHex$hashHex`), so that future verification logic can parse and recompute the hash.

2. Ensure that `createApiKey` continues to call `hashApiKey(key)` and store the resulting string in `key_hash` as before, but now the value is a PBKDF2-based hash instead of raw SHA-256. No change to the DB schema is needed since `key_hash` remains a string.

3. Since we already import from `"crypto"`, we do not need new external dependencies; we can import `pbkdf2Sync` alongside `createHash` (or replace `createHash` if no longer needed elsewhere in the file).

Specific changes:

- In `utils/mcp/auth.ts`, update the import line to also include `pbkdf2Sync` from `"crypto"`.
- Redefine `hashApiKey` to:
  - Generate `const salt = randomBytes(16);`
  - Set `const iterations = 100_000;`
  - Compute `const derivedKey = pbkdf2Sync(key, salt, iterations, 32, "sha256");`
  - Return a formatted string including method, iterations, salt, and derived key in hex.

No other parts of the given snippet need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
