### PR TITLE
Fix: Parallelize _app.tsx fetch initialization with isolated task failures

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from "next/app";
 import "../styles/globals.css";
-import { useState, useEffect, useCallback, useContext } from "react";
+import { useState, useEffect, useCallback, useContext, useRef } from "react";
 import { useRouter } from "next/router";
 import {
   ProfileMapContext,
@@ -469,10 +469,71 @@ function Shopstr({ props }: { props: AppProps }) {
   const [selectedSection, setSelectedSection] = useState("");
 
   const router = useRouter();
+  const initializationRunRef = useRef(0);
 
   /** FETCH initial FOLLOWS, RELAYS, PRODUCTS, and PROFILES **/
   useEffect(() => {
     async function fetchData() {
+      const runId = ++initializationRunRef.current;
+      const isCurrentRun = () => runId === initializationRunRef.current;
+      type EditorFn = (...args: any[]) => void;
+
+      const guard = <TFn extends EditorFn>(fn: TFn) => {
+        return ((...args: Parameters<TFn>) => {
+          if (!isCurrentRun()) return;
+          fn(...args);
+        }) as TFn;
+      };
+      const createGuardedEditors = <T extends Record<string, EditorFn>,>(editors: T): T => {
+        const guardedEditors = {} as T;
+
+        (Object.keys(editors) as Array<keyof T>).forEach((key) => {
+          guardedEditors[key] = guard(editors[key]);
+        });
+
+        return guardedEditors;
+      };
+
+      const {
+        guardedEditProductContext,
+        guardedEditReviewsContext,
+        guardedEditShopContext,
+        guardedEditProfileContext,
+        guardedEditChatContext,
+        guardedEditFollowsContext,
+        guardedEditRelaysContext,
+        guardedEditBlossomContext,
+        guardedEditCashuWalletContext,
+        guardedEditCommunityContext,
+      } = createGuardedEditors({
+        guardedEditProductContext: editProductContext,
+        guardedEditReviewsContext: editReviewsContext,
+        guardedEditShopContext: editShopContext,
+        guardedEditProfileContext: editProfileContext,
+        guardedEditChatContext: editChatContext,
+        guardedEditFollowsContext: editFollowsContext,
+        guardedEditRelaysContext: editRelaysContext,
+        guardedEditBlossomContext: editBlossomContext,
+        guardedEditCashuWalletContext: editCashuWalletContext,
+        guardedEditCommunityContext: editCommunityContext,
+      });
+
+      const runTask = async <T,>(
+        taskName: string,
+        task: () => Promise<T>,
+        onError?: () => void
+      ): Promise<T | undefined> => {
+        try {
+          return await task();
+        } catch (error) {
+          console.error(`Error ${taskName}:`, error);
+          if (isCurrentRun()) {
+            onError?.();
+          }
+          return undefined;
+        }
+      };
+
       try {
         // Check login status
         if (getLocalStorageData().signInMethod === "amber") {
@@ -500,191 +561,206 @@ function Shopstr({ props }: { props: AppProps }) {
           localStorage.setItem("relays", JSON.stringify(allRelays));
         }
 
-        // Sequential fetch for critical data with individual error handling
-        try {
-          const { relayList, readRelayList, writeRelayList } =
-            await fetchAllRelays(nostr!, signer!, allRelays, editRelaysContext);
+        // Fire them first and in parellel since independent of each other and other depend on it
+        const [relayResult, userPubkey] = await Promise.all([
+          runTask(
+            "fetching relays",
+            () => fetchAllRelays(nostr!, signer!, allRelays, guardedEditRelaysContext),
+            () => guardedEditRelaysContext([], [], [], false)
+          ),
+          runTask(
+            "resolving signer pubkey",
+            async () => (await signer?.getPubKey()) || undefined
+          ),
+        ]);
 
-          if (relayList.length !== 0) {
-            localStorage.setItem("relays", JSON.stringify(relayList));
-            localStorage.setItem("readRelays", JSON.stringify(readRelayList));
-            localStorage.setItem("writeRelays", JSON.stringify(writeRelayList));
-            allRelays = [...relayList, ...readRelayList];
-          }
-        } catch (error) {
-          console.error("Error fetching relays:", error);
-          editRelaysContext([], [], [], false);
-        }
+        if (!isCurrentRun()) return;
 
-        try {
-          const { blossomServers } = await fetchAllBlossomServers(
-            nostr!,
-            signer!,
-            allRelays,
-            editBlossomContext
+        if (relayResult && relayResult.relayList.length !== 0) {
+          localStorage.setItem("relays", JSON.stringify(relayResult.relayList));
+          localStorage.setItem(
+            "readRelays",
+            JSON.stringify(relayResult.readRelayList)
           );
-
-          if (blossomServers.length != 0) {
-            localStorage.setItem(
-              "blossomServers",
-              JSON.stringify(blossomServers)
-            );
-          }
-        } catch (error) {
-          console.error("Error fetching blossom servers:", error);
-          editBlossomContext([], false);
-        }
-
-        // Fetch products and collect profile pubkeys
-        let productEvents: NostrEvent[] = [];
-        let profileSetFromProducts = new Set<string>();
-        try {
-          const result = await fetchAllPosts(
-            nostr!,
-            allRelays,
-            editProductContext
+          localStorage.setItem(
+            "writeRelays",
+            JSON.stringify(relayResult.writeRelayList)
           );
-          productEvents = result.productEvents;
-          profileSetFromProducts = result.profileSetFromProducts;
-        } catch (error) {
-          console.error("Error fetching products:", error);
-          editProductContext([], false);
+          allRelays = [...relayResult.relayList, ...relayResult.readRelayList];
         }
 
-        // Handle profile fetching
-        let pubkeysToFetchProfilesFor = [...profileSetFromProducts];
-        const userPubkey = (await signer?.getPubKey()) || undefined;
-        const profileSetFromChats = new Set<string>();
-
-        if (isLoggedIn) {
-          try {
-            const { profileSetFromChats: newProfileSetFromChats } =
-              await fetchGiftWrappedChatsAndMessages(
-                nostr!,
-                signer!,
-                allRelays,
-                editChatContext,
-                userPubkey
-              );
-
-            newProfileSetFromChats.forEach((profile) =>
-              profileSetFromChats.add(profile)
-            );
-          } catch (error) {
-            console.error("Error fetching chats:", error);
-            editChatContext(new Map(), false);
-          }
-        }
-
-        if (userPubkey && profileSetFromChats.size != 0) {
-          pubkeysToFetchProfilesFor = [
-            userPubkey as string,
-            ...pubkeysToFetchProfilesFor,
-            ...profileSetFromChats,
-          ];
-        } else if (userPubkey) {
-          pubkeysToFetchProfilesFor = [
-            userPubkey as string,
-            ...pubkeysToFetchProfilesFor,
-          ];
-        }
-
-        try {
-          await fetchProfile(
-            nostr!,
-            allRelays,
-            pubkeysToFetchProfilesFor,
-            editProfileContext,
-            profileContext.profileData
-          );
-        } catch (error) {
-          console.error("Error fetching profiles:", error);
-          editProfileContext(new Map(profileContext.profileData), false);
-        }
-
-        try {
-          await fetchShopProfile(
-            nostr!,
-            allRelays,
-            pubkeysToFetchProfilesFor,
-            editShopContext
-          );
-        } catch (error) {
-          console.error("Error fetching shop profiles:", error);
-          editShopContext(new Map(), false);
-        }
-
-        try {
-          await fetchReviews(
-            nostr!,
-            allRelays,
-            productEvents,
-            editReviewsContext
-          );
-        } catch (error) {
-          console.error("Error fetching reviews:", error);
-          editReviewsContext(new Map(), new Map(), false);
-        }
-
-        try {
-          await fetchAllCommunities(nostr!, allRelays, editCommunityContext);
-        } catch (error) {
-          console.error("Error fetching communities:", error);
-          editCommunityContext(new Map(), false);
-        }
-
-        // Fetch wallet if logged in
-        if (isLoggedIn) {
-          try {
-            const { cashuMints, cashuProofs } = await fetchCashuWallet(
+        // We just fire them and not await them so that they just update their context and not block others
+        const blossomPromise = runTask(
+          "fetching blossom servers",
+          () =>
+            fetchAllBlossomServers(
               nostr!,
               signer!,
               allRelays,
-              editCashuWalletContext
-            );
+              guardedEditBlossomContext
+            ),
+          () => guardedEditBlossomContext([], false)
+        );
 
-            if (cashuMints.length !== 0 && cashuProofs) {
-              localStorage.setItem("mints", JSON.stringify(cashuMints));
-              localStorage.setItem("tokens", JSON.stringify(cashuProofs));
-            }
-          } catch (error) {
-            console.error("Error fetching wallet:", error);
-            editCashuWalletContext([], [], [], false);
-          }
+        const walletPromise = isLoggedIn
+          ? runTask(
+              "fetching wallet",
+              () =>
+                fetchCashuWallet(
+                  nostr!,
+                  signer!,
+                  allRelays,
+                  guardedEditCashuWalletContext
+                ),
+              () => guardedEditCashuWalletContext([], [], [], false)
+            )
+          : Promise.resolve(undefined);
+
+        const followsPromise = runTask(
+          "fetching follows",
+          () =>
+            fetchAllFollows(
+              nostr!,
+              allRelays,
+              guardedEditFollowsContext,
+              userPubkey
+            ),
+          () => guardedEditFollowsContext([], 0, false)
+        );
+
+        const communitiesPromise = runTask(
+          "fetching communities",
+          () => fetchAllCommunities(nostr!, allRelays, guardedEditCommunityContext),
+          () => guardedEditCommunityContext(new Map(), false)
+        );
+        
+
+        const productsPromise = runTask(
+          "fetching products",
+          () => fetchAllPosts(nostr!, allRelays, guardedEditProductContext),
+          () => guardedEditProductContext([], false)
+        );
+
+        const chatsPromise = isLoggedIn
+          ? runTask(
+              "fetching chats",
+              () =>
+                fetchGiftWrappedChatsAndMessages(
+                  nostr!,
+                  signer!,
+                  allRelays,
+                  guardedEditChatContext,
+                  userPubkey
+                ),
+              () => guardedEditChatContext(new Map(), false)
+            )
+          : Promise.resolve(undefined);
+
+        // Run them in parellel first since required for profile/shops/reviews
+        const [productsResult, chatsResult] = await Promise.all([
+          productsPromise,
+          chatsPromise,
+        ]);
+
+        if (!isCurrentRun()) return;
+
+        // Derive the pubkey list
+        const productEvents = productsResult?.productEvents ?? [];
+        const profileSetFromProducts =
+          productsResult?.profileSetFromProducts ?? new Set<string>();
+        const profileSetFromChats = chatsResult?.profileSetFromChats ?? new Set<string>();
+
+        const pubkeySet = new Set<string>([
+          ...profileSetFromProducts,
+          ...profileSetFromChats,
+        ]);
+
+        if (userPubkey) {
+          pubkeySet.add(userPubkey);
         }
 
-        try {
-          await fetchAllFollows(
-            nostr!,
-            allRelays,
-            editFollowsContext,
-            userPubkey
+        const pubkeysToFetchProfilesFor = Array.from(pubkeySet);
+
+        // These start immediately — no waiting for wallet, blossom, follows, or communities.
+        await Promise.all([
+          runTask(
+            "fetching profiles",
+            () =>
+              fetchProfile(
+                nostr!,
+                allRelays,
+                pubkeysToFetchProfilesFor,
+                guardedEditProfileContext,
+                profileContext.profileData
+              ),
+            () => guardedEditProfileContext(new Map(profileContext.profileData), false)
+          ),
+          runTask(
+            "fetching shop profiles",
+            () =>
+              fetchShopProfile(
+                nostr!,
+                allRelays,
+                pubkeysToFetchProfilesFor,
+                guardedEditShopContext
+              ),
+            () => guardedEditShopContext(new Map(), false)
+          ),
+          runTask(
+            "fetching reviews",
+            () =>
+              fetchReviews(
+                nostr!,
+                allRelays,
+                productEvents,
+                guardedEditReviewsContext
+              ),
+            () => guardedEditReviewsContext(new Map(), new Map(), false)
+          ),
+        ]);
+
+        if (!isCurrentRun()) return;
+
+        // By now these are likely already done; we await to catch errors and read results.
+        const [blossomResult, walletResult] = await Promise.all([
+          blossomPromise,
+          walletPromise,
+          followsPromise,
+          communitiesPromise,
+        ]);
+
+        if (!isCurrentRun()) return;
+
+        if (blossomResult?.blossomServers?.length) {
+          localStorage.setItem(
+            "blossomServers",
+            JSON.stringify(blossomResult.blossomServers)
           );
-        } catch (error) {
-          console.error("Error fetching follows:", error);
-          editFollowsContext([], 0, false);
         }
 
-        // After all fetching operations complete, retry failed relay publishes
-        try {
+        if (walletResult?.cashuMints?.length && walletResult.cashuProofs) {
+          localStorage.setItem("mints", JSON.stringify(walletResult.cashuMints));
+          localStorage.setItem("tokens", JSON.stringify(walletResult.cashuProofs));
+        }
+
+        await runTask("retrying relay publishes", async () => {
           const { relays, writeRelays } = getLocalStorageData();
           const retryNostr = new NostrManager([...relays, ...writeRelays]);
           await retryFailedRelayPublishes(retryNostr);
-        } catch (error) {
-          console.error("Failed to retry relay publishes:", error);
-        }
+        });
       } catch (error) {
         console.error("Critical error during app initialization:", error);
-        editProductContext([], false);
-        editReviewsContext(new Map(), new Map(), false);
-        editShopContext(new Map(), false);
-        editProfileContext(new Map(), false);
-        editChatContext(new Map(), false);
-        editFollowsContext([], 0, false);
-        editRelaysContext([], [], [], false);
-        editBlossomContext([], false);
-        editCashuWalletContext([], [], [], false);
-        editCommunityContext(new Map(), false);
+        if (!isCurrentRun()) return;
+        guardedEditProductContext([], false);
+        guardedEditReviewsContext(new Map(), new Map(), false);
+        guardedEditShopContext(new Map(), false);
+        guardedEditProfileContext(new Map(), false);
+        guardedEditChatContext(new Map(), false);
+        guardedEditFollowsContext([], 0, false);
+        guardedEditRelaysContext([], [], [], false);
+        guardedEditBlossomContext([], false);
+        guardedEditCashuWalletContext([], [], [], false);
+        guardedEditCommunityContext(new Map(), false);
       }
     }
 


### PR DESCRIPTION

### Description

- Refactor `_app.tsx` initial loading to parallelize independent fetches while preserving required ordering (relay discovery first).
- Adds a small wrapper for consistent error handling and fallback updates, and prevents outdated async responses from overwriting newer state.
- Add run-id guard to prevent stale async responses from changing state after a newer init starts.
- Existing localStorage persistence and relay retry behavior remain unchanged.


### Before

- App bootstrap in `_app.tsx` follows a long mostly sequential chain.
- Slow or failing steps delay unrelated data initialization.
- Repeated initial triggers (for example storage events) can allow stale async results to overwrite newer state.

### After

- Initialization now occurs in parellel stages
- Each fetch task is isolated: one failure does not block other tasks.
- Stale runs are ignored so only the latest init updates state.

This would help reduce the latency and improve the performance
### Resolved or fixed issue
`none`  

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
