### PR TITLE
fix: use NIP-99 content as listing description (summary fallback)

### DIFF
--- a/utils/parsers/__tests__/product-parser-functions.test.ts
+++ b/utils/parsers/__tests__/product-parser-functions.test.ts
@@ -54,6 +54,17 @@ describe("parseTags", () => {
     expect(result.summary).toBe("Fallback summary");
   });
 
+  it("should fallback to summary tag when content is only whitespace", () => {
+    const event = {
+      ...baseEvent,
+      content: "   ",
+      tags: [["summary", "Whitespace fallback summary"]],
+    };
+    const result = parseTags(event)!;
+
+    expect(result.summary).toBe("Whitespace fallback summary");
+  });
+
   it("should parse multiple image and category tags into arrays", () => {
     const event = {
       ...baseEvent,

--- a/utils/parsers/__tests__/product-parser-functions.test.ts
+++ b/utils/parsers/__tests__/product-parser-functions.test.ts
@@ -24,7 +24,7 @@ describe("parseTags", () => {
     mockedCalculateTotalCost.mockReturnValue(999);
   });
 
-  it("should parse top-level event data and simple tags correctly", () => {
+  it("should parse top-level event data and prefer content as description", () => {
     const event = {
       ...baseEvent,
       tags: [
@@ -39,8 +39,19 @@ describe("parseTags", () => {
     expect(result.pubkey).toBe("test-pubkey");
     expect(result.createdAt).toBe(1672531200);
     expect(result.title).toBe("My Product");
-    expect(result.summary).toBe("A great product");
+    expect(result.summary).toBe("Product description");
     expect(result.location).toBe("Online");
+  });
+
+  it("should fallback to summary tag when content is empty", () => {
+    const event = {
+      ...baseEvent,
+      content: "",
+      tags: [["summary", "Fallback summary"]],
+    };
+    const result = parseTags(event)!;
+
+    expect(result.summary).toBe("Fallback summary");
   });
 
   it("should parse multiple image and category tags into arrays", () => {

--- a/utils/parsers/product-parser-functions.ts
+++ b/utils/parsers/product-parser-functions.ts
@@ -46,7 +46,7 @@ export const parseTags = (productEvent: NostrEvent) => {
     pubkey: "",
     createdAt: 0,
     title: "",
-    summary: "",
+    summary: productEvent.content || "",
     publishedAt: "",
     images: [],
     categories: [],
@@ -68,7 +68,11 @@ export const parseTags = (productEvent: NostrEvent) => {
         parsedData.title = values[0]!;
         break;
       case "summary":
-        parsedData.summary = values[0]!;
+        // NIP-99 uses event content as primary description.
+        // Keep summary tag as backward-compatible fallback when content is empty.
+        if (!parsedData.summary.trim()) {
+          parsedData.summary = values[0]!;
+        }
         break;
       case "published_at":
         parsedData.publishedAt = values[0]!;

--- a/utils/parsers/product-parser-functions.ts
+++ b/utils/parsers/product-parser-functions.ts
@@ -69,7 +69,7 @@ export const parseTags = (productEvent: NostrEvent) => {
         break;
       case "summary":
         // NIP-99 uses event content as primary description.
-        // Keep summary tag as backward-compatible fallback when content is empty.
+        // Keep summary tag as backward-compatible fallback when content is empty or whitespace.
         if (!parsedData.summary.trim()) {
           parsedData.summary = values[0]!;
         }


### PR DESCRIPTION
## What changed
- updated product parsing to use the event  field as the primary listing description
- kept  tag as a backward-compatible fallback when  is empty
- added parser tests for both precedence and fallback behavior

## Why
Issue #201  highlighted that listings created by other clients could show incorrect descriptions because we were relying on the summary tag instead of the event content field. This change aligns parsing with expected NIP-99 behavior and improves cross-client compatibility.

## Impact
- Listings now display the correct description source across clients.
- Legacy events that only provide summary continue to work.
- Behavior is now explicitly validated by parser tests.
