### PR TITLE
Fix : Resolved the test issues in the current main branch

### DIFF
--- a/components/utility-components/__tests__/shopstr-switch.test.tsx
+++ b/components/utility-components/__tests__/shopstr-switch.test.tsx
@@ -15,8 +15,16 @@ jest.mock("next/router", () => ({
 }));
 
 jest.mock("@nextui-org/react", () => ({
-  Switch: (props: { onClick: () => void; color: string }) => (
-    <button role="switch" onClick={props.onClick} data-color={props.color} />
+  Switch: (props: {
+    onValueChange: (value: boolean) => void;
+    isSelected: boolean;
+    color: string;
+  }) => (
+    <button
+      role="switch"
+      onClick={() => props.onValueChange(!props.isSelected)}
+      data-color={props.color}
+    />
   ),
 }));
 

--- a/components/utility-components/__tests__/shopstr-switch.test.tsx
+++ b/components/utility-components/__tests__/shopstr-switch.test.tsx
@@ -15,17 +15,32 @@ jest.mock("next/router", () => ({
 }));
 
 jest.mock("@nextui-org/react", () => ({
+  __esModule: true,
   Switch: (props: {
     onValueChange: (value: boolean) => void;
     isSelected: boolean;
     color: string;
-  }) => (
-    <button
-      role="switch"
-      onClick={() => props.onValueChange(!props.isSelected)}
-      data-color={props.color}
-    />
-  ),
+  }) => {
+    const React = jest.requireActual("react");
+    const [selected, setSelected] = React.useState(props.isSelected);
+
+    React.useEffect(() => {
+      setSelected(props.isSelected);
+    }, [props.isSelected]);
+
+    return (
+      <button
+        role="switch"
+        aria-checked={selected}
+        onClick={() => {
+          const nextValue = !selected;
+          setSelected(nextValue);
+          props.onValueChange(nextValue);
+        }}
+        data-color={props.color}
+      />
+    );
+  },
 }));
 
 describe("ShopstrSwitch", () => {
@@ -69,5 +84,17 @@ describe("ShopstrSwitch", () => {
     const switchControl = screen.getByRole("switch");
 
     expect(switchControl).toHaveAttribute("data-color", "warning");
+  });
+
+  it("should toggle values across multiple clicks", () => {
+    render(<ShopstrSwitch wotFilter={false} setWotFilter={mockSetWotFilter} />);
+    const switchControl = screen.getByRole("switch");
+
+    fireEvent.click(switchControl);
+    fireEvent.click(switchControl);
+
+    expect(mockSetWotFilter).toHaveBeenNthCalledWith(1, true);
+    expect(mockSetWotFilter).toHaveBeenNthCalledWith(2, false);
+    expect(switchControl).toHaveAttribute("aria-checked", "false");
   });
 });

--- a/components/utility-components/profile/__tests__/profile-dropdown.test.tsx
+++ b/components/utility-components/profile/__tests__/profile-dropdown.test.tsx
@@ -161,6 +161,9 @@ describe("ProfileWithDropdown", () => {
     mockOnOpen.mockClear();
     (LogOut as jest.Mock).mockClear();
     (navigator.clipboard.writeText as jest.Mock).mockClear();
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: async () => ({}),
+    });
   });
 
   it("renders with fallback data and correct dropdown items", () => {

--- a/components/utility-components/profile/__tests__/profile-dropdown.test.tsx
+++ b/components/utility-components/profile/__tests__/profile-dropdown.test.tsx
@@ -147,6 +147,17 @@ describe("ProfileWithDropdown", () => {
     "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
   const npub = nip19.npubEncode(pubkey);
   let consoleWarnSpy: jest.SpyInstance;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    if (typeof (globalThis as any).fetch !== "function") {
+      Object.defineProperty(globalThis, "fetch", {
+        value: jest.fn(),
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
 
   beforeAll(() => {
     consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -156,12 +167,16 @@ describe("ProfileWithDropdown", () => {
     consoleWarnSpy.mockRestore();
   });
 
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
   beforeEach(() => {
     mockRouterPush.mockClear();
     mockOnOpen.mockClear();
     (LogOut as jest.Mock).mockClear();
     (navigator.clipboard.writeText as jest.Mock).mockClear();
-    (global as any).fetch = jest.fn().mockResolvedValue({
+    fetchSpy = jest.spyOn(globalThis as any, "fetch").mockResolvedValue({
       json: async () => ({}),
     });
   });


### PR DESCRIPTION
### Description
Fixed tests by updating mocks to match current component behavior:

Fixed :
`shopstr-switch.test.tsx` mock was using `onClick`, but the component now uses `onValueChange`. Updated the mock to call `onValueChange(!isSelected)` so `setWotFilter` is triggered correctly.

`profile-dropdown.test.tsx` the component now runs `fetch` inside `useEffect` ,tests did not include a `fetch` mock. Added a simple global `fetch` mock returning empty JSON.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines