### PR TITLE
Fix: Failing Tests - Update test mocks for marketplace and profile dropdown components

### DIFF
--- a/components/home/__tests__/marketplace.test.tsx
+++ b/components/home/__tests__/marketplace.test.tsx
@@ -78,7 +78,10 @@ const renderComponent = ({
     typeof routerQuery.npub === "string" ||
     (Array.isArray(routerQuery.npub) && typeof routerQuery.npub[0] === "string")
   ) {
-    (nip19.decode as jest.Mock).mockReturnValue({ data: "decoded-pubkey" });
+    (nip19.decode as jest.Mock).mockReturnValue({
+      type: "npub",
+      data: "decoded-pubkey",
+    });
   }
 
   const mockOnOpen = jest.fn();

--- a/components/utility-components/__tests__/shopstr-switch.test.tsx
+++ b/components/utility-components/__tests__/shopstr-switch.test.tsx
@@ -15,8 +15,16 @@ jest.mock("next/router", () => ({
 }));
 
 jest.mock("@nextui-org/react", () => ({
-  Switch: (props: { onClick: () => void; color: string }) => (
-    <button role="switch" onClick={props.onClick} data-color={props.color} />
+  Switch: (props: {
+    onValueChange: (value: boolean) => void;
+    isSelected: boolean;
+    color: string;
+  }) => (
+    <button
+      role="switch"
+      onClick={() => props.onValueChange(!props.isSelected)}
+      data-color={props.color}
+    />
   ),
 }));
 

--- a/components/utility-components/profile/__tests__/profile-dropdown.test.tsx
+++ b/components/utility-components/profile/__tests__/profile-dropdown.test.tsx
@@ -13,6 +13,9 @@ import { LogOut } from "@/utils/nostr/nostr-helper-functions";
 import { nip19 } from "nostr-tools";
 import React from "react";
 
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
 const mockRouterPush = jest.fn();
 jest.mock("next/router", () => ({
   useRouter: () => ({
@@ -167,6 +170,9 @@ describe("ProfileWithDropdown", () => {
     mockOnOpen.mockClear();
     (LogOut as jest.Mock).mockClear();
     (navigator.clipboard.writeText as jest.Mock).mockClear();
+    mockFetch.mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ profile: { content: null } }),
+    });
   });
 
   it("renders with fallback data and correct dropdown items", () => {


### PR DESCRIPTION
### Description
This pull request updates several Jest test mocks to match the current component and library behavior, improving test reliability and alignment with production code.

- Adjusts the `nip19.decode` mock in `marketplace.test.tsx` to return an object including both `type: "npub"` and `data: "decoded-pubkey"`, reflecting the actual `nostr-tools` decode shape.

- Refactors the `@nextui-org/react` `Switch` mock in `shopstr-switch.test.tsx` to use `onValueChange` and `isSelected` instead of a simple `onClick`, so tests cover the real toggle semantics.

- Adds a global `fetch` mock in `profile-dropdown.test.tsx` and stubs a resolved JSON payload with `profile.content = null` to match the profile fetch flow and ensure the fallback data path is exercised.

These changes keep the tests in sync with the current component contracts and external APIs, reduce brittle assumptions, and make future UI changes easier to validate.

### Resolved or fixed issue
`none` 

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines