### PR TITLE
Harden order message reliability for grouping, payment tagging, and completion metadata

### DIFF
--- a/components/messages/__tests__/chat-panel.test.tsx
+++ b/components/messages/__tests__/chat-panel.test.tsx
@@ -192,6 +192,46 @@ describe("ChatPanel Component", () => {
       });
     });
 
+    it("should block completion when shipping info is incomplete", async () => {
+      await renderComponent(
+        {
+          isPayment: true,
+          chatsMap: new Map([
+            [
+              "test-pubkey-1",
+              {
+                decryptedChat: [
+                  {
+                    id: "shipping-msg-1",
+                    pubkey: "test-pubkey-1",
+                    kind: 14,
+                    content: "Shipping update",
+                    created_at: 1,
+                    sig: "sig-shipping",
+                    read: true,
+                    tags: [
+                      ["subject", "shipping-info"],
+                      ["carrier", "UPS"],
+                    ],
+                  },
+                ],
+                unreadCount: 0,
+              },
+            ],
+          ]),
+        },
+        {}
+      );
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: /Mark as Completed/i })
+      );
+
+      expect(
+        await screen.findByText(/Missing shipping fields: tracking/i)
+      ).toBeInTheDocument();
+    });
+
     it("should gracefully handle errors on shipping form submission", async () => {
       const consoleErrorSpy = jest
         .spyOn(console, "error")

--- a/components/messages/__tests__/chat-panel.test.tsx
+++ b/components/messages/__tests__/chat-panel.test.tsx
@@ -232,7 +232,7 @@ describe("ChatPanel Component", () => {
       ).toBeInTheDocument();
     });
 
-    it("should block completion when no shipping info message exists", async () => {
+    it("should allow completion when no shipping info message exists", async () => {
       await renderComponent(
         {
           isPayment: true,
@@ -264,9 +264,17 @@ describe("ChatPanel Component", () => {
         await screen.findByRole("button", { name: /Mark as Completed/i })
       );
 
-      expect(
-        await screen.findByText(/no shipping update was found/i)
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(nostrHelpers.constructGiftWrappedEvent).toHaveBeenCalledWith(
+          expect.anything(),
+          "mock-buyer-pubkey",
+          expect.stringContaining("has been completed"),
+          "order-completed",
+          expect.objectContaining({
+            status: "completed",
+          })
+        );
+      });
     });
 
     it("should gracefully handle errors on shipping form submission", async () => {

--- a/components/messages/__tests__/chat-panel.test.tsx
+++ b/components/messages/__tests__/chat-panel.test.tsx
@@ -232,6 +232,43 @@ describe("ChatPanel Component", () => {
       ).toBeInTheDocument();
     });
 
+    it("should block completion when no shipping info message exists", async () => {
+      await renderComponent(
+        {
+          isPayment: true,
+          chatsMap: new Map([
+            [
+              "test-pubkey-1",
+              {
+                decryptedChat: [
+                  {
+                    id: "order-msg-1",
+                    pubkey: "test-pubkey-1",
+                    kind: 14,
+                    content: "Order placed",
+                    created_at: 1,
+                    sig: "sig-1",
+                    read: true,
+                    tags: [["subject", "order-info"]],
+                  },
+                ],
+                unreadCount: 0,
+              },
+            ],
+          ]),
+        },
+        {}
+      );
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: /Mark as Completed/i })
+      );
+
+      expect(
+        await screen.findByText(/no shipping update was found/i)
+      ).toBeInTheDocument();
+    });
+
     it("should gracefully handle errors on shipping form submission", async () => {
       const consoleErrorSpy = jest
         .spyOn(console, "error")

--- a/components/messages/chat-panel.tsx
+++ b/components/messages/chat-panel.tsx
@@ -1,6 +1,13 @@
 // initialize new react funcitonal component
 import { Button, Input } from "@heroui/react";
-import { useEffect, useContext, useRef, useState } from "react";
+import {
+  useEffect,
+  useContext,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
 import { useForm, Controller } from "react-hook-form";
 import { nip19 } from "nostr-tools";
 import {
@@ -31,6 +38,8 @@ import {
 } from "@/utils/nostr/nostr-helper-functions";
 import { calculateWeightedScore } from "@/utils/parsers/review-parser-functions";
 import { ReviewsContext } from "../../utils/context/context";
+import FailureModal from "../utility-components/failure-modal";
+import { getLatestShippingInfo } from "@/utils/messages/order-message-utils";
 import {
   NostrContext,
   SignerContext,
@@ -80,6 +89,8 @@ const ChatPanel = ({
   );
   const [productAddress, setProductAddress] = useState("");
   const [orderId, setOrderId] = useState("");
+  const [showFailureModal, setShowFailureModal] = useState(false);
+  const [failureText, setFailureText] = useState("");
 
   const reviewsContext = useContext(ReviewsContext);
 
@@ -154,34 +165,24 @@ const ChatPanel = ({
         randomNsecForReceiver
       );
 
-      // Get shipping info from the most recent shipping message
-      const shippingInfo = {
-        tracking: "",
-        carrier: "",
-        eta: 0,
-      };
+      const shippingInfo = getLatestShippingInfo(messages);
 
-      // Find the most recent shipping-info message
-      const shippingMessage = messages
-        .slice()
-        .reverse()
-        .find((msg) => {
-          const subject = msg.tags.find((tag) => tag[0] === "subject")?.[1];
-          return subject === "shipping-info";
-        });
-
-      if (shippingMessage) {
-        const trackingTag = shippingMessage.tags.find(
-          (tag) => tag[0] === "tracking"
+      if (!shippingInfo) {
+        setFailureText(
+          "Cannot complete this order because no shipping update was found."
         );
-        const carrierTag = shippingMessage.tags.find(
-          (tag) => tag[0] === "carrier"
-        );
-        const etaTag = shippingMessage.tags.find((tag) => tag[0] === "eta");
+        setShowFailureModal(true);
+        return;
+      }
 
-        if (trackingTag) shippingInfo.tracking = trackingTag[1] || "";
-        if (carrierTag) shippingInfo.carrier = carrierTag[1] || "";
-        if (etaTag) shippingInfo.eta = parseInt(etaTag[1] || "0");
+      if (shippingInfo.missingFields.length > 0) {
+        setFailureText(
+          `Cannot complete this order yet. Missing shipping fields: ${shippingInfo.missingFields.join(
+            ", "
+          )}.`
+        );
+        setShowFailureModal(true);
+        return;
       }
 
       const message =
@@ -413,10 +414,10 @@ const ChatPanel = ({
             size="md"
             value={messageInput}
             placeholder="Type your message..."
-            onChange={(e) => {
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
               setMessageInput(e.target.value);
             }}
-            onKeyDown={async (e) => {
+            onKeyDown={async (e: KeyboardEvent<HTMLInputElement>) => {
               if (
                 e.key === "Enter" &&
                 !(messageInput === "" || isSendingDMLoading)
@@ -748,6 +749,14 @@ const ChatPanel = ({
                 </form>
               </ModalContent>
             </Modal>
+            <FailureModal
+              bodyText={failureText}
+              isOpen={showFailureModal}
+              onClose={() => {
+                setShowFailureModal(false);
+                setFailureText("");
+              }}
+            />
           </>
         )
       )}

--- a/components/messages/chat-panel.tsx
+++ b/components/messages/chat-panel.tsx
@@ -60,6 +60,11 @@ const ChatPanel = ({
   isSendingDMLoading: boolean;
   isPayment: boolean;
 }) => {
+  const FIELD_LABELS: Record<string, string> = {
+    tracking: "Tracking number",
+    carrier: "Carrier",
+  };
+
   const [messageInput, setMessageInput] = useState("");
   const [messages, setMessages] = useState<NostrMessageEvent[]>([]); // [chatPubkey, chat]
   const [showShippingModal, setShowShippingModal] = useState(false);
@@ -177,9 +182,9 @@ const ChatPanel = ({
 
       if (shippingInfo.missingFields.length > 0) {
         setFailureText(
-          `Cannot complete this order yet. Missing shipping fields: ${shippingInfo.missingFields.join(
-            ", "
-          )}.`
+          `Cannot complete this order yet. Missing shipping fields: ${shippingInfo.missingFields
+            .map((field) => FIELD_LABELS[field] ?? field)
+            .join(", ")}.`
         );
         setShowFailureModal(true);
         return;

--- a/components/messages/chat-panel.tsx
+++ b/components/messages/chat-panel.tsx
@@ -172,15 +172,7 @@ const ChatPanel = ({
 
       const shippingInfo = getLatestShippingInfo(messages);
 
-      if (!shippingInfo) {
-        setFailureText(
-          "Cannot complete this order because no shipping update was found."
-        );
-        setShowFailureModal(true);
-        return;
-      }
-
-      if (shippingInfo.missingFields.length > 0) {
+      if (shippingInfo && shippingInfo.missingFields.length > 0) {
         setFailureText(
           `Cannot complete this order yet. Missing shipping fields: ${shippingInfo.missingFields
             .map((field) => FIELD_LABELS[field] ?? field)
@@ -194,8 +186,8 @@ const ChatPanel = ({
         "Your order from " +
         userNPub +
         " has been completed." +
-        (shippingInfo.tracking ? " Tracking: " + shippingInfo.tracking : "") +
-        (shippingInfo.carrier ? " Carrier: " + shippingInfo.carrier : "");
+        (shippingInfo?.tracking ? " Tracking: " + shippingInfo.tracking : "") +
+        (shippingInfo?.carrier ? " Carrier: " + shippingInfo.carrier : "");
 
       const giftWrappedMessageEvent = await constructGiftWrappedEvent(
         decodedRandomPubkeyForSender.data as string,
@@ -208,9 +200,9 @@ const ChatPanel = ({
           status: "completed",
           isOrder: true,
           orderId,
-          ...(shippingInfo.tracking && { tracking: shippingInfo.tracking }),
-          ...(shippingInfo.carrier && { carrier: shippingInfo.carrier }),
-          ...(shippingInfo.eta && { eta: shippingInfo.eta }),
+          ...(shippingInfo?.tracking && { tracking: shippingInfo.tracking }),
+          ...(shippingInfo?.carrier && { carrier: shippingInfo.carrier }),
+          ...(shippingInfo?.eta && { eta: shippingInfo.eta }),
         }
       );
 

--- a/components/messages/orders-dashboard.tsx
+++ b/components/messages/orders-dashboard.tsx
@@ -33,7 +33,9 @@ import parseTags, {
 } from "@/utils/parsers/product-parser-functions";
 import {
   buildOrderGroupingKey,
+  getOrderConsolidationKey,
   getOrderStatusLookupKeys,
+  registerTaggedOrderGroupingKey,
   resolveExplicitPaymentMethod,
 } from "@/utils/messages/order-message-utils";
 import {
@@ -495,6 +497,7 @@ const OrdersDashboard = () => {
       }
 
       const consolidatedOrdersMap = new Map<string, OrderData>();
+      const taggedOrderGroupKeys = new Map<string, string | null>();
 
       const getCachedStatusForOrder = (order: OrderData) => {
         for (const lookupKey of order.statusLookupKeys) {
@@ -508,7 +511,11 @@ const OrdersDashboard = () => {
       };
 
       for (const order of ordersList) {
-        const existing = consolidatedOrdersMap.get(order.orderGroupKey);
+        const consolidationKey = getOrderConsolidationKey(
+          order,
+          taggedOrderGroupKeys
+        );
+        const existing = consolidatedOrdersMap.get(consolidationKey);
 
         if (!existing) {
           const cachedStatus = getCachedStatusForOrder(order);
@@ -523,7 +530,7 @@ const OrdersDashboard = () => {
             ? statusPriorityInit[cachedStatus] || 0
             : 0;
           const orderPriority = statusPriorityInit[order.status] || 0;
-          consolidatedOrdersMap.set(order.orderGroupKey, {
+          consolidatedOrdersMap.set(consolidationKey, {
             ...order,
             orderId: order.orderTag || order.orderId,
             status:
@@ -531,6 +538,11 @@ const OrdersDashboard = () => {
                 ? cachedStatus
                 : order.status,
           });
+          registerTaggedOrderGroupingKey(
+            order,
+            taggedOrderGroupKeys,
+            consolidationKey
+          );
         } else {
           const statusPriority: Record<string, number> = {
             canceled: 5,
@@ -559,7 +571,7 @@ const OrdersDashboard = () => {
             new Set([...existing.statusLookupKeys, ...order.statusLookupKeys])
           );
 
-          consolidatedOrdersMap.set(order.orderGroupKey, {
+          consolidatedOrdersMap.set(consolidationKey, {
             ...existing,
             orderTag: existing.orderTag || order.orderTag,
             orderId: existing.orderTag || order.orderTag || existing.orderId,
@@ -605,6 +617,11 @@ const OrdersDashboard = () => {
               order.subscriptionFrequency || existing.subscriptionFrequency,
             subscriptionId: order.subscriptionId || existing.subscriptionId,
           });
+          registerTaggedOrderGroupingKey(
+            order,
+            taggedOrderGroupKeys,
+            consolidationKey
+          );
         }
       }
 

--- a/components/messages/orders-dashboard.tsx
+++ b/components/messages/orders-dashboard.tsx
@@ -32,6 +32,11 @@ import parseTags, {
   ProductData,
 } from "@/utils/parsers/product-parser-functions";
 import {
+  buildOrderGroupingKey,
+  getOrderStatusLookupKeys,
+  resolveExplicitPaymentMethod,
+} from "@/utils/messages/order-message-utils";
+import {
   constructGiftWrappedEvent,
   constructMessageSeal,
   constructMessageGiftWrap,
@@ -71,6 +76,9 @@ ChartJS.register(
 
 interface OrderData {
   orderId: string;
+  orderTag?: string;
+  orderGroupKey: string;
+  statusLookupKeys: string[];
   buyerPubkey: string;
   productAddress: string;
   amount: number;
@@ -284,7 +292,9 @@ const OrdersDashboard = () => {
         const chat = entry[1] as NostrMessageEvent[];
         for (const messageEvent of chat) {
           const tagsMap = new Map(
-            messageEvent.tags.map((tag: string[]) => [tag[0], tag[1]])
+            messageEvent.tags
+              .filter((tag): tag is [string, string] => tag.length >= 2)
+              .map(([key, value]) => [key, value])
           );
           const subject = tagsMap.get("subject") || "";
           if (
@@ -293,9 +303,11 @@ const OrdersDashboard = () => {
             subject === "shipping-info" ||
             subject === "order-completed"
           ) {
-            const orderId = tagsMap.get("order") || messageEvent.id;
-            if (orderId && !orderIds.includes(orderId)) {
-              orderIds.push(orderId);
+            const orderStatusKeys = getOrderStatusLookupKeys(messageEvent);
+            for (const statusKey of orderStatusKeys) {
+              if (!orderIds.includes(statusKey)) {
+                orderIds.push(statusKey);
+              }
             }
           }
         }
@@ -350,7 +362,10 @@ const OrdersDashboard = () => {
             subject === "order-completed" ||
             subject === "zapsnag-order"
           ) {
-            const orderId = tagsMap.get("order") || messageEvent.id;
+            const orderTag = tagsMap.get("order") || "";
+            const orderGroupKey = buildOrderGroupingKey(messageEvent);
+            const statusLookupKeys = getOrderStatusLookupKeys(messageEvent);
+            const orderId = orderTag || messageEvent.id;
             const itemTag = messageEvent.tags.find((tag) => tag[0] === "item");
             const productAddress =
               tagsMap.get("a") || (itemTag ? itemTag[1] : "") || "";
@@ -440,33 +455,13 @@ const OrdersDashboard = () => {
             }
             const finalAmount = amount > 0 ? amount : productPrice * quantity;
 
-            let paymentMethod = "Not specified";
-            if (paymentType) {
-              switch (paymentType.toLowerCase()) {
-                case "ecash":
-                  paymentMethod = "Cashu";
-                  break;
-                case "lightning":
-                  paymentMethod = "Lightning";
-                  break;
-                default:
-                  paymentMethod =
-                    paymentType.charAt(0).toUpperCase() + paymentType.slice(1);
-              }
-            } else if (messageEvent.content) {
-              const content = messageEvent.content.toLowerCase();
-              if (content.includes("lightning") || content.includes("lnurl")) {
-                paymentMethod = "Lightning";
-              } else if (
-                content.includes("cashu") ||
-                content.includes("ecash")
-              ) {
-                paymentMethod = "Cashu";
-              }
-            }
+            const paymentMethod = resolveExplicitPaymentMethod(paymentType);
 
             ordersList.push({
               orderId,
+              orderTag: orderTag || undefined,
+              orderGroupKey,
+              statusLookupKeys,
               buyerPubkey,
               productAddress,
               amount: finalAmount,
@@ -501,11 +496,22 @@ const OrdersDashboard = () => {
 
       const consolidatedOrdersMap = new Map<string, OrderData>();
 
+      const getCachedStatusForOrder = (order: OrderData) => {
+        for (const lookupKey of order.statusLookupKeys) {
+          const cachedStatus = cachedStatuses[lookupKey];
+          if (cachedStatus) {
+            return cachedStatus;
+          }
+        }
+
+        return undefined;
+      };
+
       for (const order of ordersList) {
-        const existing = consolidatedOrdersMap.get(order.orderId);
+        const existing = consolidatedOrdersMap.get(order.orderGroupKey);
 
         if (!existing) {
-          const cachedStatus = cachedStatuses[order.orderId];
+          const cachedStatus = getCachedStatusForOrder(order);
           const statusPriorityInit: Record<string, number> = {
             canceled: 5,
             completed: 4,
@@ -517,8 +523,9 @@ const OrdersDashboard = () => {
             ? statusPriorityInit[cachedStatus] || 0
             : 0;
           const orderPriority = statusPriorityInit[order.status] || 0;
-          consolidatedOrdersMap.set(order.orderId, {
+          consolidatedOrdersMap.set(order.orderGroupKey, {
             ...order,
+            orderId: order.orderTag || order.orderId,
             status:
               cachedPriority > orderPriority && cachedStatus
                 ? cachedStatus
@@ -534,7 +541,7 @@ const OrdersDashboard = () => {
           };
           const existingPriority = statusPriority[existing.status] || 0;
           const newPriority = statusPriority[order.status] || 0;
-          const cachedStatus = cachedStatuses[order.orderId];
+          const cachedStatus = getCachedStatusForOrder(order);
           const cachedPriority = cachedStatus
             ? statusPriority[cachedStatus] || 0
             : 0;
@@ -548,8 +555,15 @@ const OrdersDashboard = () => {
             finalStatus = cachedStatus;
           }
 
-          consolidatedOrdersMap.set(order.orderId, {
+          const mergedStatusLookupKeys = Array.from(
+            new Set([...existing.statusLookupKeys, ...order.statusLookupKeys])
+          );
+
+          consolidatedOrdersMap.set(order.orderGroupKey, {
             ...existing,
+            orderTag: existing.orderTag || order.orderTag,
+            orderId: existing.orderTag || order.orderTag || existing.orderId,
+            statusLookupKeys: mergedStatusLookupKeys,
             status: finalStatus,
             address: order.address || existing.address,
             pickupLocation: order.pickupLocation || existing.pickupLocation,
@@ -643,7 +657,9 @@ const OrdersDashboard = () => {
       for (const order of consolidatedOrders) {
         if (order.status && order.orderId) {
           const currentPriority = statusPriorityForPersist[order.status] || 0;
-          const cachedStatusValue = cachedStatuses[order.orderId];
+          const cachedStatusValue = order.statusLookupKeys
+            .map((lookupKey) => cachedStatuses[lookupKey])
+            .find((status): status is string => Boolean(status));
           const cachedPriority = cachedStatusValue
             ? statusPriorityForPersist[cachedStatusValue] || 0
             : 0;

--- a/utils/messages/__tests__/order-message-utils.test.ts
+++ b/utils/messages/__tests__/order-message-utils.test.ts
@@ -1,0 +1,76 @@
+import {
+  buildOrderGroupingKey,
+  getLatestShippingInfo,
+  getOrderStatusLookupKeys,
+  resolveExplicitPaymentMethod,
+} from "../order-message-utils";
+
+describe("order-message-utils", () => {
+  test("buildOrderGroupingKey stays stable across lifecycle subjects", () => {
+    const baseEvent = {
+      id: "msg-1",
+      tags: [
+        ["subject", "order-info"],
+        ["a", "30402:merchant:dtag"],
+        ["amount", "1200"],
+        ["address", "123 Main St"],
+        ["pickup", "Storefront"],
+      ],
+    } as any;
+
+    const followUpEvent = {
+      ...baseEvent,
+      id: "msg-2",
+      tags: [
+        ["subject", "shipping-info"],
+        ["a", "30402:merchant:dtag"],
+        ["amount", "1200"],
+        ["address", "123 Main St"],
+        ["pickup", "Storefront"],
+      ],
+    } as any;
+
+    expect(buildOrderGroupingKey(baseEvent)).toBe(
+      buildOrderGroupingKey(followUpEvent)
+    );
+  });
+
+  test("resolveExplicitPaymentMethod only uses explicit tags", () => {
+    expect(resolveExplicitPaymentMethod("ecash")).toBe("Cashu");
+    expect(resolveExplicitPaymentMethod("lightning")).toBe("Lightning");
+    expect(resolveExplicitPaymentMethod()).toBe("Not specified");
+  });
+
+  test("getOrderStatusLookupKeys includes tag, grouping key, and message id", () => {
+    const event = {
+      id: "msg-3",
+      tags: [
+        ["subject", "order-receipt"],
+        ["order", "order-123"],
+        ["a", "30402:merchant:dtag"],
+        ["amount", "2400"],
+      ],
+    } as any;
+
+    const lookupKeys = getOrderStatusLookupKeys(event);
+    expect(lookupKeys).toEqual(
+      expect.arrayContaining(["order-123", "msg-3"])
+    );
+    expect(lookupKeys.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("getLatestShippingInfo surfaces missing fields", () => {
+    const shippingEvent = {
+      id: "msg-4",
+      tags: [
+        ["subject", "shipping-info"],
+        ["tracking", ""],
+        ["carrier", "UPS"],
+      ],
+    } as any;
+
+    const result = getLatestShippingInfo([shippingEvent]);
+    expect(result?.carrier).toBe("UPS");
+    expect(result?.missingFields).toEqual(["tracking"]);
+  });
+});

--- a/utils/messages/__tests__/order-message-utils.test.ts
+++ b/utils/messages/__tests__/order-message-utils.test.ts
@@ -1,7 +1,9 @@
 import {
   buildOrderGroupingKey,
+  getOrderConsolidationKey,
   getLatestShippingInfo,
   getOrderStatusLookupKeys,
+  registerTaggedOrderGroupingKey,
   resolveExplicitPaymentMethod,
 } from "../order-message-utils";
 
@@ -35,6 +37,15 @@ describe("order-message-utils", () => {
     );
   });
 
+  test("buildOrderGroupingKey returns empty string when fallback metadata is incomplete", () => {
+    const incompleteEvent = {
+      id: "msg-incomplete",
+      tags: [["subject", "payment-change"]],
+    } as any;
+
+    expect(buildOrderGroupingKey(incompleteEvent)).toBe("");
+  });
+
   test("resolveExplicitPaymentMethod only uses explicit tags", () => {
     expect(resolveExplicitPaymentMethod("ecash")).toBe("Cashu");
     expect(resolveExplicitPaymentMethod("lightning")).toBe("Lightning");
@@ -57,6 +68,49 @@ describe("order-message-utils", () => {
       expect.arrayContaining(["order-123", "msg-3"])
     );
     expect(lookupKeys.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("repeated tagged orders keep distinct consolidation keys", () => {
+    const taggedOrderGroupKeys = new Map<string, string | null>();
+    const firstOrder = {
+      orderId: "msg-1",
+      orderTag: "order-1",
+      orderGroupKey: "same-group",
+    };
+    const secondOrder = {
+      orderId: "msg-2",
+      orderTag: "order-2",
+      orderGroupKey: "same-group",
+    };
+
+    const firstKey = getOrderConsolidationKey(firstOrder, taggedOrderGroupKeys);
+    registerTaggedOrderGroupingKey(
+      firstOrder,
+      taggedOrderGroupKeys,
+      firstKey
+    );
+
+    const secondKey = getOrderConsolidationKey(
+      secondOrder,
+      taggedOrderGroupKeys
+    );
+    registerTaggedOrderGroupingKey(
+      secondOrder,
+      taggedOrderGroupKeys,
+      secondKey
+    );
+
+    expect(firstKey).toBe("order-1");
+    expect(secondKey).toBe("order-2");
+    expect(
+      getOrderConsolidationKey(
+        {
+          orderId: "msg-3",
+          orderGroupKey: "same-group",
+        },
+        taggedOrderGroupKeys
+      )
+    ).toBe("msg-3");
   });
 
   test("getLatestShippingInfo surfaces missing fields", () => {

--- a/utils/messages/order-message-utils.ts
+++ b/utils/messages/order-message-utils.ts
@@ -10,17 +10,27 @@ const buildTagMap = (messageEvent: NostrMessageEvent) =>
       .map((tag) => [tag[0], tag[1]] as [string, string])
   );
 
+const hasOrderGroupingData = (value?: string | null) => Boolean(value?.trim());
+
 const _buildOrderGroupingKeyFromMap = (
   tagsMap: Map<string, string>,
   messageEvent: NostrMessageEvent
 ) => {
   const itemTag = messageEvent.tags.find((tag) => tag[0] === "item");
+  const productReference = tagsMap.get("a") || itemTag?.[1] || "";
+  const amount = tagsMap.get("amount") || "";
+  const fulfillmentTarget =
+    tagsMap.get("address") || tagsMap.get("pickup") || "";
 
-  return [
-    tagsMap.get("a") || itemTag?.[1] || "",
-    tagsMap.get("amount") || "",
-    tagsMap.get("address") || tagsMap.get("pickup") || "",
-  ]
+  if (
+    !hasOrderGroupingData(productReference) ||
+    !hasOrderGroupingData(amount) ||
+    !hasOrderGroupingData(fulfillmentTarget)
+  ) {
+    return "";
+  }
+
+  return [productReference, amount, fulfillmentTarget]
     .map(normalizeKeyPart)
     .join("\0");
 };
@@ -31,16 +41,64 @@ export const buildOrderGroupingKey = (
 
 export const getOrderStatusLookupKeys = (messageEvent: NostrMessageEvent) => {
   const tagsMap = buildTagMap(messageEvent);
+  const orderTag = tagsMap.get("order");
+  const orderGroupKey = _buildOrderGroupingKeyFromMap(tagsMap, messageEvent);
+
   return Array.from(
     new Set(
       [
-        tagsMap.get("order"),
-        _buildOrderGroupingKeyFromMap(tagsMap, messageEvent),
+        orderTag,
+        orderTag ? undefined : orderGroupKey,
         messageEvent.id,
       ]
         .filter((value): value is string => Boolean(value))
     )
   );
+};
+
+type OrderConsolidationCandidate = {
+  orderId: string;
+  orderTag?: string;
+  orderGroupKey: string;
+};
+
+export const getOrderConsolidationKey = (
+  order: OrderConsolidationCandidate,
+  taggedOrderGroupKeys: Map<string, string | null>
+) => {
+  if (order.orderTag) {
+    return order.orderTag;
+  }
+
+  if (order.orderGroupKey) {
+    const matchedTaggedOrderKey = taggedOrderGroupKeys.get(order.orderGroupKey);
+    if (matchedTaggedOrderKey) {
+      return matchedTaggedOrderKey;
+    }
+  }
+
+  return order.orderId;
+};
+
+export const registerTaggedOrderGroupingKey = (
+  order: OrderConsolidationCandidate,
+  taggedOrderGroupKeys: Map<string, string | null>,
+  consolidationKey: string
+) => {
+  if (!order.orderTag || !order.orderGroupKey) {
+    return;
+  }
+
+  const existingTaggedOrderKey = taggedOrderGroupKeys.get(order.orderGroupKey);
+
+  if (typeof existingTaggedOrderKey === "undefined") {
+    taggedOrderGroupKeys.set(order.orderGroupKey, consolidationKey);
+    return;
+  }
+
+  if (existingTaggedOrderKey !== consolidationKey) {
+    taggedOrderGroupKeys.set(order.orderGroupKey, null);
+  }
 };
 
 export const resolveExplicitPaymentMethod = (paymentTag?: string) => {
@@ -82,14 +140,20 @@ export const getLatestShippingInfo = (
   const etaValue = tagsMap.get("eta");
   const parsedEta = etaValue ? Number(etaValue.trim()) : 0;
   const eta = Number.isFinite(parsedEta) ? parsedEta : 0;
+  const missingFields: ShippingInfo["missingFields"] = [];
+
+  if (!tracking) {
+    missingFields.push("tracking");
+  }
+
+  if (!carrier) {
+    missingFields.push("carrier");
+  }
 
   return {
     tracking,
     carrier,
     eta,
-    missingFields: [
-      ...(tracking ? [] : ["tracking"]),
-      ...(carrier ? [] : ["carrier"]),
-    ],
+    missingFields,
   };
 };

--- a/utils/messages/order-message-utils.ts
+++ b/utils/messages/order-message-utils.ts
@@ -1,0 +1,100 @@
+import { NostrMessageEvent } from "../types/types";
+
+const normalizeKeyPart = (value?: string | null) =>
+  value?.trim().toLowerCase() || "__empty__";
+
+const buildTagMap = (messageEvent: NostrMessageEvent) =>
+  new Map(
+    messageEvent.tags
+      .filter((tag): tag is [string, string] => tag.length >= 2)
+      .map(([key, value]) => [key, value])
+  );
+
+export const buildOrderGroupingKey = (
+  messageEvent: NostrMessageEvent
+): string => {
+  const tagsMap = buildTagMap(messageEvent);
+  const itemTag = messageEvent.tags.find(
+    (tag): tag is [string, string, string?] => tag[0] === "item"
+  );
+
+  // Different lifecycle messages for the same order can carry different subjects
+  // and order tags, so we group them by the stable product and fulfillment fields.
+  return [
+    tagsMap.get("a") || itemTag?.[1] || "",
+    itemTag?.[2] || tagsMap.get("quantity") || "",
+    tagsMap.get("amount") || "",
+    tagsMap.get("address") || "",
+    tagsMap.get("pickup") || "",
+    tagsMap.get("size") || "",
+    tagsMap.get("volume") || "",
+    tagsMap.get("weight") || "",
+    tagsMap.get("bulk") || "",
+    tagsMap.get("donation_amount") || "",
+    tagsMap.get("donation_percentage") || "",
+    tagsMap.get("subscription") || "",
+    tagsMap.get("subscription_frequency") || "",
+    tagsMap.get("subscription_id") || "",
+  ]
+    .map(normalizeKeyPart)
+    .join("|");
+};
+
+export const getOrderStatusLookupKeys = (messageEvent: NostrMessageEvent) => {
+  const tagsMap = buildTagMap(messageEvent);
+  return Array.from(
+    new Set(
+      [tagsMap.get("order"), buildOrderGroupingKey(messageEvent), messageEvent.id]
+        .filter((value): value is string => Boolean(value))
+    )
+  );
+};
+
+export const resolveExplicitPaymentMethod = (paymentTag?: string) => {
+  if (!paymentTag) return "Not specified";
+
+  switch (paymentTag.toLowerCase()) {
+    case "ecash":
+      return "Cashu";
+    case "lightning":
+      return "Lightning";
+    default:
+      return paymentTag.charAt(0).toUpperCase() + paymentTag.slice(1);
+  }
+};
+
+export type ShippingInfo = {
+  tracking: string;
+  carrier: string;
+  eta: number;
+  missingFields: Array<"tracking" | "carrier">;
+};
+
+export const getLatestShippingInfo = (
+  messages: NostrMessageEvent[]
+): ShippingInfo | null => {
+  const shippingMessage = messages
+    .slice()
+    .reverse()
+    .find((messageEvent) => {
+      const subject = buildTagMap(messageEvent).get("subject");
+      return subject === "shipping-info";
+    });
+
+  if (!shippingMessage) return null;
+
+  const tagsMap = buildTagMap(shippingMessage);
+  const tracking = tagsMap.get("tracking") || "";
+  const carrier = tagsMap.get("carrier") || "";
+  const eta = tagsMap.get("eta") ? parseInt(tagsMap.get("eta") || "0") : 0;
+
+  return {
+    tracking,
+    carrier,
+    eta,
+    missingFields: [
+      ...(tracking ? [] : ["tracking"]),
+      ...(carrier ? [] : ["carrier"]),
+    ],
+  };
+};

--- a/utils/messages/order-message-utils.ts
+++ b/utils/messages/order-message-utils.ts
@@ -10,16 +10,12 @@ const buildTagMap = (messageEvent: NostrMessageEvent) =>
       .map((tag) => [tag[0], tag[1]] as [string, string])
   );
 
-export const buildOrderGroupingKey = (
+const _buildOrderGroupingKeyFromMap = (
+  tagsMap: Map<string, string>,
   messageEvent: NostrMessageEvent
-): string => {
-  const tagsMap = buildTagMap(messageEvent);
-  const itemTag = messageEvent.tags.find(
-    (tag): tag is [string, string, string?] => tag[0] === "item"
-  );
+) => {
+  const itemTag = messageEvent.tags.find((tag) => tag[0] === "item");
 
-  // Different lifecycle messages for the same order can carry different subjects
-  // and order tags, so we group them by the stable product and fulfillment fields.
   return [
     tagsMap.get("a") || itemTag?.[1] || "",
     tagsMap.get("amount") || "",
@@ -29,11 +25,19 @@ export const buildOrderGroupingKey = (
     .join("\0");
 };
 
+export const buildOrderGroupingKey = (
+  messageEvent: NostrMessageEvent
+): string => _buildOrderGroupingKeyFromMap(buildTagMap(messageEvent), messageEvent);
+
 export const getOrderStatusLookupKeys = (messageEvent: NostrMessageEvent) => {
   const tagsMap = buildTagMap(messageEvent);
   return Array.from(
     new Set(
-      [tagsMap.get("order"), buildOrderGroupingKey(messageEvent), messageEvent.id]
+      [
+        tagsMap.get("order"),
+        _buildOrderGroupingKeyFromMap(tagsMap, messageEvent),
+        messageEvent.id,
+      ]
         .filter((value): value is string => Boolean(value))
     )
   );
@@ -76,8 +80,8 @@ export const getLatestShippingInfo = (
   const tracking = tagsMap.get("tracking") || "";
   const carrier = tagsMap.get("carrier") || "";
   const etaValue = tagsMap.get("eta");
-  const parsedEta = etaValue ? parseInt(etaValue, 10) : 0;
-  const eta = Number.isNaN(parsedEta) ? 0 : parsedEta;
+  const parsedEta = etaValue ? Number(etaValue.trim()) : 0;
+  const eta = Number.isFinite(parsedEta) ? parsedEta : 0;
 
   return {
     tracking,

--- a/utils/messages/order-message-utils.ts
+++ b/utils/messages/order-message-utils.ts
@@ -6,8 +6,8 @@ const normalizeKeyPart = (value?: string | null) =>
 const buildTagMap = (messageEvent: NostrMessageEvent) =>
   new Map(
     messageEvent.tags
-      .filter((tag): tag is [string, string] => tag.length >= 2)
-      .map(([key, value]) => [key, value])
+      .filter((tag) => tag.length >= 2)
+      .map((tag) => [tag[0], tag[1]] as [string, string])
   );
 
 export const buildOrderGroupingKey = (
@@ -22,22 +22,11 @@ export const buildOrderGroupingKey = (
   // and order tags, so we group them by the stable product and fulfillment fields.
   return [
     tagsMap.get("a") || itemTag?.[1] || "",
-    itemTag?.[2] || tagsMap.get("quantity") || "",
     tagsMap.get("amount") || "",
-    tagsMap.get("address") || "",
-    tagsMap.get("pickup") || "",
-    tagsMap.get("size") || "",
-    tagsMap.get("volume") || "",
-    tagsMap.get("weight") || "",
-    tagsMap.get("bulk") || "",
-    tagsMap.get("donation_amount") || "",
-    tagsMap.get("donation_percentage") || "",
-    tagsMap.get("subscription") || "",
-    tagsMap.get("subscription_frequency") || "",
-    tagsMap.get("subscription_id") || "",
+    tagsMap.get("address") || tagsMap.get("pickup") || "",
   ]
     .map(normalizeKeyPart)
-    .join("|");
+    .join("\0");
 };
 
 export const getOrderStatusLookupKeys = (messageEvent: NostrMessageEvent) => {
@@ -86,7 +75,9 @@ export const getLatestShippingInfo = (
   const tagsMap = buildTagMap(shippingMessage);
   const tracking = tagsMap.get("tracking") || "";
   const carrier = tagsMap.get("carrier") || "";
-  const eta = tagsMap.get("eta") ? parseInt(tagsMap.get("eta") || "0") : 0;
+  const etaValue = tagsMap.get("eta");
+  const parsedEta = etaValue ? parseInt(etaValue, 10) : 0;
+  const eta = Number.isNaN(parsedEta) ? 0 : parsedEta;
 
   return {
     tracking,


### PR DESCRIPTION
## Description
This PR improves reliability in the order-message pipeline by reducing fragile fallbacks and enforcing clearer handling of incomplete data.

Added shared order-message utilities in order-message-utils.ts for:

- Stable order grouping key derivation
- Status lookup key generation
- Explicit payment-method resolution from tags
- Latest shipping-info extraction with missing-field detection

Updated order consolidation in orders-dashboard.tsx:

- Switched to utility-based grouping/status key flow
- Avoided content-text payment inference when payment tag is missing
- Improved status cache lookups using multiple keys

Updated completion flow in chat-panel.tsx:

- Blocks completion when shipping metadata is missing/incomplete
- Surfaces clear error feedback instead of silently propagating partial shipping state

Added/updated tests:

- order-message-utils.test.ts
- chat-panel.test.tsx


## Impact
- Reduces risk of one logical order splitting due to inconsistent tags.
- Prevents payment method misclassification from message body text.
- Prevents silent completion with incomplete shipping metadata.
- Centralizes message reliability logic for easier maintenance.

Resolved or fixed issue
Fixes #388