### PR TITLE
Fix direct listing cold loads from SSR data

### DIFF
--- a/components/__tests__/listing-page.test.tsx
+++ b/components/__tests__/listing-page.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from "@testing-library/react";
+import { useRouter } from "next/router";
+import { nip19 } from "nostr-tools";
+import ListingPage, {
+  getServerSideProps,
+} from "../../pages/listing/[[...productId]]";
+import { ProductContext } from "@/utils/context/context";
+import {
+  fetchProductByDTagAndPubkey,
+  fetchProductByIdFromDb,
+  fetchProductByTitleSlug,
+} from "@/utils/db/db-service";
+import { NostrEvent } from "@/utils/types/types";
+
+jest.mock("next/router", () => ({ __esModule: true, useRouter: jest.fn() }));
+jest.mock("nostr-tools", () => ({
+  Event: {},
+  nip19: {
+    decode: jest.fn(),
+    naddrEncode: jest.fn(() => "naddr1encoded"),
+  },
+}));
+jest.mock("@/utils/db/db-service", () => ({
+  fetchProductByDTagAndPubkey: jest.fn(),
+  fetchProductByIdFromDb: jest.fn(),
+  fetchProductByTitleSlug: jest.fn(),
+}));
+jest.mock(
+  "@/components/storefront/storefront-theme-wrapper",
+  () =>
+    function MockStorefrontThemeWrapper({
+      children,
+    }: {
+      children: any;
+    }) {
+      return <div data-testid="storefront-theme-wrapper">{children}</div>;
+    }
+);
+jest.mock(
+  "../../components/utility-components/checkout-card",
+  () =>
+    function MockCheckoutCard({ productData }: { productData: any }) {
+      return <div data-testid="checkout-card">{productData.title}</div>;
+    }
+);
+jest.mock(
+  "../../components/utility-components/modals/event-modals",
+  () => ({
+    RawEventModal: () => null,
+    EventIdModal: () => null,
+  })
+);
+
+const mockUseRouter = useRouter as jest.Mock;
+const mockFetchProductByDTagAndPubkey =
+  fetchProductByDTagAndPubkey as jest.Mock;
+const mockFetchProductByIdFromDb = fetchProductByIdFromDb as jest.Mock;
+const mockFetchProductByTitleSlug = fetchProductByTitleSlug as jest.Mock;
+
+const baseEvent: NostrEvent = {
+  id: "event-id",
+  pubkey: "f".repeat(64),
+  created_at: 1710000000,
+  kind: 30402,
+  tags: [
+    ["d", "listing-d-tag"],
+    ["title", "Cold Load Listing"],
+    ["summary", "Loads from SSR props"],
+    ["image", "https://example.com/listing.png"],
+    ["price", "10", "USD"],
+    ["shipping", "Free"],
+    ["location", "Online"],
+  ],
+  content: "",
+  sig: "signature",
+};
+
+describe("Listing page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      isReady: true,
+      push: jest.fn(),
+      replace: jest.fn(),
+      query: { productId: ["cold-load-listing"] },
+    });
+  });
+
+  it("renders from the SSR-fetched product when product context is empty", () => {
+    render(
+      <ProductContext.Provider
+        value={{
+          productEvents: [],
+          isLoading: false,
+          addNewlyCreatedProductEvent: jest.fn(),
+          removeDeletedProductEvent: jest.fn(),
+        }}
+      >
+        <ListingPage
+          ogMeta={{
+            title: "Shopstr Listing",
+            description: "Check out this listing on Shopstr!",
+            image: "/shopstr-2000x2000.png",
+            url: "/listing/cold-load-listing",
+          }}
+          initialProductEvent={baseEvent}
+        />
+      </ProductContext.Provider>
+    );
+
+    expect(screen.getByTestId("checkout-card")).toHaveTextContent(
+      "Cold Load Listing"
+    );
+  });
+
+  it("returns the initial product event for direct naddr requests", async () => {
+    (nip19.decode as jest.Mock).mockReturnValue({
+      type: "naddr",
+      data: {
+        identifier: "listing-d-tag",
+        pubkey: baseEvent.pubkey,
+      },
+    });
+    mockFetchProductByDTagAndPubkey.mockResolvedValue(baseEvent);
+
+    const result = await getServerSideProps({
+      query: { productId: ["naddr1testlisting"] },
+    } as any);
+
+    expect(mockFetchProductByDTagAndPubkey).toHaveBeenCalledWith(
+      "listing-d-tag",
+      baseEvent.pubkey
+    );
+    expect(mockFetchProductByIdFromDb).not.toHaveBeenCalled();
+    expect(mockFetchProductByTitleSlug).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      props: {
+        ogMeta: expect.objectContaining({
+          title: "Cold Load Listing",
+          url: "/listing/naddr1testlisting",
+        }),
+        initialProductEvent: baseEvent,
+      },
+    });
+  });
+});

