### PR TITLE
Fix : Product card dropdown click isolation on marketplace (prevent unintended listing navigation)

### DIFF
--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -250,7 +250,10 @@ const DisplayProducts = ({
     return `/listing/${product.id}`;
   };
 
-  const onProductClick = (product: ProductData, e?: React.MouseEvent) => {
+  const onProductClick = (
+    product: ProductData,
+    e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+  ) => {
     setFocusedProduct(product);
     if (product.pubkey === userPubkey) {
       e?.preventDefault();

--- a/components/utility-components/__tests__/product-card.test.tsx
+++ b/components/utility-components/__tests__/product-card.test.tsx
@@ -7,6 +7,7 @@ import { ProductData } from "@/utils/parsers/product-parser-functions";
 
 const mockRouter = {
   pathname: "/product-page",
+  push: jest.fn(),
 };
 jest.mock("next/router", () => ({
   useRouter: () => mockRouter,
@@ -18,7 +19,9 @@ jest.mock("../profile/profile-dropdown", () => ({
       data-testid="profile-dropdown"
       data-pubkey={props.pubkey}
       data-keys={JSON.stringify(props.dropDownKeys)}
-    ></div>
+    >
+      <button data-testid="profile-dropdown-trigger">Seller</button>
+    </div>
   ),
 }));
 jest.mock(
@@ -77,6 +80,10 @@ const renderWithContext = (
 };
 
 describe("ProductCard", () => {
+  beforeEach(() => {
+    mockRouter.push.mockClear();
+  });
+
   it("returns null if no productData is provided", () => {
     // @ts-expect-error: Intentionally passing null to test component's null-handling
     const { container } = render(<ProductCard productData={null} />);
@@ -105,6 +112,40 @@ describe("ProductCard", () => {
         mockProductData,
         expect.any(Object)
       );
+    });
+
+    it("navigates via router.push when href is provided", () => {
+      renderWithContext(
+        <ProductCard productData={mockProductData} href="/listing/test-slug" />
+      );
+
+      fireEvent.click(screen.getByTestId("image-carousel").parentElement!);
+      expect(mockRouter.push).toHaveBeenCalledWith("/listing/test-slug");
+    });
+
+    it("does not navigate when clicking seller dropdown area", () => {
+      renderWithContext(
+        <ProductCard productData={mockProductData} href="/listing/test-slug" />
+      );
+
+      fireEvent.click(screen.getByTestId("profile-dropdown-trigger"));
+      expect(mockRouter.push).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate if onProductClick prevents default", () => {
+      const onProductClick = jest.fn((_product, event) => event?.preventDefault());
+
+      renderWithContext(
+        <ProductCard
+          productData={mockProductData}
+          href="/listing/test-slug"
+          onProductClick={onProductClick}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId("image-carousel").parentElement!);
+      expect(onProductClick).toHaveBeenCalled();
+      expect(mockRouter.push).not.toHaveBeenCalled();
     });
 
     it('shows "shop_profile" dropdown key for the owner', () => {

--- a/components/utility-components/__tests__/product-card.test.tsx
+++ b/components/utility-components/__tests__/product-card.test.tsx
@@ -66,6 +66,12 @@ const mockProductData: ProductData = {
   totalCost: 1000,
 };
 
+const mockSellerZapsnagProduct: ProductData = {
+  ...mockProductData,
+  d: "zapsnag",
+  categories: ["zapsnag"],
+};
+
 const renderWithContext = (
   ui: React.ReactElement,
   userPubkey: string | null = null
@@ -123,6 +129,15 @@ describe("ProductCard", () => {
       expect(mockRouter.push).toHaveBeenCalledWith("/listing/test-slug");
     });
 
+    it("navigates when pressing Enter on the linked card itself", () => {
+      renderWithContext(
+        <ProductCard productData={mockProductData} href="/listing/test-slug" />
+      );
+
+      fireEvent.keyDown(screen.getByRole("link"), { key: "Enter" });
+      expect(mockRouter.push).toHaveBeenCalledWith("/listing/test-slug");
+    });
+
     it("does not navigate when clicking seller dropdown area", () => {
       renderWithContext(
         <ProductCard productData={mockProductData} href="/listing/test-slug" />
@@ -145,6 +160,25 @@ describe("ProductCard", () => {
 
       fireEvent.click(screen.getByTestId("image-carousel").parentElement!);
       expect(onProductClick).toHaveBeenCalled();
+      expect(mockRouter.push).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate when pressing Enter on nested controls inside a linked seller card", () => {
+      renderWithContext(
+        <ProductCard
+          productData={mockSellerZapsnagProduct}
+          href="/listing/test-slug"
+        />,
+        "owner_pubkey"
+      );
+
+      fireEvent.keyDown(
+        screen.getByRole("button", {
+          name: /open flash sale in nostr client/i,
+        }),
+        { key: "Enter" }
+      );
+
       expect(mockRouter.push).not.toHaveBeenCalled();
     });
 

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -28,7 +28,10 @@ export default function ProductCard({
   href,
 }: {
   productData: ProductData;
-  onProductClick?: (productId: ProductData, e?: React.MouseEvent) => void;
+  onProductClick?: (
+    productId: ProductData,
+    e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+  ) => void;
   href?: string | null;
 }) {
   const [showRawEventModal, setShowRawEventModal] = useState(false);
@@ -62,22 +65,20 @@ export default function ProductCard({
     return Boolean(isCarouselControl || isDropdown || isProfileDropdown);
   };
 
-  const openHrefInNewTab = () => {
-    if (!href) return;
-    window.open(href, "_blank", "noopener,noreferrer");
+  const getElementTarget = (target: EventTarget | null): Element | null => {
+    return target instanceof Element ? target : null;
   };
 
-  const handleCardClick = (e: React.MouseEvent) => {
-    const target = e.target as Element;
+  const navigateToHref = () => {
+    if (!href) return;
+    void router.push(href);
+  };
+
+  const handleCardClick = (e: React.MouseEvent<HTMLElement>) => {
+    const target = getElementTarget(e.target);
     if (shouldBlockCardNavigation(target)) {
       e.preventDefault();
       e.stopPropagation();
-      return;
-    }
-
-    if (href && (e.metaKey || e.ctrlKey)) {
-      e.preventDefault();
-      openHrefInNewTab();
       return;
     }
 
@@ -89,16 +90,25 @@ export default function ProductCard({
     }
 
     if (href) {
-      void router.push(href);
+      // Keep native link behavior for modified clicks/new tabs.
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+      e.preventDefault();
+      navigateToHref();
     }
   };
 
-  const handleCardAuxClick = (e: React.MouseEvent) => {
-    if (e.button !== 1) {
-      return;
+  const handleCardClickCapture = (e: React.MouseEvent<HTMLElement>) => {
+    const target = getElementTarget(e.target);
+    if (shouldBlockCardNavigation(target)) {
+      // Cancel link default early; allow nested controls to handle the click.
+      e.preventDefault();
     }
+  };
 
-    const target = e.target as Element;
+  const handleCardKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    const target = getElementTarget(e.target);
     if (shouldBlockCardNavigation(target)) {
       e.preventDefault();
       e.stopPropagation();
@@ -106,34 +116,30 @@ export default function ProductCard({
     }
 
     if (href) {
-      e.preventDefault();
-      openHrefInNewTab();
-    }
-  };
+      // Link semantics: activate with Enter only.
+      if (e.key !== "Enter") {
+        return;
+      }
 
-  const handleCardKeyDown = (e: React.KeyboardEvent) => {
+      e.preventDefault();
+      if (onProductClick) {
+        onProductClick(productData, e);
+        if (e.defaultPrevented) {
+          return;
+        }
+      }
+      navigateToHref();
+      return;
+    }
+
+    // Button semantics for non-link interactive cards.
     if (e.key !== "Enter" && e.key !== " ") {
       return;
     }
 
-    const target = e.target as Element;
-    if (shouldBlockCardNavigation(target)) {
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
-
     e.preventDefault();
-
     if (onProductClick) {
-      onProductClick(productData);
-      if (e.defaultPrevented) {
-        return;
-      }
-    }
-
-    if (href) {
-      void router.push(href);
+      onProductClick(productData, e);
     }
   };
 
@@ -159,15 +165,8 @@ export default function ProductCard({
     }
   };
 
-  const content = (
-    <div
-      className={isCardInteractive ? "cursor-pointer" : ""}
-      onClick={isCardInteractive ? handleCardClick : undefined}
-      onAuxClick={href ? handleCardAuxClick : undefined}
-      onKeyDown={isCardInteractive ? handleCardKeyDown : undefined}
-      role={isCardInteractive ? "link" : undefined}
-      tabIndex={isCardInteractive ? 0 : undefined}
-    >
+  const contentBody = (
+    <>
       <div>
         <ImageCarousel
           images={productData.images}
@@ -251,7 +250,6 @@ export default function ProductCard({
           className="mb-3"
           data-profile-dropdown
           onClick={(e) => {
-            e.preventDefault();
             e.stopPropagation();
           }}
         >
@@ -285,6 +283,29 @@ export default function ProductCard({
           </div>
         )}
       </div>
+    </>
+  );
+
+  const content = href ? (
+    <a
+      href={href}
+      className={isCardInteractive ? "cursor-pointer" : ""}
+      onClickCapture={isCardInteractive ? handleCardClickCapture : undefined}
+      onClick={isCardInteractive ? handleCardClick : undefined}
+      onKeyDown={isCardInteractive ? handleCardKeyDown : undefined}
+    >
+      {contentBody}
+    </a>
+  ) : (
+    <div
+      className={isCardInteractive ? "cursor-pointer" : ""}
+      onClickCapture={isCardInteractive ? handleCardClickCapture : undefined}
+      onClick={isCardInteractive ? handleCardClick : undefined}
+      onKeyDown={isCardInteractive ? handleCardKeyDown : undefined}
+      role={isCardInteractive ? "button" : undefined}
+      tabIndex={isCardInteractive ? 0 : undefined}
+    >
+      {contentBody}
     </div>
   );
 

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -7,7 +7,6 @@ import {
   DropdownItem,
   Button,
 } from "@heroui/react";
-import Link from "next/link";
 import {
   ArrowTopRightOnSquareIcon,
   EllipsisVerticalIcon,
@@ -49,25 +48,96 @@ export default function ProductCard({
     ? Date.now() / 1000 > productData.expiration
     : false;
 
-  const handleCardClick = (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
+  const shouldBlockCardNavigation = (target: Element | null) => {
     const isCarouselControl =
-      target.closest('button[title*="slide"]') ||
-      target.closest('li[role="button"]') ||
-      target.closest(".carousel-control");
+      target?.closest('button[title*="slide"]') ||
+      target?.closest('li[role="button"]') ||
+      target?.closest(".carousel-control");
     const isDropdown =
-      target.closest('[role="menu"]') ||
-      target.closest('[data-slot="trigger"]') ||
-      target.closest('button[data-slot="trigger"]');
-    if (isCarouselControl || isDropdown) {
+      target?.closest('[role="menu"]') ||
+      target?.closest('[data-slot="trigger"]') ||
+      target?.closest('button[data-slot="trigger"]');
+    const isProfileDropdown = target?.closest("[data-profile-dropdown]");
+
+    return Boolean(isCarouselControl || isDropdown || isProfileDropdown);
+  };
+
+  const openHrefInNewTab = () => {
+    if (!href) return;
+    window.open(href, "_blank", "noopener,noreferrer");
+  };
+
+  const handleCardClick = (e: React.MouseEvent) => {
+    const target = e.target as Element;
+    if (shouldBlockCardNavigation(target)) {
       e.preventDefault();
       e.stopPropagation();
       return;
     }
+
+    if (href && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      openHrefInNewTab();
+      return;
+    }
+
     if (onProductClick) {
       onProductClick(productData, e);
+      if (e.defaultPrevented) {
+        return;
+      }
+    }
+
+    if (href) {
+      void router.push(href);
     }
   };
+
+  const handleCardAuxClick = (e: React.MouseEvent) => {
+    if (e.button !== 1) {
+      return;
+    }
+
+    const target = e.target as Element;
+    if (shouldBlockCardNavigation(target)) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    if (href) {
+      e.preventDefault();
+      openHrefInNewTab();
+    }
+  };
+
+  const handleCardKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "Enter" && e.key !== " ") {
+      return;
+    }
+
+    const target = e.target as Element;
+    if (shouldBlockCardNavigation(target)) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    e.preventDefault();
+
+    if (onProductClick) {
+      onProductClick(productData);
+      if (e.defaultPrevented) {
+        return;
+      }
+    }
+
+    if (href) {
+      void router.push(href);
+    }
+  };
+
+  const isCardInteractive = Boolean(href || onProductClick);
 
   const handleNjumpClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -90,7 +160,14 @@ export default function ProductCard({
   };
 
   const content = (
-    <div className="cursor-pointer" onClick={handleCardClick}>
+    <div
+      className={isCardInteractive ? "cursor-pointer" : ""}
+      onClick={isCardInteractive ? handleCardClick : undefined}
+      onAuxClick={href ? handleCardAuxClick : undefined}
+      onKeyDown={isCardInteractive ? handleCardKeyDown : undefined}
+      role={isCardInteractive ? "link" : undefined}
+      tabIndex={isCardInteractive ? 0 : undefined}
+    >
       <div>
         <ImageCarousel
           images={productData.images}
@@ -172,6 +249,7 @@ export default function ProductCard({
         )}
         <div
           className="mb-3"
+          data-profile-dropdown
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -214,15 +292,7 @@ export default function ProductCard({
     <div
       className={`${cardHoverStyle} my-4 w-full rounded-2xl bg-white shadow-md transition-all duration-300 dark:bg-neutral-900`}
     >
-      <div className="w-full overflow-hidden rounded-2xl">
-        {href ? (
-          <Link href={href} className="block">
-            {content}
-          </Link>
-        ) : (
-          content
-        )}
-      </div>
+      <div className="w-full overflow-hidden rounded-2xl">{content}</div>
       <RawEventModal
         isOpen={showRawEventModal}
         onClose={() => setShowRawEventModal(false)}

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -108,10 +108,13 @@ export default function ProductCard({
   };
 
   const handleCardKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    // Let nested interactive controls handle their own keyboard activation.
+    if (e.target !== e.currentTarget) {
+      return;
+    }
+
     const target = getElementTarget(e.target);
     if (shouldBlockCardNavigation(target)) {
-      e.preventDefault();
-      e.stopPropagation();
       return;
     }
 

--- a/components/utility-components/profile/profile-dropdown.tsx
+++ b/components/utility-components/profile/profile-dropdown.tsx
@@ -305,7 +305,10 @@ export const ProfileWithDropdown = ({
   return (
     <>
       <div
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
         onPointerDown={(e) => e.stopPropagation()}
         onMouseDown={(e) => e.stopPropagation()}
       >
@@ -320,13 +323,15 @@ export const ProfileWithDropdown = ({
               avatarProps={{
                 src: pfp,
               }}
-              className={"transition-transform"}
+              className={
+                "group cursor-pointer rounded-md px-1 py-0.5 transition-all duration-200 hover:bg-black/5 hover:shadow-sm dark:hover:bg-white/10"
+              }
               classNames={{
                 name: `overflow-hidden text-ellipsis whitespace-nowrap text-light-text dark:text-dark-text hidden ${nameClassname} ${
                   isNip05Verified
                     ? "text-shopstr-purple dark:text-shopstr-yellow"
                     : ""
-                }`,
+                } group-hover:underline group-hover:underline-offset-2`,
                 base: `${baseClassname}`,
               }}
               name={displayName}

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -17,7 +17,7 @@ const customJestConfig = {
 module.exports = async () => {
   const jestConfig = await createJestConfig(customJestConfig)();
   jestConfig.transformIgnorePatterns = [
-    "/node_modules/(?!(dexie|nostr-tools|@getalby/lightning-tools|@cashu/cashu-ts|uuid)/)",
+        "/node_modules/(?!(dexie|nostr-tools|@noble|@scure|@getalby/lightning-tools|@cashu/cashu-ts|uuid)/)",
     "^.+\\.module\\.(css|sass|scss)$",
   ];
 


### PR DESCRIPTION
### Issue

- Clicking the seller dropdown area inside a marketplace product card was opening the listing page, instead of only opening/interacting with the dropdown because the card content was wrapped in Next Link although nested controls were present

### Description
For opening the dedicated dropdown only and not moving to listing page following things were changed

- Removed the Link wrapper from the card body and switched to controlled navigation handlers.
- Added a interaction guard to block navigation for nested interactions like carousel controls, dropdown menus, profile dropdown region .
- Added explicit click navigation handler for normal card clicks.
- Added auxiliary click handler to support middle-click new-tab behavior.
- Preserved parent override behavior: if onProductClick prevents default, card route push is skipped.


### Resolved or fixed issue
`none`  

### Screenshots (if applicable)  

### Before
[Screencast from 2026-04-13 15-49-54.webm](https://github.com/user-attachments/assets/854035ff-1675-44e2-a276-9b3bfaf53be2)

### After
<img width="1174" height="686" alt="image" src="https://github.com/user-attachments/assets/234a7bb5-b6b3-4ffb-a1fc-b339cc67c71e" />

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
