### PR TITLE
fix:Remove redundant autoFocus attributes from product form inputs

### DIFF
--- a/components/product-form.tsx
+++ b/components/product-form.tsx
@@ -382,8 +382,8 @@ export default function ProductForm({
                 return (
                   <Input
                     className="text-light-text dark:text-dark-text"
-                    autoFocus
                     variant="bordered"
+                    autoFocus
                     fullWidth={true}
                     label="Product name"
                     labelPlacement="inside"
@@ -591,7 +591,6 @@ export default function ProductForm({
                   <Input
                     className="text-light-text dark:text-dark-text"
                     type="number"
-                    autoFocus
                     variant="flat"
                     label="Price"
                     labelPlacement="inside"
@@ -672,7 +671,6 @@ export default function ProductForm({
                   : "";
                 return (
                   <LocationDropdown
-                    autoFocus
                     variant="bordered"
                     aria-label="Select Location"
                     label="Location"
@@ -705,7 +703,6 @@ export default function ProductForm({
                 return (
                   <Select
                     className="text-light-text dark:text-dark-text"
-                    autoFocus
                     variant="bordered"
                     aria-label="Shipping Option"
                     label="Shipping option"
@@ -886,7 +883,6 @@ export default function ProductForm({
                   <Select
                     variant="bordered"
                     isMultiline={true}
-                    autoFocus
                     aria-label="Category"
                     label="Categories"
                     labelPlacement="inside"


### PR DESCRIPTION
---
  Description                                                                                    
  - Removed autoFocus from all always-visible fields in the new product listing form          
  (components/product-form.tsx)
  - Affected fields: Product Name, Price, Location, Shipping Option, and Categories
  - Previously, multiple autoFocus attributes were present on fields throughout the form. When
   the modal opened, the browser would scroll the viewport to bring the focused element into  
  view, causing the form to open mid-scroll (visually landing on the Price or Categories      
  field) instead of at the top
  - The form now opens cleanly at the top, with the Product Name field visible first as       
  expected
  - autoFocus on conditionally rendered fields (Shipping Cost when "Added Cost" is selected,  
  and fields inside "Additional options") has been intentionally kept since those only appear 
  on explicit user interaction

  Resolved or fixed issue

  none

  Screenshots

  ▎ Before: Opening the "List Product" modal caused the view to auto-scroll mid-form, landing 
  on the Price or Categories field.
  
<img width="2560" height="1440" alt="Screenshot 2026-04-03 195009" src="https://github.com/user-attachments/assets/de21957a-89d2-496f-8490-2a6c789b6cef" />

  ▎ After: The modal opens at the top of the form with Product Name visible first.
  
  
<img width="2560" height="1440" alt="Screenshot 2026-04-03 201101" src="https://github.com/user-attachments/assets/987d5405-e117-44ed-94d0-c64195313863" />


  Affirmation

  - My code follows the https://github.com/hxrshxz/shopstr/blob/main/contributing.md
  guidelines