### PR TITLE
Fix: resolve marketplace listing click routing mismatch 

### DIFF
--- a/components/home/marketplace.tsx
+++ b/components/home/marketplace.tsx
@@ -264,10 +264,9 @@ function MarketplacePage({
     }
   };
 
-  const handleTitleClick = (product: ProductData) => {
+  const getProductHref = (product: ProductData) => {
     if (product.d === "zapsnag" || product.categories?.includes("zapsnag")) {
-      router.push(`/listing/${product.id}`);
-      return;
+      return `/listing/${product.id}`;
     }
 
     const allParsed = productEventContext.productEvents
@@ -277,10 +276,14 @@ function MarketplacePage({
 
     const slug = getListingSlug(product, allParsed);
     if (slug) {
-      router.push(`/listing/${slug}`);
-    } else {
-      router.push(`/listing/${product.id}`);
+      return `/listing/${slug}`;
     }
+
+    return `/listing/${product.id}`;
+  };
+
+  const handleTitleClick = (product: ProductData) => {
+    router.push(getProductHref(product));
   };
 
   const renderProductScores = () => {

--- a/pages/listing/[[...productId]].tsx
+++ b/pages/listing/[[...productId]].tsx
@@ -140,9 +140,11 @@ const Listing = () => {
   useEffect(() => {
     if (router.isReady) {
       const { productId } = router.query;
-      const productIdString = productId ? productId[0] : "";
-      setProductIdString(productIdString!);
-      if (!productIdString) {
+      const resolvedProductId = Array.isArray(productId)
+        ? productId[0] || ""
+        : productId || "";
+      setProductIdString(resolvedProductId);
+      if (!resolvedProductId) {
         router.push("/marketplace");
       }
     }

--- a/proxy.ts
+++ b/proxy.ts
@@ -120,8 +120,5 @@ export function proxy(request: NextRequest) {
     }
   }
 
-  const response = NextResponse.next();
-  response.headers.delete("X-Powered-By");
-
-  return response;
+  return NextResponse.next();
 }


### PR DESCRIPTION
### Description
- Fixed marketplace listing navigation mismatch where normal click could route differently from opening the same listing in a new tab.
- Refactored marketplace title-click handling to use the same href resolution path used by listing links.
- Hardened listing route parameter parsing in the catch-all listing page to correctly handle both string and array query forms during client-side navigation.
- Resolved a TypeScript safety issue by guaranteeing a string fallback before setting listing identifier state.
- Simplified proxy pass-through response handling by returning `NextResponse.next()` directly at the end of proxy execution, removing unnecessary response mutation that could contribute to Next.js waitUntil/AwaiterOnce invariant behavior seen in the cache-events request flow.

### Resolved or fixed issue
Fixes #378


### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

