### PR TITLE
fix: avoid mutating shared arrays during product sorting

### DIFF
--- a/components/ZapsnagButton.tsx
+++ b/components/ZapsnagButton.tsx
@@ -103,7 +103,7 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
       let lud16 = "";
 
       if (events.length > 0) {
-        const kind0 = events.sort((a, b) => b.created_at - a.created_at)[0];
+        const kind0 = [...events].sort((a, b) => b.created_at - a.created_at)[0];
         if (kind0) {
           try {
             const content = JSON.parse(kind0.content || "{}");

--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -87,11 +87,9 @@ const DisplayProducts = ({
     if (!productEventContext) return;
     if (!productEventContext.isLoading && productEventContext.productEvents) {
       setIsProductLoading(true);
-      const sortedProductEvents = [
-        ...productEventContext.productEvents.sort(
-          (a: NostrEvent, b: NostrEvent) => b.created_at - a.created_at
-        ),
-      ];
+      const sortedProductEvents = [...productEventContext.productEvents].sort(
+        (a: NostrEvent, b: NostrEvent) => b.created_at - a.created_at
+      );
       const parsedProductData: ProductData[] = [];
       sortedProductEvents.forEach((event) => {
         if (wotFilter) {


### PR DESCRIPTION
Summary
Avoid mutating shared arrays during product sorting.

Fix
Replaced in-place sorting with a non-mutating approach using a shallow copy.

Impact
Prevents unintended side effects
Improves data consistency across components

Scope
Single-file change
No unrelated modifications