### PR TITLE
ci: add workflow concurrency controls

### DIFF
--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-prettier:
     name: Check lint and formatting

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   stale:
     name: Mark and close inactive issues and PRs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   jest:
     name: Jest suite and coverage


### PR DESCRIPTION
### Description
This PR now adds concurrency controls to the existing GitHub Actions workflows.

- `Tests` and `Lint and Prettier` cancel stale in-progress runs for the same PR or branch, keeping only the latest CI signal and saving Actions minutes.
- `Close inactive issues and PRs` uses a workflow-level concurrency group without canceling in-progress runs, so stale bot updates do not overlap or stop midway.
- Workflow permissions remain unchanged and minimal.

### Resolved or fixed issue
Related to #264. The original test workflow gap has already been addressed on upstream `main`; this PR now focuses on workflow concurrency.

### Screenshots (if applicable)
N/A as this is CI-only.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/shopstr-eng/shopstr/blob/main/contributing.md) guidelines
