### PR TITLE
fix: reject whitespace-only passphrases in SignInModal

### DIFF
--- a/components/sign-in/SignInModal.tsx
+++ b/components/sign-in/SignInModal.tsx
@@ -176,7 +176,7 @@ export default function SignInModal({
 
   const handleNsecSignup = async () => {
     if (validPrivateKey === "success" || isNcryptsec) {
-      if (passphrase === "" || passphrase === null) {
+      if (!passphrase || passphrase.trim() === "") {
         setFailureText("No passphrase provided!");
         setShowFailureModal(true);
       } else {
@@ -250,7 +250,7 @@ export default function SignInModal({
 
   const handleSignIn = async () => {
     if (validPrivateKey === "success" || isNcryptsec) {
-      if (passphrase === "" || passphrase === null) {
+      if (!passphrase || passphrase.trim() === "") {
         setFailureText("No passphrase provided!");
         setShowFailureModal(true);
       } else {


### PR DESCRIPTION
---
Description
                                                                                                                        
  - handleNsecSignup and handleSignIn in components/sign-in/SignInModal.tsx validated passphrases with
    passphrase ===  "", which only catches a fully empty string
  - A passphrase of "   " (spaces only) would pass this check, proceed to encryption/decryption, and then silently fail 
  — giving the user no useful feedback
  - Replaced both checks with !passphrase || passphrase.trim() === "" so whitespace-only input is correctly caught and  
  the "No passphrase provided!" error is shown immediately
  - Affects both sign-in and sign-up flows that use an nsec private key or ncryptsec

  Resolved or fixed issue

  none

  Screenshots (if applicable)

  N/A — no visual changes, error message behaviour is unchanged

  Affirmation

  - My code follows the https://github.com/hxrshxz/shopstr/blob/main/contributing.md guidelines

  ---