### PR TITLE
 fix: resolve product card and title overlap on wide screens 

### DIFF
--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -367,7 +367,7 @@ const DisplayProducts = ({
         ) : null}
         {filteredProducts.length > 0 ? (
           <>
-            <div className="grid max-w-full grid-cols-[repeat(auto-fill,minmax(300px,1fr))] justify-items-center gap-4 overflow-x-hidden">
+            <div className="grid max-w-full grid-cols-[repeat(auto-fill,minmax(280px,1fr))] justify-items-stretch gap-4 overflow-x-hidden">
               {getCurrentPageProducts().map(
                 (productData: ProductData, index) => (
                   <ProductCard

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -87,8 +87,8 @@ export default function ProductCard({
       <div className="flex flex-col p-4">
         {router.pathname !== "/" && (
           <div className="mb-2 flex items-center justify-between">
-            <div className="flex max-w-[80%] items-center gap-2">
-              <h2 className="truncate text-xl font-semibold text-light-text dark:text-dark-text">
+            <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+              <h2 className="min-w-0 truncate text-xl font-semibold text-light-text dark:text-dark-text">
                 {productData.title}
               </h2>
               {isZapsnag && productData.pubkey === userPubkey && (
@@ -191,9 +191,9 @@ export default function ProductCard({
 
   return (
     <div
-      className={`${cardHoverStyle} mx-2 my-4 rounded-2xl bg-white shadow-md duration-300 transition-all dark:bg-neutral-900`}
+      className={`${cardHoverStyle} my-4 w-full rounded-2xl bg-white shadow-md duration-300 transition-all dark:bg-neutral-900`}
     >
-      <div className="w-80 overflow-hidden rounded-2xl">
+      <div className="w-full overflow-hidden rounded-2xl">
         {href ? (
           <Link href={href} className="block">
             {content}


### PR DESCRIPTION
 - Fixed product card title overflow causing component overlap — the card title (h2) was a     flex child without min-w-0, so Tailwind's truncate class never actually truncated. The        element expanded to its full text content width, overflowing into adjacent elements (status   badges, dropdown button, and neighbouring cards). Fixed by adding min-w-0 to both the h2 and
   its flex container, and replacing max-w-[80%] with flex-1 overflow-hidden so the container
  properly constrains its children.
  - Fixed product cards overflowing their grid columns on wide screens — cards had a fixed    
  w-80 (320px) width inside grid columns that could be as narrow as 300px (minmax(300px,1fr)),
   and the grid used justify-items-center which centered cards at their natural width instead 
  of stretching them to fit the column. On wider screens with many columns, cards physically  
  overflowed their cells and overlapped neighbours. Fixed by:
    - Switching to justify-items-stretch so each card fills its column
    - Replacing the fixed w-80 with w-full on both the outer and inner card divs
    - Removing mx-2 horizontal margins (spacing is now handled by the grid gap-4)
    - Reducing min column width to 280px to allow slightly more flexible column fitting       

---

  Resolved or fixed issue

  none

---

  Screenshots

  Before: Cards with long titles overflowed and overlapped adjacent cards and UI components on
   large screens.

<img width="2560" height="1440" alt="card-overlap" src="https://github.com/user-attachments/assets/774fee1b-4189-4b8a-9b43-fb85f6021add" />

---

  After: Titles truncate correctly with ellipsis; cards fill their grid columns without       
  overflow.

<img width="2661" height="1440" alt="card-overlap-fix" src="https://github.com/user-attachments/assets/ad4968ed-3b2c-4bbc-8601-94d0d6db74c8" />


  Affirmation

  - My code follows the https://github.com/hxrshxz/shopstr/blob/main/contributing.md
  guidelines