### PR TITLE
Fix : Move nip-05 verification to server to bypass CORS issue

### DIFF
--- a/pages/api/nostr/verify-nip05.ts
+++ b/pages/api/nostr/verify-nip05.ts
@@ -1,0 +1,176 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+const HOSTNAME_REGEX =
+  /^(?=.{1,253}$)(?!-)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])$/i;
+
+function isPrivateIPv4(address: string): boolean {
+  const parts = address.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return true;
+
+  const a = parts[0];
+  const b = parts[1];
+  if (a === undefined || b === undefined) return true;
+
+  if (a === 10 || a === 127 || a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isPrivateIPv6(address: string): boolean {
+  const normalized = address.toLowerCase();
+  if (normalized === "::1" || normalized === "::") return true;
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  if (
+    normalized.startsWith("fe8") ||
+    normalized.startsWith("fe9") ||
+    normalized.startsWith("fea") ||
+    normalized.startsWith("feb")
+  ) {
+    return true;
+  }
+
+  // Handle IPv4-mapped IPv6 addresses, e.g. ::ffff:127.0.0.1
+  if (normalized.startsWith("::ffff:")) {
+    const ipv4 = normalized.replace("::ffff:", "");
+    return isPrivateIPv4(ipv4);
+  }
+
+  return false;
+}
+
+function isInternalAddress(address: string): boolean {
+  const ipType = isIP(address);
+  if (ipType === 4) return isPrivateIPv4(address);
+  if (ipType === 6) return isPrivateIPv6(address);
+  return true;
+}
+
+function normalizeDomain(domain: string): string | null {
+  const normalized = domain.trim().toLowerCase();
+
+  if (!normalized) return null;
+  if (normalized.includes("/") || normalized.includes("?") || normalized.includes("#")) {
+    return null;
+  }
+  if (normalized.includes(":")) return null; // disallow explicit ports
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
+    return null;
+  }
+  if (normalized.endsWith(".local")) return null;
+  if (isIP(normalized) !== 0) return null; // disallow IP literals
+  if (!HOSTNAME_REGEX.test(normalized)) return null;
+
+  return normalized;
+}
+
+async function isPublicResolvableHost(hostname: string): Promise<boolean> {
+  try {
+    const records = await lookup(hostname, { all: true, verbatim: true });
+    if (!records.length) return false;
+    return records.every((record) => !isInternalAddress(record.address));
+  } catch {
+    return false;
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  let { nip05, pubkey } = req.query;
+
+  if (Array.isArray(nip05)) nip05 = nip05[0];
+  if (Array.isArray(pubkey)) pubkey = pubkey[0];
+
+  if (typeof nip05 !== "string" || typeof pubkey !== "string") {
+    return res.status(400).json({ error: "Missing nip05 or pubkey" });
+  }
+
+  // According to NIP-05 spec, if there is no username (no '@'), we assume '_@domain'
+  if (!nip05.includes("@")) {
+    nip05 = `_@${nip05}`;
+  }
+
+  try {
+    const parts = nip05.split("@");
+    if (parts.length !== 2) {
+      return res.status(400).json({ verified: false, error: "Invalid format" });
+    }
+
+    const [username, domain] = parts;
+    if (!username || !domain) {
+      return res
+        .status(400)
+        .json({ verified: false, error: "Invalid username or domain" });
+    }
+
+    const trimmedUsername = username.trim();
+    const normalizedDomain = normalizeDomain(domain);
+    if (!trimmedUsername || !normalizedDomain) {
+      return res.status(400).json({ verified: false, error: "Invalid username or domain" });
+    }
+
+    const hostIsPublic = await isPublicResolvableHost(normalizedDomain);
+    if (!hostIsPublic) {
+      return res.status(200).json({ verified: false });
+    }
+
+    const targetUrl = new URL("/.well-known/nostr.json", `https://${normalizedDomain}`);
+    targetUrl.searchParams.set("name", trimmedUsername);
+
+    // Enforce strict NIP-05 endpoint and HTTPS only.
+    if (
+      targetUrl.protocol !== "https:" ||
+      targetUrl.pathname !== "/.well-known/nostr.json"
+    ) {
+      return res.status(400).json({ verified: false, error: "Invalid verification URL" });
+    }
+
+    // Server-side fetch (bypasses browser CORS policy)
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+    let response: Response;
+    try {
+      response = await fetch(targetUrl, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (!response.ok) {
+      return res.status(200).json({ verified: false });
+    }
+
+    const data = await response.json();
+    if (!data || typeof data !== "object") {
+      return res.status(200).json({ verified: false });
+    }
+
+    const names = data.names || {};
+    const verified =
+      names[trimmedUsername] === pubkey ||
+      names[trimmedUsername.toLowerCase()] === pubkey;
+
+    // Cache the result briefly to avoid spamming the target domain
+    res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
+    return res.status(200).json({ verified });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      console.warn(`NIP-05 verification proxy timeout for ${nip05}`);
+    } else {
+      console.error("NIP-05 verification proxy error:", error);
+    }
+    // Return 200 with verified: false so fetching logic cleanly handles it without throwing
+    return res.status(200).json({ verified: false });
+  }
+}

--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -1560,53 +1560,43 @@ export function getDefaultBlossomServer(): string {
 
 export async function verifyNip05Identifier(
   nip05: string,
-  pubkey: string
+  pubkey: string,
+  options?: { baseUrl?: string }
 ): Promise<boolean> {
   try {
     if (!nip05 || !pubkey) return false;
 
-    const parts = nip05.split("@");
-    if (parts.length !== 2) return false;
+    const params = new URLSearchParams({ nip05, pubkey });
+    const path = `/api/nostr/verify-nip05?${params.toString()}`;
 
-    const [username, domain] = parts;
-    if (!username || !domain) return false;
+    let requestUrl = path;
+    const runtimeBaseUrl =
+      options?.baseUrl ||
+      (typeof window !== "undefined" ? window.location.origin : undefined);
 
-    let url;
-    try {
-      url = `https://${domain}/.well-known/nostr.json?name=${username}`;
-    } catch {
+    // Node/SSR fetch generally needs an absolute URL.
+    if (runtimeBaseUrl) {
+      requestUrl = new URL(path, runtimeBaseUrl).toString();
+    } else if (typeof window === "undefined") {
       return false;
     }
 
+    // Use a timeout to prevent hanging requests
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    let response: Response;
     try {
-      // Use a timeout to prevent hanging requests
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
-
-      const response = await fetch(url, { signal: controller.signal });
+      response = await fetch(requestUrl, { signal: controller.signal });
+    } finally {
       clearTimeout(timeoutId);
-
-      if (!response.ok) return false;
-
-      let data;
-      try {
-        data = await response.json();
-      } catch {
-        return false;
-      }
-
-      if (!data || typeof data !== "object") return false;
-
-      const names = data.names || {};
-      return (
-        names[username] === pubkey || names[username.toLowerCase()] === pubkey
-      );
-    } catch {
-      // This will catch fetch errors, timeout errors, etc.
-      return false;
     }
+
+    if (!response.ok) return false;
+
+    const data = await response.json();
+    return !!data.verified;
   } catch {
-    // Catch any unexpected errors
+    // Catch any unexpected errors (e.g., timeout, network failure)
     return false;
   }
 }


### PR DESCRIPTION
### Description

Route the NIP-05 .well-known fetch requests through backend-server instead of making them directly from the browser frontend . Because server-to-server HTTP calls do not enforce browser CORS restrictions, this will successfully bypass the block and allow verified profiles and images to load reliably.

- It does server-side fetch to .well-known/nostr.json, which avoids browser CORS limits
- It compares returned names mapping with the pubkey and sets verified true/false
- It returns verified false for upstream/network failuresz

Status Code Description:

- 200 + verified:false  -  for a valid request where verification fails or upstream lookup fails.
- 400 - only for malformed input (bad nip05 format)

These are few error scenarios:

- ETIMEDOUT: remote domain did not respond in time.
- EAI_AGAIN / ENOTFOUND: DNS issue or non-resolving domain.
- ERR_TLS_CERT_ALTNAME_INVALID: remote certificate is misconfigured for that hostname.
- malformed identifiers (example like @domain or npub-like hostnames in nip05 field) are not valid NIP-05 identities.

The Main files changed (rest are changes to solve lint and test errors):
`utils/nostr/nostr-helper-functions.ts`
`pages/api/nostr/verify-nip05.ts`

### Resolved or fixed issue
`Fixes #262 `  

### Screenshots 
## BEFORE 
<img width="1496" height="806" alt="image" src="https://github.com/user-attachments/assets/2be31804-9a9d-42c6-9675-225452f2f587" />

## AFTER
<img width="1172" height="529" alt="image" src="https://github.com/user-attachments/assets/04053f4f-22df-4d30-af23-fa41abeddf07" />

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines