### PR TITLE
Fix asterisk placement and tooltip trigger in the password creation view

### DIFF
--- a/pages/onboarding/keys.tsx
+++ b/pages/onboarding/keys.tsx
@@ -102,7 +102,7 @@ const Keys = () => {
                 <h2 className="text-light-text dark:text-dark-text text-2xl font-bold">
                   Step 1: Account Creation
                 </h2>
-                <p className="text-light-text dark:text-dark-text">
+                <p className="text-light-text dark:text-dark-text text-sm">
                   Enter a passphrase to make sure your data is secured. You can
                   view your account information under your profile settings.
                 </p>
@@ -111,12 +111,11 @@ const Keys = () => {
               <div className="mb-6 flex flex-col space-y-2">
                 <div className="flex items-center gap-2">
                   <label className="text-light-text dark:text-dark-text text-xl font-bold">
-                    Passphrase:<span className="text-red-500">*</span>
+                    Passphrase<span className="text-red-500">*</span>
                   </label>
                   <Tooltip
                     content="This passphrase acts as a password and is used to keep your account secure. Remember it and keep it safe as it can't be recovered!"
                     placement="right"
-                    trigger="focus"
                     closeDelay={100}
                   >
                     <button


### PR DESCRIPTION
### Description
Basically removed the colon before asterisk. It makes it look nicer. 
Also removed the `trigger="focus"` bug so the tooltip gets triggered on hover.   

### Resolved or fixed issue
none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines