### PR TITLE
Escape special characters in marketplace search queries

### DIFF
--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import DisplayProducts from "../display-products";
+import {
+  FollowsContext,
+  ProductContext,
+  ProfileMapContext,
+} from "@/utils/context/context";
+import {
+  NostrContext,
+  SignerContext,
+} from "@/components/utility-components/nostr-context-provider";
+
+jest.mock("next/router", () => ({
+  __esModule: true,
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    query: {},
+    pathname: "/marketplace",
+    asPath: "/marketplace",
+  })),
+}));
+
+jest.mock("../utility-components/product-card", () =>
+  function MockProductCard({ productData }: { productData: { title: string } }) {
+    return <div>{productData.title}</div>;
+  }
+);
+
+jest.mock("../display-product-modal", () => () => null);
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  deleteEvent: jest.fn(),
+}));
+jest.mock("@/utils/url-slugs", () => ({
+  getListingSlug: jest.fn(),
+}));
+
+describe("DisplayProducts search filtering", () => {
+  it("matches literal special characters in search queries", async () => {
+    render(
+      <SignerContext.Provider value={{ pubkey: "viewer-pubkey", isLoggedIn: true }}>
+        <NostrContext.Provider value={{ nostr: {} as any }}>
+          <ProfileMapContext.Provider
+            value={{
+              profileData: new Map(),
+              isLoading: false,
+              updateProfileData: jest.fn(),
+            }}
+          >
+            <FollowsContext.Provider
+              value={{
+                followList: [],
+                firstDegreeFollowsLength: 0,
+                isLoading: false,
+              }}
+            >
+              <ProductContext.Provider
+                value={{
+                  productEvents: [
+                    {
+                      id: "product-1",
+                      pubkey: "seller-pubkey",
+                      created_at: 1,
+                      kind: 30018,
+                      tags: [
+                        ["title", "C++ Guide"],
+                        ["summary", "A beginner-friendly manual"],
+                        ["price", "10", "USD"],
+                        ["image", "https://example.com/guide.png"],
+                      ],
+                      content: "content",
+                      sig: "sig",
+                    },
+                  ],
+                  isLoading: false,
+                  addNewlyCreatedProductEvent: jest.fn(),
+                  removeDeletedProductEvent: jest.fn(),
+                }}
+              >
+                <DisplayProducts
+                  selectedCategories={new Set()}
+                  selectedLocation=""
+                  selectedSearch="c++"
+                />
+              </ProductContext.Provider>
+            </FollowsContext.Provider>
+          </ProfileMapContext.Provider>
+        </NostrContext.Provider>
+      </SignerContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("C++ Guide")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -23,6 +23,9 @@ import {
 } from "@/components/utility-components/nostr-context-provider";
 import { getListingSlug } from "@/utils/url-slugs";
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 const DisplayProducts = ({
   focusedPubkey,
   selectedCategories,
@@ -276,12 +279,14 @@ const DisplayProducts = ({
   };
 
   const productSatisfiesSearchFilter = (productData: ProductData) => {
-    if (!selectedSearch) return true;
+    const normalizedSearch = selectedSearch.trim();
+
+    if (!normalizedSearch) return true;
     if (!productData.title) return false;
 
-    if (selectedSearch.includes("naddr")) {
+    if (normalizedSearch.includes("naddr")) {
       try {
-        const parsedNaddr = nip19.decode(selectedSearch);
+        const parsedNaddr = nip19.decode(normalizedSearch);
         if (parsedNaddr.type === "naddr") {
           return (
             productData.d === parsedNaddr.data.identifier &&
@@ -294,9 +299,9 @@ const DisplayProducts = ({
       }
     }
 
-    if (selectedSearch.includes("npub")) {
+    if (normalizedSearch.includes("npub")) {
       try {
-        const parsedNpub = nip19.decode(selectedSearch);
+        const parsedNpub = nip19.decode(normalizedSearch);
         if (parsedNpub.type === "npub") {
           return parsedNpub.data === productData.pubkey;
         }
@@ -307,7 +312,7 @@ const DisplayProducts = ({
     }
 
     try {
-      const re = new RegExp(selectedSearch, "gi");
+      const re = new RegExp(escapeRegExp(normalizedSearch), "i");
 
       const titleMatch = productData.title.match(re);
       if (titleMatch && titleMatch.length > 0) return true;
@@ -317,7 +322,7 @@ const DisplayProducts = ({
         if (summaryMatch && summaryMatch.length > 0) return true;
       }
 
-      const numericSearch = parseFloat(selectedSearch);
+      const numericSearch = parseFloat(normalizedSearch);
       if (!isNaN(numericSearch) && productData.price === numericSearch) {
         return true;
       }


### PR DESCRIPTION
## Summary

Search currently treats user input as a regular expression, which causes unexpected behavior for queries containing special characters such as "c++", "foo.bar", or "[test]".

## Changes

- Trimmed the search query to remove extra whitespace
- Escaped regex metacharacters before constructing the search matcher
- Ensured user input is treated as a literal string instead of a regex pattern
- Added a regression test to verify that queries like "c++" return correct results

## Why this matters

This improves search reliability and user experience by ensuring common queries with special characters behave as expected.

## Scope

- Minimal and focused change
- Does not affect existing search logic beyond fixing incorrect matches
- No new dependencies introduced

## Testing

- Added test case for special character queries (e.g. "c++")
- Verified locally using:
  npm test -- --runInBand components/__tests__/display-products.test.tsx