### PR TITLE
doc: update Docker commands and application URL in contributing guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -91,9 +91,11 @@ This application requires a PostgreSQL database. You can run it locally using Do
    docker compose up -d
    ```
 
-2. Create a `.env` file in the root directory. You can copy from the template:
+2. Create a `.env` file in the root directory. If the repository includes an environment template, copy whichever template file exists:
 
    ```bash
+   cp .env.example .env
+   # or, in some setups:
    cp env.example .env
    ```
 

--- a/contributing.md
+++ b/contributing.md
@@ -88,10 +88,16 @@ This application requires a PostgreSQL database. You can run it locally using Do
 1. Start PostgreSQL:
 
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
-2. Create a `.env` file in the root directory with the following:
+2. Create a `.env` file in the root directory. You can copy from the template:
+
+   ```bash
+   cp env.example .env
+   ```
+
+   Or create it manually with:
 
    ```
    DATABASE_URL=postgresql://shopstr:shopstr@localhost:5432/shopstr
@@ -102,19 +108,19 @@ This application requires a PostgreSQL database. You can run it locally using Do
 4. To stop the database:
 
    ```bash
-   docker-compose down
+   docker compose down
    ```
 
 5. To remove all data and start fresh:
    ```bash
-   docker-compose down -v
+   docker compose down -v
    ```
 
-The application will be available at `http://localhost:3000`
+The application will be available at `http://localhost:5000`
 
 ### 4. Verify Installation
 
-- Open your browser to `http://localhost:3000`
+- Open your browser to `http://localhost:5000`
 - Check that the application loads without errors
 - Check the browser console for any warnings or errors
 


### PR DESCRIPTION
### Description
- Updated Docker Compose commands in `contributing.md` from deprecated `docker-compose` to modern `docker compose` syntax:
  - `docker compose up -d`
  - `docker compose down`
  - `docker compose down -v`
- Updated local development URL references from `http://localhost:3000` to `http://localhost:5000` to match the project dev script (`next dev -p 5000`).
- Improved environment setup instructions by adding a template-based flow:
  - Added `cp env.example .env` as the primary setup path.
  - Kept manual `.env` creation instructions as a fallback.

Impact:
- Prevents `zsh: command not found: docker-compose` errors for contributors using newer Docker installations.
- Aligns docs with the actual runtime port, reducing onboarding confusion.
- Makes initial setup faster and less error-prone by encouraging use of `env.example`.

### Resolved or fixed issue
none

### Screenshots (if applicable)
N/A (documentation-only change; no UI updates)

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

