### PR TITLE
 fix: replace biased shuffle with Fisher-Yates algorithm 

### DIFF
--- a/components/storefront/storefront-order-confirmation.tsx
+++ b/components/storefront/storefront-order-confirmation.tsx
@@ -97,7 +97,11 @@ export default function StorefrontOrderConfirmation({
         }
       } catch {}
     }
-    return products.sort(() => Math.random() - 0.5).slice(0, 4);
+    for (let i = products.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [products[i], products[j]] = [products[j], products[i]];
+    }
+    return products.slice(0, 4);
   }, [productContext.productEvents, shopPubkey]);
 
   const formatPaymentMethod = (method: string) => {

--- a/pages/order-summary/index.tsx
+++ b/pages/order-summary/index.tsx
@@ -102,7 +102,11 @@ export default function OrderSummary() {
           }
         } catch {}
       }
-      const shuffled = products.sort(() => Math.random() - 0.5).slice(0, 4);
+      for (let i = products.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [products[i], products[j]] = [products[j], products[i]];
+      }
+      const shuffled = products.slice(0, 4);
       setLatestProducts(shuffled);
     }
   }, [productContext.isLoading, productContext.productEvents, orderData]);


### PR DESCRIPTION
---                                                                                                                                         
  Description

  - Replaced array.sort(() => Math.random() - 0.5) with a proper Fisher-Yates shuffle in two post-checkout "you might also like" product      
  sections
  - The sort-based approach is statistically biased — JS's sort algorithm calls the comparator a non-uniform number of times, making some     
  product orderings appear significantly more often than others
  - Fisher-Yates guarantees a truly uniform shuffle: every permutation has equal probability in O(n) time
  - Affected files:
    - pages/order-summary/index.tsx
    - components/storefront/storefront-order-confirmation.tsx

  Resolved or fixed issue

  none

  Screenshots

  N/A — logic-only change, no UI differences visible to the user

  Affirmation

  - My code follows the https://github.com/hxrshxz/shopstr/blob/main/contributing.md guidelines

  ---