### PR TITLE
Revalidate stored cart discounts before checkout

### DIFF
--- a/components/utility-components/checkout-card.tsx
+++ b/components/utility-components/checkout-card.tsx
@@ -48,7 +48,7 @@ import { RawEventModal, EventIdModal } from "./modals/event-modals";
 import { getLocalStorageJson } from "@/utils/safe-json";
 
 const SUMMARY_CHARACTER_LIMIT = 100;
-type CartDiscountsMap = Record<string, { code: string; percentage: number }>;
+type CartDiscountsMap = Record<string, { code: string }>;
 
 const isCartDiscountsMap = (value: unknown): value is CartDiscountsMap => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -60,11 +60,8 @@ const isCartDiscountsMap = (value: unknown): value is CartDiscountsMap => {
       return false;
     }
 
-    const candidate = entry as { code?: unknown; percentage?: unknown };
-    return (
-      typeof candidate.code === "string" &&
-      typeof candidate.percentage === "number"
-    );
+    const candidate = entry as { code?: unknown };
+    return typeof candidate.code === "string";
   });
 };
 
@@ -377,7 +374,6 @@ export default function CheckoutCard({
         );
         discounts[productData.pubkey] = {
           code: discountCode,
-          percentage: appliedDiscount,
         };
         localStorage.setItem("cartDiscounts", JSON.stringify(discounts));
       }

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -42,7 +42,7 @@ interface QuantitySelectorProps {
   max: number;
 }
 
-type CartDiscountsMap = Record<string, { code: string; percentage: number }>;
+type CartDiscountsMap = Record<string, { code: string }>;
 
 const isCartDiscountsMap = (value: unknown): value is CartDiscountsMap => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -54,11 +54,8 @@ const isCartDiscountsMap = (value: unknown): value is CartDiscountsMap => {
       return false;
     }
 
-    const candidate = entry as { code?: unknown; percentage?: unknown };
-    return (
-      typeof candidate.code === "string" &&
-      typeof candidate.percentage === "number"
-    );
+    const candidate = entry as { code?: unknown };
+    return typeof candidate.code === "string";
   });
 };
 
@@ -213,7 +210,13 @@ export default function Component() {
   }, []);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
+    let isCancelled = false;
+
+    const loadCart = async () => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
       const sfPk =
         sessionStorage.getItem("sf_seller_pubkey") ||
         localStorage.getItem("sf_seller_pubkey") ||
@@ -226,11 +229,13 @@ export default function Component() {
       let cartList = fullCart;
       if (sfPk) {
         const filtered = fullCart.filter((item) => item.pubkey === sfPk);
-        setExcludedItemCount(fullCart.length - filtered.length);
+        if (!isCancelled) {
+          setExcludedItemCount(fullCart.length - filtered.length);
+        }
         cartList = filtered;
       }
 
-      if (cartList && cartList.length > 0) {
+      if (!isCancelled && cartList.length > 0) {
         setProducts(cartList);
         for (const item of cartList as ProductData[]) {
           if (item.selectedQuantity) {
@@ -242,7 +247,6 @@ export default function Component() {
         }
       }
 
-      // Load saved discount codes
       const discounts = getLocalStorageJson<CartDiscountsMap>(
         "cartDiscounts",
         {},
@@ -252,25 +256,85 @@ export default function Component() {
           validate: isCartDiscountsMap,
         }
       );
-      if (Object.keys(discounts).length > 0) {
-        const codes: { [pubkey: string]: string } = {};
-        const applied: { [pubkey: string]: number } = {};
 
-        Object.entries(discounts).forEach(([pubkey, data]) => {
-          if (!data || typeof data !== "object") return;
-          const code = (data as { code?: unknown }).code;
-          const percentage = (data as { percentage?: unknown }).percentage;
-          if (typeof code !== "string" || typeof percentage !== "number") {
-            return;
-          }
-          codes[pubkey] = code;
-          applied[pubkey] = percentage;
-        });
-
-        setDiscountCodes(codes);
-        setAppliedDiscounts(applied);
+      if (Object.keys(discounts).length === 0) {
+        return;
       }
-    }
+
+      const validatedDiscounts = await Promise.all(
+        Object.entries(discounts).map(async ([pubkey, data]) => {
+          if (!data || typeof data !== "object") return null;
+
+          const code = (data as { code?: unknown }).code;
+          if (typeof code !== "string" || !code.trim()) return null;
+
+          try {
+            const response = await fetch(
+              `/api/db/discount-codes?validate=true&code=${encodeURIComponent(
+                code
+              )}&pubkey=${pubkey}`
+            );
+
+            if (!response.ok) {
+              return null;
+            }
+
+            const result = await response.json();
+            if (
+              result.valid &&
+              typeof result.discount_percentage === "number" &&
+              result.discount_percentage > 0
+            ) {
+              return {
+                pubkey,
+                code,
+                percentage: result.discount_percentage,
+              };
+            }
+          } catch (error) {
+            console.error("Failed to revalidate stored discount code:", error);
+          }
+
+          return null;
+        })
+      );
+
+      if (isCancelled) {
+        return;
+      }
+
+      const codes: { [pubkey: string]: string } = {};
+      const applied: { [pubkey: string]: number } = {};
+      const refreshedDiscounts: CartDiscountsMap = {};
+
+      validatedDiscounts.forEach((entry) => {
+        if (!entry) return;
+
+        codes[entry.pubkey] = entry.code;
+        applied[entry.pubkey] = entry.percentage;
+        refreshedDiscounts[entry.pubkey] = {
+          code: entry.code,
+        };
+      });
+
+      setDiscountCodes(codes);
+      setAppliedDiscounts(applied);
+
+      if (Object.keys(refreshedDiscounts).length > 0) {
+        localStorage.setItem(
+          "cartDiscounts",
+          JSON.stringify(refreshedDiscounts)
+        );
+      } else {
+        localStorage.removeItem("cartDiscounts");
+      }
+    };
+
+    loadCart();
+
+    return () => {
+      isCancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -421,7 +485,6 @@ export default function Component() {
         );
         discounts[pubkey] = {
           code: code,
-          percentage: result.discount_percentage,
         };
         localStorage.setItem("cartDiscounts", JSON.stringify(discounts));
       } else {


### PR DESCRIPTION
There is an issue here in the regular web cart checkout flow on current main.

Saved discounts are restored from localStorage on page load in (https://github.com/shopstr-eng/shopstr/blob/main/pages/cart/index.tsx#L245-L272), but that restore path only does a shape check that code is a string and percentage is a number in (https://github.com/shopstr-eng/shopstr/blob/main/pages/cart/index.tsx#L45-L60). it does not revalidate the stored discount against /api/db/discount-codes.

Those restored percentages are then used directly to recalculate discounted prices in (https://github.com/shopstr-eng/shopstr/blob/main/pages/cart/index.tsx#L283-L310), the resulting totals are passed into checkout in (https://github.com/shopstr-eng/shopstr/blob/main/pages/cart/index.tsx#L841-L855), and CartInvoiceCard then uses totalCost directly as the payment amount in (https://github.com/shopstr-eng/shopstr/blob/main/components/cart-invoice-card.tsx#L784-L790) and creates the payment quote from that amount in (https://github.com/shopstr-eng/shopstr/blob/main/components/cart-invoice-card.tsx#L971-L1007).

So the concern is that the restored localStorage discount is still trusted in the browser cart flow without server-side revalidation before payment.

Any user can edit localStorage in a browser with low effort; the path is directly in the public cart/checkout flow or a buyer can underpay by tampering with stored discount percentages, leading to direct revenue loss.