### PR TITLE
Fixing the intermixing of user and shop profiles and ensuring persistance of user-profile data

### DIFF
--- a/components/utility-components/profile/profile-dropdown.tsx
+++ b/components/utility-components/profile/profile-dropdown.tsx
@@ -59,6 +59,23 @@ export const ProfileWithDropdown = ({
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   useEffect(() => {
+    if (!pubkey) return;
+    fetch(`/api/db/fetch-profile?pubkey=${encodeURIComponent(pubkey)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const content = data?.profile?.content;
+        if (!content) return;
+        setDisplayName(() => {
+          let name = content.name || npub;
+          name = name.length > 15 ? name.slice(0, 15) + "..." : name;
+          return name;
+        });
+        if (content.picture) setPfp(content.picture);
+      })
+      .catch(() => {});
+  }, [pubkey, npub]);
+
+  useEffect(() => {
     const profileMap = profileContext.profileData;
     const profile = profileMap.has(pubkey) ? profileMap.get(pubkey) : undefined;
     setDisplayName(() => {

--- a/pages/api/db/fetch-profile.ts
+++ b/pages/api/db/fetch-profile.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fetchCachedEvents } from "@/utils/db/db-service";
+
+/**
+ * GET /api/db/fetch-profile?pubkey=<hex>
+ * Returns the most recent kind:0 profile cached in the DB for the given pubkey.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") return res.status(405).end();
+  const { pubkey } = req.query;
+  if (!pubkey || typeof pubkey !== "string")
+    return res.status(400).json({ error: "pubkey required" });
+  try {
+    const events = await fetchCachedEvents(0, { pubkey, limit: 1 });
+    const event = events[0];
+    if (!event) return res.status(200).json({ profile: null });
+    let content: Record<string, any> = {};
+    try { content = JSON.parse(event.content); } catch { return res.status(200).json({ profile: null }); }
+    return res.status(200).json({ profile: { pubkey: event.pubkey, content, created_at: event.created_at } });
+  } catch (error) {
+    console.error("Failed to fetch profile:", error);
+    return res.status(500).json({ error: "Failed to fetch profile" });
+  }
+}

--- a/pages/settings/user-profile.tsx
+++ b/pages/settings/user-profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext, useMemo } from "react";
+import { useEffect, useRef, useState, useContext, useMemo } from "react";
 import { SettingsBreadCrumbs } from "@/components/settings/settings-bread-crumbs";
 import { ProfileMapContext } from "@/utils/context/context";
 import { useForm, Controller } from "react-hook-form";
@@ -62,30 +62,32 @@ const UserProfilePage = () => {
     return "https://robohash.org/" + userPubkey;
   }, [userPubkey]);
 
+  const contextLoadedRef = useRef(false);
   useEffect(() => {
     if (!userPubkey) return;
+    if (contextLoadedRef.current) return;
     setIsFetchingProfile(true);
-    const profileMap = profileContext.profileData;
-    const profile = profileMap.has(userPubkey)
-      ? profileMap.get(userPubkey)
-      : undefined;
-    if (profile) {
-      reset(profile.content);
-    }
-    setIsFetchingProfile(false);
+    fetch(`/api/db/fetch-profile?pubkey=${encodeURIComponent(userPubkey)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (contextLoadedRef.current) return;
+        if (data?.profile?.content) reset(data.profile.content);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!contextLoadedRef.current) setIsFetchingProfile(false);
+      });
+  }, [userPubkey, reset]);
 
-    if (signer instanceof NostrNSecSigner) {
-      const nsecSigner = signer as NostrNSecSigner;
-      nsecSigner._getNSec().then(
-        (nsec) => {
-          setUserNSec(nsec);
-        },
-        (err: unknown) => {
-          console.error(err);
-        }
-      );
-    }
-  }, [profileContext, userPubkey, signer, reset]);
+  useEffect(() => {
+    if (!userPubkey) return;
+    const profile = profileContext.profileData.get(userPubkey);
+    if (!profile) return;
+    contextLoadedRef.current = true;
+    setIsFetchingProfile(true);
+    reset(profile.content);
+    setIsFetchingProfile(false);
+  }, [profileContext, userPubkey, reset]);
 
   const onSubmit = async (data: { [x: string]: string }) => {
     if (!userPubkey) throw new Error("pubkey is undefined");
@@ -223,7 +225,16 @@ const UserProfilePage = () => {
                   ) : (
                     <EyeIcon
                       className="h-6 w-6 flex-shrink-0 px-1 text-light-text hover:text-purple-700 dark:text-dark-text dark:hover:text-yellow-700"
-                      onClick={() => {
+                      onClick={async () => {
+                        // Only decrypt nsec when user explicitly asks to see it.
+                        if (!userNSec && signer instanceof NostrNSecSigner) {
+                          try {
+                            const nsec = await (signer as NostrNSecSigner)._getNSec();
+                            setUserNSec(nsec);
+                          } catch (err) {
+                            console.error(err);
+                          }
+                        }
                         setViewState("shown");
                       }}
                     />

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -446,6 +446,7 @@ export const fetchProfile = async (
       const fetchedEvents = await nostr.fetch([subParams], {}, relays);
 
       for (const event of fetchedEvents) {
+        if (event.kind !== 0) continue;
         const existing = profileMap.get(event.pubkey);
         if (
           existing === null ||


### PR DESCRIPTION
Fixing the intermixing of user and shop profiles and ensuring persistance of user-profile data

### Description
When users saved their profile, the display name and about section would mysteriously change to their **shop profile data**. Additionally, repeated passphrase prompts (2-3 times) occurred on save, and profile data would vanish on page refresh.
Fixed this implementing kind filtering and ensuring saving to db for faster access and ultimately showing relay data.

### Resolved or fixed issue
#284 

### Affirmation

- [ ] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