--- a/pages/listing/[[...productId]].tsx
+++ b/pages/listing/[[...productId]].tsx
@@ -41,6 +41,7 @@ import { NostrEvent } from "@/utils/types/types";
 
 type ListingPageProps = {
   ogMeta: OgMetaProps;
+  initialProductEvent: NostrEvent | null;
 };
 
 function eventToOgMeta(event: NostrEvent, urlPath: string): OgMetaProps {
@@ -67,6 +68,53 @@ const LISTING_FALLBACK: OgMetaProps = {
   description: "Check out this listing on Shopstr!",
 };
 
+async function fetchInitialProductEvent(
+  identifier: string
+): Promise<NostrEvent | null> {
+  if (identifier.startsWith("naddr1")) {
+    try {
+      const decoded = nip19.decode(identifier);
+      if (decoded.type === "naddr") {
+        return await fetchProductByDTagAndPubkey(
+          decoded.data.identifier,
+          decoded.data.pubkey
+        );
+      }
+    } catch {}
+
+    return null;
+  }
+
+  const eventById = await fetchProductByIdFromDb(identifier);
+  if (eventById) return eventById;
+
+  return await fetchProductByTitleSlug(identifier);
+}
+
+function getListingStateFromEvent(event: NostrEvent | null) {
+  if (!event) {
+    return {
+      parsedProduct: undefined,
+      rawEvent: undefined,
+      isZapsnag: false,
+    };
+  }
+
+  if (event.kind === 1) {
+    return {
+      parsedProduct: parseZapsnagNote(event),
+      rawEvent: event as Event,
+      isZapsnag: true,
+    };
+  }
+
+  return {
+    parsedProduct: parseTags(event),
+    rawEvent: event as Event,
+    isZapsnag: false,
+  };
+}
+
 export const getServerSideProps: GetServerSideProps<ListingPageProps> = async (
   context
 ) => {
@@ -74,49 +122,44 @@ export const getServerSideProps: GetServerSideProps<ListingPageProps> = async (
   const identifier = Array.isArray(productId) ? productId[0] : productId;
 
   if (!identifier) {
-    return { props: { ogMeta: LISTING_FALLBACK } };
+    return { props: { ogMeta: LISTING_FALLBACK, initialProductEvent: null } };
   }
 
   const urlPath = `/listing/${identifier}`;
 
   try {
-    if (identifier.startsWith("naddr1")) {
-      try {
-        const decoded = nip19.decode(identifier);
-        if (decoded.type === "naddr") {
-          const event = await fetchProductByDTagAndPubkey(
-            decoded.data.identifier,
-            decoded.data.pubkey
-          );
-          if (event)
-            return { props: { ogMeta: eventToOgMeta(event, urlPath) } };
-        }
-      } catch {}
-      return { props: { ogMeta: { ...LISTING_FALLBACK, url: urlPath } } };
+    const initialProductEvent = await fetchInitialProductEvent(identifier);
+    if (initialProductEvent) {
+      return {
+        props: {
+          ogMeta: eventToOgMeta(initialProductEvent, urlPath),
+          initialProductEvent,
+        },
+      };
     }
-
-    const eventById = await fetchProductByIdFromDb(identifier);
-    if (eventById)
-      return { props: { ogMeta: eventToOgMeta(eventById, urlPath) } };
-
-    const eventBySlug = await fetchProductByTitleSlug(identifier);
-    if (eventBySlug)
-      return { props: { ogMeta: eventToOgMeta(eventBySlug, urlPath) } };
   } catch (error) {
     console.error("SSR OG fetch error for listing:", error);
   }
 
-  return { props: { ogMeta: { ...LISTING_FALLBACK, url: urlPath } } };
+  return {
+    props: {
+      ogMeta: { ...LISTING_FALLBACK, url: urlPath },
+      initialProductEvent: null,
+    },
+  };
 };
 
-const Listing = () => {
+const Listing = ({ initialProductEvent }: ListingPageProps) => {
   const router = useRouter();
+  const initialListingState = getListingStateFromEvent(initialProductEvent);
   const [productData, setProductData] = useState<ProductData | undefined>(
-    undefined
+    initialListingState.parsedProduct
   );
-  const [isZapsnag, setIsZapsnag] = useState(false);
+  const [isZapsnag, setIsZapsnag] = useState(initialListingState.isZapsnag);
   const [productIdString, setProductIdString] = useState("");
-  const [rawEvent, setRawEvent] = useState<Event | undefined>(undefined);
+  const [rawEvent, setRawEvent] = useState<Event | undefined>(
+    initialListingState.rawEvent
+  );
   const [showRawEventModal, setShowRawEventModal] = useState(false);
   const [showEventIdModal, setShowEventIdModal] = useState(false);
   const [sfSellerPubkey, setSfSellerPubkey] = useState("");
@@ -140,13 +183,26 @@ const Listing = () => {
   useEffect(() => {
     if (router.isReady) {
       const { productId } = router.query;
-      const productIdString = productId ? productId[0] : "";
-      setProductIdString(productIdString!);
-      if (!productIdString) {
+      const nextProductIdString = Array.isArray(productId)
+        ? productId[0] || ""
+        : productId || "";
+      setProductIdString(nextProductIdString);
+      if (!nextProductIdString) {
         router.push("/marketplace");
       }
     }
-  }, [router]);
+  }, [router, router.isReady, router.query]);
+
+  useEffect(() => {
+    if (!initialProductEvent) return;
+
+    const initialState = getListingStateFromEvent(initialProductEvent);
+    if (!initialState.parsedProduct) return;
+
+    setRawEvent(initialState.rawEvent);
+    setIsZapsnag(initialState.isZapsnag);
+    setProductData(initialState.parsedProduct);
+  }, [initialProductEvent]);
 
   useEffect(() => {
     if (!productContext.isLoading && productContext.productEvents) {
@@ -191,18 +247,12 @@ const Listing = () => {
           localStorage.removeItem("sf_shop_slug");
         }
         setRawEvent(matchingEvent);
-        let parsed;
-        if (matchingEvent.kind === 1) {
-          parsed = parseZapsnagNote(matchingEvent);
-          setIsZapsnag(true);
-        } else {
-          parsed = parseTags(matchingEvent);
-          setIsZapsnag(false);
-        }
-        setProductData(parsed);
+        const nextState = getListingStateFromEvent(matchingEvent);
+        setIsZapsnag(nextState.isZapsnag);
+        setProductData(nextState.parsedProduct);
 
-        if (parsed && parsed.title && matchingEvent.kind !== 1) {
-          const canonicalSlug = getListingSlug(parsed, allParsed);
+        if (nextState.parsedProduct && matchingEvent.kind !== 1) {
+          const canonicalSlug = getListingSlug(nextState.parsedProduct, allParsed);
           if (canonicalSlug && productIdString !== canonicalSlug) {
             router.replace(`/listing/${canonicalSlug}`, undefined, {
               shallow: true,


### PR DESCRIPTION
## Summary

- seed the listing page from an SSR-fetched initial product event on direct loads
- keep the existing ProductContext-driven resolution and canonical slug behavior for hydrated navigations
- add a regression test covering the empty-context cold-load path and naddr SSR lookup

## Root Cause

The listing page body depended on client-side ProductContext hydration. That works after marketplace navigation, but a fresh direct naddr listing load starts without that client state. SSR was only producing OG metadata, not page data the component could render from immediately.

## Validation

- local branch pushed to fork successfully
- automated verification was limited in this workspace because the local project toolchain was incomplete
