### PR TITLE
fix(fetchAllPosts): remove duplicate cacheEventsToDatabase call for p…

### DIFF
--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -127,16 +127,6 @@ export const fetchAllPosts = async (
 
       editProductContext(mergedProductArray, false);
 
-      // Cache fetched products to database via API (only valid events with signatures)
-      const validProducts = fetchedEvents.filter(
-        (e) => e.id && e.sig && e.pubkey
-      );
-      if (validProducts.length > 0) {
-        cacheEventsToDatabase(validProducts).catch((error) =>
-          console.error("Failed to cache products to database:", error)
-        );
-      }
-
       resolve({
         productEvents: mergedProductArray,
         profileSetFromProducts,


### PR DESCRIPTION
### Description
This PR removes a redundant call to `cacheEventsToDatabase` in `fetchAllPosts` within `fetch-service.ts`. Previously, product events fetched from relays were being cached to the database twice per fetch, causing duplicate writes and unnecessary I/O. Now, each event is cached exactly once.

Fixes #338 

### Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors