### PR TITLE
Fix MCP onboarding quick-start correctness

### DIFF
--- a/__tests__/pages/api/mcp/onboard.test.ts
+++ b/__tests__/pages/api/mcp/onboard.test.ts
@@ -47,10 +47,23 @@ const FIXED_NSEC = "nsec1testonboard";
 const FIXED_NPUB = "npub1testonboard";
 const FIXED_AGENT_NAME = "Test Agent";
 
-type MockResponse = NextApiResponse & {
+type MockResponse = {
   statusCode: number;
   jsonBody: unknown;
+  status(code: number): MockResponse;
+  json(payload: unknown): MockResponse;
 };
+
+function setNodeEnv(value: "development" | "production" | "test" | undefined) {
+  const env = process.env as Record<string, string | undefined>;
+
+  if (value === undefined) {
+    delete env["NODE_ENV"];
+    return;
+  }
+
+  env["NODE_ENV"] = value;
+}
 
 function createMockRequest(
   overrides: Partial<NextApiRequest> = {}
@@ -72,7 +85,7 @@ function createMockRequest(
 }
 
 function createMockResponse(): MockResponse {
-  const res = {
+  const res: MockResponse = {
     statusCode: 200,
     jsonBody: undefined,
     status(code: number) {
@@ -83,20 +96,24 @@ function createMockResponse(): MockResponse {
       this.jsonBody = payload;
       return this;
     },
-  } as MockResponse;
+  };
 
   return res;
 }
 
 describe("MCP onboard API quick-start correctness", () => {
   const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  let handler: typeof import("../onboard").default;
+  const originalAllowedHosts = process.env.MCP_ALLOWED_HOSTS;
+  const originalNodeEnv = process.env.NODE_ENV;
+  let handler: typeof import("@/pages/api/mcp/onboard").default;
 
   beforeEach(async () => {
     jest.resetModules();
     jest.clearAllMocks();
 
     delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.MCP_ALLOWED_HOSTS;
+    setNodeEnv("test");
 
     checkOnboardRateLimitMock.mockReturnValue(true);
     initializeApiKeysTableMock.mockResolvedValue(undefined);
@@ -112,7 +129,7 @@ describe("MCP onboard API quick-start correctness", () => {
     nsecEncodeMock.mockReturnValue(FIXED_NSEC);
     npubEncodeMock.mockReturnValue(FIXED_NPUB);
 
-    handler = (await import("../onboard")).default;
+    handler = (await import("@/pages/api/mcp/onboard")).default;
   });
 
   afterEach(() => {
@@ -121,13 +138,25 @@ describe("MCP onboard API quick-start correctness", () => {
     } else {
       process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
     }
+
+    if (originalAllowedHosts === undefined) {
+      delete process.env.MCP_ALLOWED_HOSTS;
+    } else {
+      process.env.MCP_ALLOWED_HOSTS = originalAllowedHosts;
+    }
+
+    if (originalNodeEnv === undefined) {
+      setNodeEnv(undefined);
+    } else {
+      setNodeEnv(originalNodeEnv);
+    }
   });
 
   it("returns local HTTP onboarding URLs and MCP-compatible curl examples", async () => {
     const req = createMockRequest();
     const res = createMockResponse();
 
-    await handler(req, res);
+    await handler(req, res as unknown as NextApiResponse);
 
     expect(res.statusCode).toBe(201);
     expect(res.jsonBody).toMatchObject({
@@ -161,6 +190,25 @@ describe("MCP onboard API quick-start correctness", () => {
     );
   });
 
+  it("escapes agent names safely inside curl payload examples", async () => {
+    const req = createMockRequest({
+      body: {
+        name: "O'Reilly Bot",
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res as unknown as NextApiResponse);
+
+    const body = res.jsonBody as {
+      quickStart: { examples: Record<string, string> };
+    };
+
+    expect(body.quickStart.examples.curl_initialize).toContain(
+      `O'"'"'Reilly Bot`
+    );
+  });
+
   it("prefers NEXT_PUBLIC_BASE_URL and normalizes trailing slashes", async () => {
     process.env.NEXT_PUBLIC_BASE_URL = "https://shopstr.example/";
 
@@ -171,7 +219,7 @@ describe("MCP onboard API quick-start correctness", () => {
     });
     const res = createMockResponse();
 
-    await handler(req, res);
+    await handler(req, res as unknown as NextApiResponse);
 
     expect(res.statusCode).toBe(201);
     expect(res.jsonBody).toMatchObject({
@@ -180,7 +228,9 @@ describe("MCP onboard API quick-start correctness", () => {
     });
   });
 
-  it("uses forwarded host and protocol when present", async () => {
+  it("uses allowlisted forwarded host and protocol when present", async () => {
+    process.env.MCP_ALLOWED_HOSTS = "shopstr.example";
+
     const req = createMockRequest({
       headers: {
         host: "127.0.0.1:5000",
@@ -190,12 +240,57 @@ describe("MCP onboard API quick-start correctness", () => {
     });
     const res = createMockResponse();
 
-    await handler(req, res);
+    await handler(req, res as unknown as NextApiResponse);
 
     expect(res.statusCode).toBe(201);
     expect(res.jsonBody).toMatchObject({
       mcpEndpoint: "https://shopstr.example/api/mcp",
       manifestUrl: "https://shopstr.example/.well-known/agent.json",
     });
+  });
+
+  it("ignores unallowlisted forwarded hosts in production", async () => {
+    setNodeEnv("production");
+    process.env.MCP_ALLOWED_HOSTS = "shopstr.example";
+
+    const req = createMockRequest({
+      headers: {
+        host: "shopstr.example",
+        "x-forwarded-host": "evil.example",
+        "x-forwarded-proto": "https",
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.jsonBody).toMatchObject({
+      mcpEndpoint: "https://shopstr.example/api/mcp",
+      manifestUrl: "https://shopstr.example/.well-known/agent.json",
+    });
+  });
+
+  it("fails safely in production when no public base URL or allowlisted host is available", async () => {
+    setNodeEnv("production");
+
+    const req = createMockRequest({
+      headers: {
+        host: "shopstr.example",
+      },
+    });
+    const res = createMockResponse();
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.jsonBody).toEqual({
+      error: "Onboarding failed. Please try again later.",
+    });
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/env.example
+++ b/env.example
@@ -8,5 +8,8 @@ MCP_ENCRYPTION_KEY=replace-with-a-long-random-secret
 # Optional: override the public base URL used in MCP onboarding responses
 # NEXT_PUBLIC_BASE_URL=https://shopstr.example
 
+# from request headers if NEXT_PUBLIC_BASE_URL is not set
+# MCP_ALLOWED_HOSTS=shopstr.example,api.shopstr.example
+
 # For production, use your actual database URL:
 # DATABASE_URL=postgresql://user:password@host:port/database

--- a/env.example
+++ b/env.example
@@ -2,6 +2,11 @@
 # For local development with docker-compose:
 DATABASE_URL=postgresql://shopstr:shopstr@localhost:5432/shopstr
 
+# Required for MCP agent onboarding when Shopstr stores encrypted nsec values
+MCP_ENCRYPTION_KEY=replace-with-a-long-random-secret
+
+# Optional: override the public base URL used in MCP onboarding responses
+# NEXT_PUBLIC_BASE_URL=https://shopstr.example
+
 # For production, use your actual database URL:
 # DATABASE_URL=postgresql://user:password@host:port/database
-

--- a/pages/api/mcp/__tests__/onboard.test.ts
+++ b/pages/api/mcp/__tests__/onboard.test.ts
@@ -1,0 +1,201 @@
+const createApiKeyMock = jest.fn();
+const initializeApiKeysTableMock = jest.fn();
+const encryptNsecMock = jest.fn();
+const checkOnboardRateLimitMock = jest.fn();
+const generateSecretKeyMock = jest.fn();
+const getPublicKeyMock = jest.fn();
+const nsecEncodeMock = jest.fn();
+const npubEncodeMock = jest.fn();
+const bytesToHexMock = jest.fn();
+
+jest.mock("@/utils/mcp/auth", () => ({
+  createApiKey: (...args: unknown[]) => createApiKeyMock(...args),
+  initializeApiKeysTable: (...args: unknown[]) =>
+    initializeApiKeysTableMock(...args),
+}));
+
+jest.mock("@/utils/mcp/nostr-signing", () => ({
+  encryptNsec: (...args: unknown[]) => encryptNsecMock(...args),
+}));
+
+jest.mock("@/utils/mcp/metrics", () => ({
+  checkOnboardRateLimit: (...args: unknown[]) =>
+    checkOnboardRateLimitMock(...args),
+}));
+
+jest.mock("nostr-tools", () => ({
+  generateSecretKey: (...args: unknown[]) => generateSecretKeyMock(...args),
+  getPublicKey: (...args: unknown[]) => getPublicKeyMock(...args),
+  nip19: {
+    nsecEncode: (...args: unknown[]) => nsecEncodeMock(...args),
+    npubEncode: (...args: unknown[]) => npubEncodeMock(...args),
+    decode: jest.fn(),
+  },
+}));
+
+jest.mock("@noble/hashes/utils", () => ({
+  bytesToHex: (...args: unknown[]) => bytesToHexMock(...args),
+  hexToBytes: jest.fn(),
+}));
+
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const FIXED_SECRET_KEY = new Uint8Array([1, 2, 3, 4]);
+const FIXED_PUBKEY = "a".repeat(64);
+const FIXED_API_KEY = "sk_test_onboard_key";
+const FIXED_NSEC = "nsec1testonboard";
+const FIXED_NPUB = "npub1testonboard";
+const FIXED_AGENT_NAME = "Test Agent";
+
+type MockResponse = NextApiResponse & {
+  statusCode: number;
+  jsonBody: unknown;
+};
+
+function createMockRequest(
+  overrides: Partial<NextApiRequest> = {}
+): NextApiRequest {
+  return {
+    method: "POST",
+    headers: {
+      host: "localhost:5000",
+    },
+    socket: {
+      remoteAddress: "127.0.0.1",
+      encrypted: false,
+    },
+    body: {
+      name: FIXED_AGENT_NAME,
+    },
+    ...overrides,
+  } as NextApiRequest;
+}
+
+function createMockResponse(): MockResponse {
+  const res = {
+    statusCode: 200,
+    jsonBody: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      return this;
+    },
+  } as MockResponse;
+
+  return res;
+}
+
+describe("MCP onboard API quick-start correctness", () => {
+  const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  let handler: typeof import("../onboard").default;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+
+    checkOnboardRateLimitMock.mockReturnValue(true);
+    initializeApiKeysTableMock.mockResolvedValue(undefined);
+    encryptNsecMock.mockReturnValue("encrypted-nsec");
+    createApiKeyMock.mockResolvedValue({
+      key: FIXED_API_KEY,
+      record: { id: 1 },
+    });
+
+    generateSecretKeyMock.mockReturnValue(FIXED_SECRET_KEY);
+    getPublicKeyMock.mockReturnValue(FIXED_PUBKEY);
+    bytesToHexMock.mockReturnValue("11".repeat(32));
+    nsecEncodeMock.mockReturnValue(FIXED_NSEC);
+    npubEncodeMock.mockReturnValue(FIXED_NPUB);
+
+    handler = (await import("../onboard")).default;
+  });
+
+  afterEach(() => {
+    if (originalBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  it("returns local HTTP onboarding URLs and MCP-compatible curl examples", async () => {
+    const req = createMockRequest();
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.jsonBody).toMatchObject({
+      apiKey: FIXED_API_KEY,
+      pubkey: FIXED_PUBKEY,
+      npub: FIXED_NPUB,
+      mcpEndpoint: "http://localhost:5000/api/mcp",
+      manifestUrl: "http://localhost:5000/.well-known/agent.json",
+      quickStart: {
+        notes: expect.arrayContaining([
+          "Run the initialize command with -i so curl prints the Mcp-Session-Id response header for follow-up requests.",
+        ]),
+      },
+    });
+
+    const body = res.jsonBody as {
+      quickStart: { examples: Record<string, string> };
+    };
+
+    expect(body.quickStart.examples.curl_initialize).toContain(
+      'curl -i -X POST http://localhost:5000/api/mcp'
+    );
+    expect(body.quickStart.examples.curl_initialize).toContain(
+      'Accept: application/json, text/event-stream'
+    );
+    expect(body.quickStart.examples.curl_list_tools).toContain(
+      'Mcp-Session-Id: <session-id-from-initialize>'
+    );
+    expect(body.quickStart.examples.curl_search).toContain(
+      'Accept: application/json, text/event-stream'
+    );
+  });
+
+  it("prefers NEXT_PUBLIC_BASE_URL and normalizes trailing slashes", async () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://shopstr.example/";
+
+    const req = createMockRequest({
+      headers: {
+        host: "localhost:5000",
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.jsonBody).toMatchObject({
+      mcpEndpoint: "https://shopstr.example/api/mcp",
+      manifestUrl: "https://shopstr.example/.well-known/agent.json",
+    });
+  });
+
+  it("uses forwarded host and protocol when present", async () => {
+    const req = createMockRequest({
+      headers: {
+        host: "127.0.0.1:5000",
+        "x-forwarded-host": "shopstr.example",
+        "x-forwarded-proto": "https",
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.jsonBody).toMatchObject({
+      mcpEndpoint: "https://shopstr.example/api/mcp",
+      manifestUrl: "https://shopstr.example/.well-known/agent.json",
+    });
+  });
+});

--- a/pages/api/mcp/onboard.ts
+++ b/pages/api/mcp/onboard.ts
@@ -18,12 +18,74 @@ import {
 } from "@/utils/mcp/request-proof-server";
 
 let tablesReady = false;
+const MCP_STREAMABLE_HTTP_ACCEPT =
+  "application/json, text/event-stream";
 
 async function ensureTables() {
   if (!tablesReady) {
     await initializeApiKeysTable();
     tablesReady = true;
   }
+}
+
+function getFirstHeaderValue(
+  value: string | string[] | undefined
+): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0]?.trim() || undefined;
+  }
+
+  return value?.split(",")[0]?.trim() || undefined;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function resolveBaseUrl(
+  req: Pick<NextApiRequest, "headers" | "socket">
+): string {
+  const configuredBaseUrl = process.env.NEXT_PUBLIC_BASE_URL?.trim();
+  if (configuredBaseUrl) {
+    return normalizeBaseUrl(configuredBaseUrl);
+  }
+
+  const forwardedProto = getFirstHeaderValue(req.headers["x-forwarded-proto"]);
+  const forwardedHost = getFirstHeaderValue(req.headers["x-forwarded-host"]);
+  const host = forwardedHost || getFirstHeaderValue(req.headers.host);
+  const protocol =
+    forwardedProto ||
+    ((req.socket as typeof req.socket & { encrypted?: boolean }).encrypted
+      ? "https"
+      : "http");
+
+  return `${protocol}://${host || "localhost:5000"}`;
+}
+
+function buildQuickStartExamples(
+  baseUrl: string,
+  apiKey: string,
+  agentName: string
+) {
+  return {
+    curl_initialize: `curl -i -X POST ${baseUrl}/api/mcp \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -H "Accept: ${MCP_STREAMABLE_HTTP_ACCEPT}" \\
+  -H "Content-Type: application/json" \\
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"${agentName}","version":"1.0.0"}},"id":1}'`,
+    curl_list_tools: `curl -X POST ${baseUrl}/api/mcp \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -H "Accept: ${MCP_STREAMABLE_HTTP_ACCEPT}" \\
+  -H "Content-Type: application/json" \\
+  -H "Mcp-Session-Id: <session-id-from-initialize>" \\
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":2}'`,
+    curl_search: `curl -X POST ${baseUrl}/api/mcp \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -H "Accept: ${MCP_STREAMABLE_HTTP_ACCEPT}" \\
+  -H "Content-Type: application/json" \\
+  -H "Mcp-Session-Id: <session-id-from-initialize>" \\
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_products","arguments":{}},"id":3}'`,
+  };
 }
 
 export default async function handler(
@@ -197,8 +259,7 @@ export default async function handler(
       encryptedNsecValue
     );
 
-    const baseUrl =
-      process.env.NEXT_PUBLIC_BASE_URL || `https://${req.headers.host}`;
+    const baseUrl = resolveBaseUrl(req);
 
     const npub = nip19.npubEncode(pubkey);
 
@@ -212,24 +273,10 @@ export default async function handler(
       quickStart: {
         description:
           "Use the API key as a Bearer token to authenticate MCP requests.",
-        examples: {
-          curl_initialize: `curl -X POST ${baseUrl}/api/mcp \\
-  -H "Authorization: Bearer ${result.key}" \\
-  -H "Content-Type: application/json" \\
-  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"${trimmedName}","version":"1.0.0"}},"id":1}'`,
-          curl_list_tools: `curl -X POST ${baseUrl}/api/mcp \\
-  -H "Authorization: Bearer ${result.key}" \\
-  -H "Content-Type: application/json" \\
-  -H "Mcp-Session-Id: <session-id-from-initialize>" \\
-  -d '{"jsonrpc":"2.0","method":"tools/list","id":2}'`,
-          curl_search: `curl -X POST ${baseUrl}/api/mcp \\
-  -H "Authorization: Bearer ${result.key}" \\
-  -H "Content-Type: application/json" \\
-  -H "Mcp-Session-Id: <session-id-from-initialize>" \\
-  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_products","arguments":{}},"id":3}'`,
-        },
+        examples: buildQuickStartExamples(baseUrl, result.key, trimmedName),
         notes: [
           "Store your API key securely — it will not be shown again.",
+          "Run the initialize command with -i so curl prints the Mcp-Session-Id response header for follow-up requests.",
           `Your permissions are set to "${perm}".${
             perm === "read"
               ? ' Upgrade to "read_write" to place orders, or "full_access" for full marketplace participation.'

--- a/pages/api/mcp/onboard.ts
+++ b/pages/api/mcp/onboard.ts
@@ -20,6 +20,7 @@ import {
 let tablesReady = false;
 const MCP_STREAMABLE_HTTP_ACCEPT =
   "application/json, text/event-stream";
+const SAFE_HTTP_PROTOCOLS = new Set(["http", "https"]);
 
 async function ensureTables() {
   if (!tablesReady) {
@@ -42,24 +43,153 @@ function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
 
+function normalizeHostValue(host: string): string {
+  const trimmedHost = host.trim().toLowerCase();
+  if (
+    trimmedHost.length === 0 ||
+    /[\s/@?#\\]/.test(trimmedHost) ||
+    trimmedHost.includes("/")
+  ) {
+    throw new Error(`Invalid host: ${host}`);
+  }
+
+  return new URL(`http://${trimmedHost}`).host.toLowerCase();
+}
+
+function parseConfiguredBaseUrl(): string | undefined {
+  const configuredBaseUrl = process.env.NEXT_PUBLIC_BASE_URL?.trim();
+  if (!configuredBaseUrl) return undefined;
+
+  const parsedBaseUrl = new URL(configuredBaseUrl);
+  const protocol = parsedBaseUrl.protocol.replace(":", "");
+  if (!SAFE_HTTP_PROTOCOLS.has(protocol)) {
+    throw new Error("NEXT_PUBLIC_BASE_URL must use http or https");
+  }
+
+  return normalizeBaseUrl(parsedBaseUrl.toString());
+}
+
+function parseAllowedHosts(): Set<string> {
+  const allowedHosts = new Set<string>();
+  const rawAllowedHosts = process.env.MCP_ALLOWED_HOSTS?.split(",") || [];
+
+  for (const host of rawAllowedHosts) {
+    const trimmedHost = host.trim();
+    if (trimmedHost.length === 0) continue;
+    allowedHosts.add(normalizeHostValue(trimmedHost));
+  }
+
+  return allowedHosts;
+}
+
+function isAllowlistedHost(host: string, allowedHosts: Set<string>): boolean {
+  const candidateUrl = new URL(`http://${host}`);
+
+  return Array.from(allowedHosts).some((allowedHost) => {
+    const allowedUrl = new URL(`http://${allowedHost}`);
+
+    if (allowedUrl.port) {
+      return allowedUrl.host === candidateUrl.host;
+    }
+
+    return allowedUrl.hostname.toLowerCase() === candidateUrl.hostname.toLowerCase();
+  });
+}
+
+function isPrivateIpv4Address(hostname: string): boolean {
+  const octets = hostname.split(".").map((part) => Number(part));
+  if (
+    octets.length !== 4 ||
+    octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+
+  const [firstOctet = -1, secondOctet = -1] = octets;
+
+  return (
+    firstOctet === 0 ||
+    firstOctet === 10 ||
+    firstOctet === 127 ||
+    (firstOctet === 192 && secondOctet === 168) ||
+    (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31)
+  );
+}
+
+function isDevelopmentHost(host: string): boolean {
+  const hostname = new URL(`http://${host}`).hostname.toLowerCase();
+
+  return (
+    hostname === "localhost" ||
+    hostname === "::1" ||
+    hostname === "[::1]" ||
+    isPrivateIpv4Address(hostname)
+  );
+}
+
+function resolveRequestProtocol(
+  req: Pick<NextApiRequest, "headers" | "socket">
+): "http" | "https" {
+  const forwardedProto = getFirstHeaderValue(
+    req.headers["x-forwarded-proto"]
+  )?.toLowerCase();
+  if (
+    forwardedProto &&
+    SAFE_HTTP_PROTOCOLS.has(forwardedProto)
+  ) {
+    return forwardedProto as "http" | "https";
+  }
+
+  return (req.socket as typeof req.socket & { encrypted?: boolean }).encrypted
+    ? "https"
+    : "http";
+}
+
+function escapeForSingleQuotedShell(value: string): string {
+  return value.replace(/'/g, `'\"'\"'`);
+}
+
+function stringifyCurlPayload(payload: Record<string, unknown>): string {
+  return escapeForSingleQuotedShell(JSON.stringify(payload));
+}
+
 function resolveBaseUrl(
   req: Pick<NextApiRequest, "headers" | "socket">
 ): string {
-  const configuredBaseUrl = process.env.NEXT_PUBLIC_BASE_URL?.trim();
+  const configuredBaseUrl = parseConfiguredBaseUrl();
   if (configuredBaseUrl) {
-    return normalizeBaseUrl(configuredBaseUrl);
+    return configuredBaseUrl;
   }
 
-  const forwardedProto = getFirstHeaderValue(req.headers["x-forwarded-proto"]);
-  const forwardedHost = getFirstHeaderValue(req.headers["x-forwarded-host"]);
-  const host = forwardedHost || getFirstHeaderValue(req.headers.host);
-  const protocol =
-    forwardedProto ||
-    ((req.socket as typeof req.socket & { encrypted?: boolean }).encrypted
-      ? "https"
-      : "http");
+  const requestHostHeader = getFirstHeaderValue(req.headers.host);
+  const requestHost = requestHostHeader
+    ? normalizeHostValue(requestHostHeader)
+    : undefined;
+  const forwardedHostHeader = getFirstHeaderValue(req.headers["x-forwarded-host"]);
+  const forwardedHost = forwardedHostHeader
+    ? normalizeHostValue(forwardedHostHeader)
+    : undefined;
+  const allowedHosts = parseAllowedHosts();
+  const isProduction = process.env.NODE_ENV === "production";
+  const candidateHosts = [forwardedHost, requestHost].filter(
+    (host, index, allHosts): host is string =>
+      typeof host === "string" && allHosts.indexOf(host) === index
+  );
+  const selectedHost = candidateHosts.find((host) => {
+    if (isAllowlistedHost(host, allowedHosts)) {
+      return true;
+    }
 
-  return `${protocol}://${host || "localhost:5000"}`;
+    return !isProduction && (host === requestHost || isDevelopmentHost(host));
+  });
+
+  if (!selectedHost) {
+    throw new Error(
+      "Unable to resolve a safe public MCP base URL. Set NEXT_PUBLIC_BASE_URL or allowlist hosts with MCP_ALLOWED_HOSTS."
+    );
+  }
+
+  return `${resolveRequestProtocol(req)}://${selectedHost}`;
 }
 
 function buildQuickStartExamples(
@@ -67,24 +197,52 @@ function buildQuickStartExamples(
   apiKey: string,
   agentName: string
 ) {
+  const initializePayload = stringifyCurlPayload({
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: {
+        name: agentName,
+        version: "1.0.0",
+      },
+    },
+    id: 1,
+  });
+  const listToolsPayload = stringifyCurlPayload({
+    jsonrpc: "2.0",
+    method: "tools/list",
+    id: 2,
+  });
+  const searchProductsPayload = stringifyCurlPayload({
+    jsonrpc: "2.0",
+    method: "tools/call",
+    params: {
+      name: "search_products",
+      arguments: {},
+    },
+    id: 3,
+  });
+
   return {
     curl_initialize: `curl -i -X POST ${baseUrl}/api/mcp \\
   -H "Authorization: Bearer ${apiKey}" \\
   -H "Accept: ${MCP_STREAMABLE_HTTP_ACCEPT}" \\
   -H "Content-Type: application/json" \\
-  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"${agentName}","version":"1.0.0"}},"id":1}'`,
+  -d '${initializePayload}'`,
     curl_list_tools: `curl -X POST ${baseUrl}/api/mcp \\
   -H "Authorization: Bearer ${apiKey}" \\
   -H "Accept: ${MCP_STREAMABLE_HTTP_ACCEPT}" \\
   -H "Content-Type: application/json" \\
   -H "Mcp-Session-Id: <session-id-from-initialize>" \\
-  -d '{"jsonrpc":"2.0","method":"tools/list","id":2}'`,
+  -d '${listToolsPayload}'`,
     curl_search: `curl -X POST ${baseUrl}/api/mcp \\
   -H "Authorization: Bearer ${apiKey}" \\
   -H "Accept: ${MCP_STREAMABLE_HTTP_ACCEPT}" \\
   -H "Content-Type: application/json" \\
   -H "Mcp-Session-Id: <session-id-from-initialize>" \\
-  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_products","arguments":{}},"id":3}'`,
+  -d '${searchProductsPayload}'`,
   };
 }
 


### PR DESCRIPTION
## Summary

This updates MCP onboarding so the generated connection details and quick-start examples match the current MCP HTTP flow more closely.

## What changed

- Updated [pages/api/mcp/onboard.ts](/c:/Users/gujja/SOB/shopstr/pages/api/mcp/onboard.ts) to resolve the onboarding base URL more safely:
  - prefer `NEXT_PUBLIC_BASE_URL` when configured
  - otherwise use `x-forwarded-proto` / `x-forwarded-host` when present
  - otherwise fall back to the local request protocol instead of hardcoding `https`

- Updated the generated onboarding quick-start examples to:
  - include `Accept: application/json, text/event-stream`
  - use `curl -i` for `initialize` so the `Mcp-Session-Id` response header is visible
  - add clearer guidance about reusing the returned session id

- Added focused regression coverage in [pages/api/mcp/__tests__/onboard.test.ts](/c:/Users/gujja/SOB/shopstr/pages/api/mcp/__tests__/onboard.test.ts) for:
  - local HTTP onboarding URLs
  - `NEXT_PUBLIC_BASE_URL` override with trailing-slash normalization
  - forwarded host/protocol handling
 
- Documented MCP onboarding setup requirements in [env.example](/c:/Users/gujja/SOB/shopstr/env.example), including `MCP_ENCRYPTION_KEY` and the optional `NEXT_PUBLIC_BASE_URL`

## Why

While testing MCP onboarding locally, the response was generating `https://localhost:5000/...` URLs even when the local server was running over plain HTTP. The quick-start examples also did not include the `Accept` header required by the current MCP endpoint, which made first-run manual testing more confusing than it needed to be.

This keeps the onboarding flow the same, but makes the generated response more accurate for local development and proxied deployments.

## Testing

- `npm test -- pages/api/mcp/__tests__/onboard.test.ts`
- `npm test -- utils/mcp/__tests__/auth.test.ts utils/mcp/__tests__/metrics.test.ts utils/mcp/__tests__/request-proof-server.test.ts`

## Notes

Manual smoke testing confirmed:
- onboarding returns the expected local `http://localhost:5000/...` MCP URLs
- MCP initialize still succeeds and returns a valid `Mcp-Session-Id`
- existing MCP auth / metrics / request-proof tests still pass
