### PR TITLE
Jotai pilot: optimize loading state and fix file uploader crash

### DIFF
--- a/atoms/loadingAtom.ts
+++ b/atoms/loadingAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const loadingAtom = atom(false);

--- a/components/utility-components/file-uploader.tsx
+++ b/components/utility-components/file-uploader.tsx
@@ -1,9 +1,11 @@
+import { useAtom } from "jotai";
 import { useContext, useRef, useState } from "react";
-import { Button, Input, Progress } from "@nextui-org/react";
+import { Button, Progress } from "@nextui-org/react";
 import {
   blossomUploadImages,
   getLocalStorageData,
 } from "@/utils/nostr/nostr-helper-functions";
+import { loadingAtom } from "@/atoms/loadingAtom";
 import { SignerContext } from "@/components/utility-components/nostr-context-provider";
 import { AnimatePresence, motion } from "framer-motion";
 import {
@@ -34,7 +36,7 @@ export const FileUploaderButton = ({
   isPlaceholder?: boolean;
   isProductUpload?: boolean;
 }) => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useAtom(loadingAtom);
   const [progress, setProgress] = useState<number | null>(null);
   const [showFailureModal, setShowFailureModal] = useState(false);
   const [failureText, setFailureText] = useState("");
@@ -426,7 +428,7 @@ export const FileUploaderButton = ({
           </Button>
         )}
 
-        <Input
+        <input
           type="file"
           accept={ALLOWED_TYPES.join(",")}
           multiple

--- a/jotai-test.md
+++ b/jotai-test.md
@@ -1,0 +1,23 @@
+# Jotai Pilot: File Uploader Flow
+
+## What was implemented
+- Replaced local useState with Jotai atom (loadingAtom)
+- Integrated atom into file uploader component
+
+## Scenario Tested
+- Uploading single and multiple images
+
+## Observations
+- Upload flow works correctly without UI issues
+- Loading state updates are consistent
+- Updates remain mostly localized to uploader component
+- No clear cascade re-renders observed across unrelated components
+
+## Insight
+Jotai's atomic model helps isolate state updates,
+making it suitable for localized UI state like file uploads.
+
+## Additional Observation
+- Observed multiple re-renders of FileUploader during upload interactions
+- Likely due to parent component updates or intermediate state changes during upload flow
+- Suggests scope for further optimization in component structure or state handling

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint": "8.57.0",
         "eslint-config-next": "13.3.0",
         "framer-motion": "10.16.4",
+        "jotai": "2.19.1",
         "next": "16.1.7",
         "next-themes": "0.2.1",
         "nostr-tools": "2.7.1",
@@ -15222,6 +15223,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.19.1.tgz",
+      "integrity": "sha512-sqm9lVZiqBHZH8aSRk32DSiZDHY3yUIlulXYn9GQj7/LvoUdYXSMti7ZPJGo+6zjzKFt5a25k/I6iBCi43PJcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "8.57.0",
     "eslint-config-next": "13.3.0",
     "framer-motion": "10.16.4",
+    "jotai": "2.19.1",
     "next": "16.1.7",
     "next-themes": "0.2.1",
     "nostr-tools": "2.7.1",


### PR DESCRIPTION
## Summary
This PR introduces a small Jotai-based pilot to manage loading state in the file uploader, along with a fix for a runtime crash caused by controlled file input handling.

## Changes
- Replaced local `useState` with a shared Jotai atom (`loadingAtom`) for managing loading state
- Updated `file-uploader.tsx` to use `useAtom`
- Fixed file input crash by converting `<input type="file" />` to an uncontrolled input
- Removed NextUI `Input` to avoid controlled behavior during re-renders
- Added initial observations in `jotai-test.md`

## Motivation
Evaluate atomic state management (Jotai) for reducing unnecessary re-renders in localized UI flows, and resolve the runtime error:
> "Failed to set the 'value' property on 'HTMLInputElement'"

## Testing
- Verified image upload flow locally (single and multiple uploads)
- Loading state behaves consistently during interactions
- No crashes observed after fixing file input handling

## Additional Observations
- Observed multiple re-renders of the FileUploader component during upload interactions
- Likely due to parent updates or intermediate state changes during upload flow
- However, updates remained mostly localized without triggering broader cascade re-renders

## Notes
- Some CORS/WebSocket errors were observed locally (likely due to relay/server configuration), but they do not affect uploader functionality

## Scope
- Changes are intentionally minimal and limited to the file uploader
- This is a pilot experiment and not a full state management migration

## Next Steps
- Compare render behavior with Context/Zustand implementations
- Explore further optimization opportunities based on observed re-renders