### PR TITLE
Resolve image mismatch bug on marketplace listings

### DIFF
--- a/components/utility-components/checkout-card.tsx
+++ b/components/utility-components/checkout-card.tsx
@@ -166,12 +166,6 @@ export default function CheckoutCard({
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setSelectedImage(productData.images[0]);
-    setShowAllImages(false);
-    setVisibleImages(productData.images.slice(0, 3));
-  }, [productData.id]);
-
-  useEffect(() => {
     if (typeof window !== "undefined") {
       const cartList = localStorage.getItem("cart")
         ? JSON.parse(localStorage.getItem("cart") as string)

--- a/pages/listing/[[...productId]].tsx
+++ b/pages/listing/[[...productId]].tsx
@@ -274,6 +274,7 @@ const Listing = () => {
             </div>
           ) : (
             <CheckoutCard
+              key={productData.id}
               productData={productData}
               setInvoiceIsPaid={setInvoiceIsPaid}
               setInvoiceGenerationFailed={setInvoiceGenerationFailed}


### PR DESCRIPTION
There seems to be an image mismatch bug on marketplace listings. In the marketplace/search results, a listing card shows product image, but after clicking into that same listing, the listing detail page displays a different image.

### Before 
<img width="761" height="224" alt="Screenshot 2026-04-02 at 5 05 08 AM" src="https://github.com/user-attachments/assets/fc4022d8-0f27-4974-ac10-8e823b87ce74" />

Right now, the marketplace card is showing the correct image from the current listing data, but when you click into the listing, the detail page reuses CheckoutCard and keeps the old selectedImage state. Because that image state is only initialized once and is not reset when productData changes, the title and listing data update but the image can still come from the previous listing.

[components/utility-components/checkout-card.tsx#L94](https://github.com/shopstr-eng/shopstr/blob/main/components/utility-components/checkout-card.tsx#L94)

To resolve this, we can reset selectedImage whenever the listing id or image array changes, and if needed also remount CheckoutCard with key={productData.id} so each listing opens with fresh state.

### After 
<img width="755" height="235" alt="Screenshot 2026-04-02 at 5 05 32 AM" src="https://github.com/user-attachments/assets/35e6495e-dfd9-4167-9165-e40e355b0d9a" />

