### PR TITLE
pull listing search predicate into a standalone utility and add NIP-56 report helpers

### DIFF
--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useContext } from "react";
-import { nip19 } from "nostr-tools";
 import { deleteEvent } from "@/utils/nostr/nostr-helper-functions";
+import { productSatisfiesAllFilters } from "@/utils/search/listing-filters";
 import { NostrEvent } from "../utils/types/types";
 import { ProductContext, FollowsContext } from "../utils/context/context";
 import ProductCard from "./utility-components/product-card";
@@ -18,9 +18,6 @@ import {
   SignerContext,
 } from "@/components/utility-components/nostr-context-provider";
 import { getListingSlug } from "@/utils/url-slugs";
-
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const DisplayProducts = ({
   focusedPubkey,
@@ -139,7 +136,14 @@ const DisplayProducts = ({
 
     const filtered = productEvents.filter((product) => {
       if (focusedPubkey && product.pubkey !== focusedPubkey) return false;
-      if (!productSatisfiesAllFilters(product)) return false;
+      if (
+        !productSatisfiesAllFilters(product, {
+          selectedCategories,
+          selectedLocation,
+          selectedSearch,
+        })
+      )
+        return false;
       if (!product.currency) return false;
       if (product.images.length === 0) return false;
       if (product.contentWarning) return false;
@@ -258,84 +262,6 @@ const DisplayProducts = ({
     } else {
       setShowModal(false);
     }
-  };
-
-  const productSatisfiesCategoryFilter = (productData: ProductData) => {
-    if (selectedCategories.size === 0) return true;
-    return Array.from(selectedCategories).some((selectedCategory) => {
-      const re = new RegExp(selectedCategory, "gi");
-      return productData?.categories?.some((category) => {
-        const match = category.match(re);
-        return match && match.length > 0;
-      });
-    });
-  };
-
-  const productSatisfieslocationFilter = (productData: ProductData) => {
-    return !selectedLocation || productData.location === selectedLocation;
-  };
-
-  const productSatisfiesSearchFilter = (productData: ProductData) => {
-    const normalizedSearch = selectedSearch.trim();
-
-    if (!normalizedSearch) return true;
-    if (!productData.title) return false;
-
-    if (normalizedSearch.includes("naddr1")) {
-      try {
-        const parsedNaddr = nip19.decode(normalizedSearch);
-        if (parsedNaddr.type === "naddr") {
-          return (
-            productData.d === parsedNaddr.data.identifier &&
-            productData.pubkey === parsedNaddr.data.pubkey
-          );
-        }
-        return false;
-      } catch {
-        return false;
-      }
-    }
-
-    if (normalizedSearch.includes("npub1")) {
-      try {
-        const parsedNpub = nip19.decode(normalizedSearch);
-        if (parsedNpub.type === "npub") {
-          return parsedNpub.data === productData.pubkey;
-        }
-        return false;
-      } catch {
-        return false;
-      }
-    }
-
-    try {
-      const re = new RegExp(escapeRegExp(normalizedSearch), "i");
-
-      const titleMatch = productData.title.match(re);
-      if (titleMatch && titleMatch.length > 0) return true;
-
-      if (productData.summary) {
-        const summaryMatch = productData.summary.match(re);
-        if (summaryMatch && summaryMatch.length > 0) return true;
-      }
-
-      const numericSearch = parseFloat(normalizedSearch);
-      if (!isNaN(numericSearch) && productData.price === numericSearch) {
-        return true;
-      }
-
-      return false;
-    } catch {
-      return false;
-    }
-  };
-
-  const productSatisfiesAllFilters = (productData: ProductData) => {
-    return (
-      productSatisfiesCategoryFilter(productData) &&
-      productSatisfieslocationFilter(productData) &&
-      productSatisfiesSearchFilter(productData)
-    );
   };
 
   const getCurrentPageProducts = () => {

--- a/utils/nostr/__tests__/nip56.test.ts
+++ b/utils/nostr/__tests__/nip56.test.ts
@@ -1,0 +1,59 @@
+import {
+  buildProfileReportTags,
+  buildListingReportTags,
+  Nip56ReportType,
+} from "../nip56";
+
+const PUBKEY =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const EVENT_ID =
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+describe("buildProfileReportTags", () => {
+  it("returns a single p tag with the reason", () => {
+    const tags = buildProfileReportTags(PUBKEY, "spam");
+    expect(tags).toEqual([["p", PUBKEY, "spam"]]);
+  });
+
+  it("includes the pubkey verbatim", () => {
+    const tags = buildProfileReportTags(PUBKEY, "impersonation");
+    expect(tags[0][1]).toBe(PUBKEY);
+  });
+
+  const reasons: Nip56ReportType[] = [
+    "nudity",
+    "malware",
+    "profanity",
+    "illegal",
+    "spam",
+    "impersonation",
+    "other",
+  ];
+
+  it.each(reasons)("accepts report type %s", (reason) => {
+    const tags = buildProfileReportTags(PUBKEY, reason);
+    expect(tags[0][2]).toBe(reason);
+  });
+});
+
+describe("buildListingReportTags", () => {
+  it("returns an e tag followed by a p tag", () => {
+    const tags = buildListingReportTags(EVENT_ID, PUBKEY, "spam");
+    expect(tags).toEqual([
+      ["e", EVENT_ID, "spam"],
+      ["p", PUBKEY],
+    ]);
+  });
+
+  it("attaches the reason to the e tag, not the p tag", () => {
+    const tags = buildListingReportTags(EVENT_ID, PUBKEY, "illegal");
+    expect(tags[0]).toEqual(["e", EVENT_ID, "illegal"]);
+    expect(tags[1]).toEqual(["p", PUBKEY]);
+    expect(tags[1]).toHaveLength(2);
+  });
+
+  it("preserves the event id verbatim", () => {
+    const tags = buildListingReportTags(EVENT_ID, PUBKEY, "other");
+    expect(tags[0][1]).toBe(EVENT_ID);
+  });
+});

--- a/utils/nostr/__tests__/nip56.test.ts
+++ b/utils/nostr/__tests__/nip56.test.ts
@@ -17,7 +17,7 @@ describe("buildProfileReportTags", () => {
 
   it("includes the pubkey verbatim", () => {
     const tags = buildProfileReportTags(PUBKEY, "impersonation");
-    expect(tags[0][1]).toBe(PUBKEY);
+    expect(tags[0]![1]).toBe(PUBKEY);
   });
 
   const reasons: Nip56ReportType[] = [
@@ -32,7 +32,7 @@ describe("buildProfileReportTags", () => {
 
   it.each(reasons)("accepts report type %s", (reason) => {
     const tags = buildProfileReportTags(PUBKEY, reason);
-    expect(tags[0][2]).toBe(reason);
+    expect(tags[0]![2]).toBe(reason);
   });
 });
 
@@ -54,6 +54,6 @@ describe("buildListingReportTags", () => {
 
   it("preserves the event id verbatim", () => {
     const tags = buildListingReportTags(EVENT_ID, PUBKEY, "other");
-    expect(tags[0][1]).toBe(EVENT_ID);
+    expect(tags[0]![1]).toBe(EVENT_ID);
   });
 });

--- a/utils/nostr/nip56.ts
+++ b/utils/nostr/nip56.ts
@@ -1,0 +1,52 @@
+/**
+ * NIP-56 Reporting helpers.
+ *
+ * NIP-56 defines kind 1984 events for reporting objectionable content.
+ * See: https://github.com/nostr-protocol/nips/blob/master/56.md
+ *
+ * Tag shapes:
+ *   Profile report:  [["p", pubkey, reason]]
+ *   Listing report:  [["e", eventId, reason], ["p", pubkey]]
+ */
+
+export type Nip56ReportType =
+  | "nudity"
+  | "malware"
+  | "profanity"
+  | "illegal"
+  | "spam"
+  | "impersonation"
+  | "other";
+
+/**
+ * Build NIP-56 kind 1984 tags for reporting a seller profile.
+ *
+ * @param pubkey  The hex pubkey of the profile being reported.
+ * @param reason  One of the NIP-56 report type strings.
+ * @returns       Tag array ready to include in a kind 1984 event.
+ */
+export function buildProfileReportTags(
+  pubkey: string,
+  reason: Nip56ReportType
+): string[][] {
+  return [["p", pubkey, reason]];
+}
+
+/**
+ * Build NIP-56 kind 1984 tags for reporting a marketplace listing (kind 30018).
+ *
+ * @param eventId  The hex id of the listing event being reported.
+ * @param pubkey   The hex pubkey of the listing author.
+ * @param reason   One of the NIP-56 report type strings.
+ * @returns        Tag array ready to include in a kind 1984 event.
+ */
+export function buildListingReportTags(
+  eventId: string,
+  pubkey: string,
+  reason: Nip56ReportType
+): string[][] {
+  return [
+    ["e", eventId, reason],
+    ["p", pubkey],
+  ];
+}

--- a/utils/search/__tests__/listing-filters.test.ts
+++ b/utils/search/__tests__/listing-filters.test.ts
@@ -1,0 +1,147 @@
+import {
+  productSatisfiesSearchFilter,
+  productSatisfiesCategoryFilter,
+  productSatisfiesLocationFilter,
+  productSatisfiesAllFilters,
+} from "../listing-filters";
+import { ProductData } from "@/utils/parsers/product-parser-functions";
+
+const makeProduct = (overrides: Partial<ProductData> = {}): ProductData => ({
+  id: "abc123",
+  pubkey: "deadbeef",
+  createdAt: 0,
+  title: "Test Product",
+  summary: "A test summary",
+  publishedAt: "",
+  images: ["https://example.com/img.png"],
+  categories: ["electronics"],
+  location: "US",
+  price: 10,
+  currency: "USD",
+  totalCost: 10,
+  ...overrides,
+});
+
+// ── productSatisfiesSearchFilter ─────────────────────────────────────────────
+
+describe("productSatisfiesSearchFilter", () => {
+  it("returns true for empty search", () => {
+    expect(productSatisfiesSearchFilter(makeProduct(), "")).toBe(true);
+    expect(productSatisfiesSearchFilter(makeProduct(), "   ")).toBe(true);
+  });
+
+  it("returns false when product has no title", () => {
+    expect(
+      productSatisfiesSearchFilter(makeProduct({ title: "" }), "anything")
+    ).toBe(false);
+  });
+
+  it("matches title case-insensitively", () => {
+    const p = makeProduct({ title: "Bitcoin Wallet" });
+    expect(productSatisfiesSearchFilter(p, "bitcoin")).toBe(true);
+    expect(productSatisfiesSearchFilter(p, "WALLET")).toBe(true);
+    expect(productSatisfiesSearchFilter(p, "lightning")).toBe(false);
+  });
+
+  it("matches summary when title does not match", () => {
+    const p = makeProduct({ title: "Gadget", summary: "runs on solar power" });
+    expect(productSatisfiesSearchFilter(p, "solar")).toBe(true);
+  });
+
+  it("matches by exact price when search is numeric", () => {
+    const p = makeProduct({ price: 42 });
+    expect(productSatisfiesSearchFilter(p, "42")).toBe(true);
+    expect(productSatisfiesSearchFilter(p, "43")).toBe(false);
+  });
+
+  it("escapes regex special chars so c++ is a literal search", () => {
+    const p = makeProduct({ title: "C++ Guide" });
+    expect(productSatisfiesSearchFilter(p, "c++")).toBe(true);
+    expect(productSatisfiesSearchFilter(p, "C++")).toBe(true);
+  });
+
+  it("returns false for invalid naddr1 strings", () => {
+    const p = makeProduct();
+    expect(productSatisfiesSearchFilter(p, "naddr1invalidgarbage")).toBe(false);
+  });
+
+  it("returns false for invalid npub1 strings", () => {
+    const p = makeProduct();
+    expect(productSatisfiesSearchFilter(p, "npub1invalidgarbage")).toBe(false);
+  });
+});
+
+// ── productSatisfiesCategoryFilter ──────────────────────────────────────────
+
+describe("productSatisfiesCategoryFilter", () => {
+  it("returns true when no categories are selected", () => {
+    expect(productSatisfiesCategoryFilter(makeProduct(), new Set())).toBe(true);
+  });
+
+  it("matches when product category is in the selected set", () => {
+    const p = makeProduct({ categories: ["clothing", "vintage"] });
+    expect(productSatisfiesCategoryFilter(p, new Set(["vintage"]))).toBe(true);
+  });
+
+  it("returns false when product has none of the selected categories", () => {
+    const p = makeProduct({ categories: ["electronics"] });
+    expect(productSatisfiesCategoryFilter(p, new Set(["clothing"]))).toBe(
+      false
+    );
+  });
+
+  it("is case-insensitive", () => {
+    const p = makeProduct({ categories: ["Electronics"] });
+    expect(productSatisfiesCategoryFilter(p, new Set(["electronics"]))).toBe(
+      true
+    );
+  });
+});
+
+// ── productSatisfiesLocationFilter ──────────────────────────────────────────
+
+describe("productSatisfiesLocationFilter", () => {
+  it("returns true when no location is selected", () => {
+    expect(productSatisfiesLocationFilter(makeProduct(), "")).toBe(true);
+  });
+
+  it("matches exact location", () => {
+    const p = makeProduct({ location: "EU" });
+    expect(productSatisfiesLocationFilter(p, "EU")).toBe(true);
+    expect(productSatisfiesLocationFilter(p, "US")).toBe(false);
+  });
+});
+
+// ── productSatisfiesAllFilters ───────────────────────────────────────────────
+
+describe("productSatisfiesAllFilters", () => {
+  it("returns true when all filters pass", () => {
+    const p = makeProduct({
+      title: "Vintage Jacket",
+      categories: ["clothing"],
+      location: "EU",
+    });
+    expect(
+      productSatisfiesAllFilters(p, {
+        selectedSearch: "jacket",
+        selectedCategories: new Set(["clothing"]),
+        selectedLocation: "EU",
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when any one filter fails", () => {
+    const p = makeProduct({
+      title: "Vintage Jacket",
+      categories: ["clothing"],
+      location: "EU",
+    });
+    expect(
+      productSatisfiesAllFilters(p, {
+        selectedSearch: "jacket",
+        selectedCategories: new Set(["electronics"]), // fails
+        selectedLocation: "EU",
+      })
+    ).toBe(false);
+  });
+});

--- a/utils/search/listing-filters.ts
+++ b/utils/search/listing-filters.ts
@@ -1,0 +1,107 @@
+import { nip19 } from "nostr-tools";
+import { ProductData } from "@/utils/parsers/product-parser-functions";
+
+export interface ListingFilters {
+  selectedCategories: Set<string>;
+  selectedLocation: string;
+  selectedSearch: string;
+}
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export function productSatisfiesCategoryFilter(
+  productData: ProductData,
+  selectedCategories: Set<string>
+): boolean {
+  if (selectedCategories.size === 0) return true;
+  return Array.from(selectedCategories).some((selectedCategory) => {
+    const re = new RegExp(selectedCategory, "gi");
+    return productData?.categories?.some((category) => {
+      const match = category.match(re);
+      return match && match.length > 0;
+    });
+  });
+}
+
+export function productSatisfiesLocationFilter(
+  productData: ProductData,
+  selectedLocation: string
+): boolean {
+  return !selectedLocation || productData.location === selectedLocation;
+}
+
+/**
+ * Returns true if productData matches the given search string.
+ *
+ * Matching rules (in priority order):
+ *  1. Empty search → always matches.
+ *  2. naddr1 bech32 → exact d-tag + pubkey match.
+ *  3. npub1 bech32  → exact pubkey match.
+ *  4. Otherwise     → case-insensitive regex match on title, then summary,
+ *                     then exact numeric price match.
+ */
+export function productSatisfiesSearchFilter(
+  productData: ProductData,
+  selectedSearch: string
+): boolean {
+  const normalizedSearch = selectedSearch.trim();
+
+  if (!normalizedSearch) return true;
+  if (!productData.title) return false;
+
+  if (normalizedSearch.includes("naddr1")) {
+    try {
+      const parsedNaddr = nip19.decode(normalizedSearch);
+      if (parsedNaddr.type === "naddr") {
+        return (
+          productData.d === parsedNaddr.data.identifier &&
+          productData.pubkey === parsedNaddr.data.pubkey
+        );
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  if (normalizedSearch.includes("npub1")) {
+    try {
+      const parsedNpub = nip19.decode(normalizedSearch);
+      if (parsedNpub.type === "npub") {
+        return parsedNpub.data === productData.pubkey;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  try {
+    const re = new RegExp(escapeRegExp(normalizedSearch), "i");
+
+    if (productData.title.match(re)) return true;
+
+    if (productData.summary && productData.summary.match(re)) return true;
+
+    const numericSearch = parseFloat(normalizedSearch);
+    if (!isNaN(numericSearch) && productData.price === numericSearch) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function productSatisfiesAllFilters(
+  productData: ProductData,
+  filters: ListingFilters
+): boolean {
+  return (
+    productSatisfiesCategoryFilter(productData, filters.selectedCategories) &&
+    productSatisfiesLocationFilter(productData, filters.selectedLocation) &&
+    productSatisfiesSearchFilter(productData, filters.selectedSearch)
+  );
+}


### PR DESCRIPTION
The filter functions in DisplayProducts had no unit tests and testing them meant spinning up the whole component with all its context providers. Moved them to utils/search/listing-filters.ts so they're plain functions that are easy to test in isolation.

Also added typed helpers in utils/nostr/nip56.ts for building kind 1984 report tags for profiles and listings since that's needed for the reporting flow anyway.

29 tests, all passing.