### PR TITLE
 fix:guard JSON.parse calls against corrupted localStorage in cart

### DIFF
--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -195,9 +195,13 @@ export default function Component() {
         sessionStorage.getItem("sf_seller_pubkey") ||
         localStorage.getItem("sf_seller_pubkey") ||
         "";
-      const fullCart: ProductData[] = localStorage.getItem("cart")
-        ? JSON.parse(localStorage.getItem("cart") as string)
-        : [];
+      let fullCart: ProductData[] = [];
+      try {
+        const raw = localStorage.getItem("cart");
+        if (raw) fullCart = JSON.parse(raw);
+      } catch {
+        localStorage.removeItem("cart");
+      }
 
       let cartList = fullCart;
       if (sfPk) {
@@ -221,7 +225,13 @@ export default function Component() {
       // Load saved discount codes
       const storedDiscounts = localStorage.getItem("cartDiscounts");
       if (storedDiscounts) {
-        const discounts = JSON.parse(storedDiscounts);
+        let discounts;
+        try {
+          discounts = JSON.parse(storedDiscounts);
+        } catch {
+          localStorage.removeItem("cartDiscounts");
+          return;
+        }
         const codes: { [pubkey: string]: string } = {};
         const applied: { [pubkey: string]: number } = {};
 
@@ -325,9 +335,13 @@ export default function Component() {
   };
 
   const handleRemoveFromCart = (productId: string) => {
-    const cartContent = localStorage.getItem("cart")
-      ? JSON.parse(localStorage.getItem("cart") as string)
-      : [];
+    let cartContent: ProductData[] = [];
+    try {
+      const raw = localStorage.getItem("cart");
+      if (raw) cartContent = JSON.parse(raw);
+    } catch {
+      localStorage.removeItem("cart");
+    }
     if (cartContent.length > 0) {
       const updatedCart = cartContent.filter(
         (obj: ProductData) => obj.id !== productId
@@ -373,7 +387,12 @@ export default function Component() {
 
         // Save to localStorage
         const storedDiscounts = localStorage.getItem("cartDiscounts");
-        const discounts = storedDiscounts ? JSON.parse(storedDiscounts) : {};
+        let discounts: { [pubkey: string]: { code: string; percentage: number } } = {};
+        try {
+          if (storedDiscounts) discounts = JSON.parse(storedDiscounts);
+        } catch {
+          localStorage.removeItem("cartDiscounts");
+        }
         discounts[pubkey] = {
           code: code,
           percentage: result.discount_percentage,
@@ -404,7 +423,13 @@ export default function Component() {
     // Remove from localStorage
     const storedDiscounts = localStorage.getItem("cartDiscounts");
     if (storedDiscounts) {
-      const discounts = JSON.parse(storedDiscounts);
+      let discounts;
+      try {
+        discounts = JSON.parse(storedDiscounts);
+      } catch {
+        localStorage.removeItem("cartDiscounts");
+        return;
+      }
       delete discounts[pubkey];
       localStorage.setItem("cartDiscounts", JSON.stringify(discounts));
     }


### PR DESCRIPTION
---
Description
                                                                                                                        
  - Four JSON.parse calls in pages/cart/index.tsx read directly from localStorage/sessionStorage with no error handling
  - If stored data is ever corrupted (browser extension interference, storage quota errors, manual tampering), any of
  these calls would throw an unhandled exception and crash the entire cart page
  - Wrapped all parse calls in try/catch blocks with safe fallbacks:
    - "cart" key falls back to [] and clears the corrupted entry so the user isn't stuck
    - "cartDiscounts" key falls back to {} and clears the corrupted entry
  - Affected locations: initial cart load, discount code load, handleRemoveFromCart, handleApplyDiscount,
  handleRemoveDiscount
  - No UI changes — silent recovery, user sees an empty cart instead of a broken page

  Resolved or fixed issue

  none

  Screenshots (if applicable)

  N/A — no UI changes

  Affirmation

  - My code follows the https://github.com/hxrshxz/shopstr/blob/main/contributing.md guidelines

  ---