### PR TITLE
fix: use local time for expiration datetime inputs

### DIFF
--- a/components/my-listings/discount-codes.tsx
+++ b/components/my-listings/discount-codes.tsx
@@ -9,6 +9,7 @@ import {
 } from "@nextui-org/react";
 import { TrashIcon } from "@heroicons/react/24/outline";
 import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import { formatCurrentDateTimeLocalValue } from "@/utils/datetime-local";
 import { SignerContext } from "@/components/utility-components/nostr-context-provider";
 import {
   buildDiscountCodeCreateProof,
@@ -198,7 +199,7 @@ export default function DiscountCodes() {
             placeholder="Select expiration date"
             value={newExpiration}
             onChange={(e) => setNewExpiration(e.target.value)}
-            min={new Date().toISOString().slice(0, 16)}
+            min={formatCurrentDateTimeLocalValue()}
             className="text-light-text dark:text-dark-text"
           />
           <Button

--- a/components/product-form.tsx
+++ b/components/product-form.tsx
@@ -41,6 +41,10 @@ import LocationDropdown from "./utility-components/dropdowns/location-dropdown";
 import ConfirmActionDropdown from "./utility-components/dropdowns/confirm-action-dropdown";
 import { ProductContext, ProfileMapContext } from "../utils/context/context";
 import { ProductData } from "@/utils/parsers/product-parser-functions";
+import {
+  formatCurrentDateTimeLocalValue,
+  formatUnixTimestampAsDateTimeLocalValue,
+} from "@/utils/datetime-local";
 import { buildSrcSet } from "@/utils/images";
 import { FileUploaderButton } from "./utility-components/file-uploader";
 import currencySelection from "../public/currencySelection.json";
@@ -123,7 +127,7 @@ export default function ProductForm({
           Required: oldValues.required ? oldValues.required : "",
           Restrictions: oldValues.restrictions ? oldValues.restrictions : "",
           Expiration: oldValues.expiration
-            ? new Date(oldValues.expiration * 1000).toISOString().slice(0, 16)
+            ? formatUnixTimestampAsDateTimeLocalValue(oldValues.expiration)
             : "",
         }
       : {
@@ -1736,7 +1740,7 @@ export default function ProductForm({
                     <div className="mt-4">
                       <Input
                         type="datetime-local"
-                        min={new Date().toISOString().slice(0, 16)}
+                        min={formatCurrentDateTimeLocalValue()}
                         variant="bordered"
                         label="Valid Until (Optional)"
                         labelPlacement="inside"

--- a/utils/__tests__/datetime-local.test.ts
+++ b/utils/__tests__/datetime-local.test.ts
@@ -1,0 +1,71 @@
+import {
+  formatCurrentDateTimeLocalValue,
+  formatDateTimeLocalValue,
+  formatUnixTimestampAsDateTimeLocalValue,
+} from "../datetime-local";
+
+describe("datetime-local helpers", () => {
+  it("formats local date parts without converting to UTC", () => {
+    const dateLike = {
+      getFullYear: () => 2026,
+      getMonth: () => 3,
+      getDate: () => 9,
+      getHours: () => 7,
+      getMinutes: () => 5,
+    };
+
+    expect(formatDateTimeLocalValue(dateLike)).toBe("2026-04-09T07:05");
+  });
+
+  it("formats unix timestamps using local date values", () => {
+    const getFullYearSpy = jest.spyOn(Date.prototype, "getFullYear");
+    const getMonthSpy = jest.spyOn(Date.prototype, "getMonth");
+    const getDateSpy = jest.spyOn(Date.prototype, "getDate");
+    const getHoursSpy = jest.spyOn(Date.prototype, "getHours");
+    const getMinutesSpy = jest.spyOn(Date.prototype, "getMinutes");
+
+    try {
+      getFullYearSpy.mockReturnValue(2027);
+      getMonthSpy.mockReturnValue(10);
+      getDateSpy.mockReturnValue(3);
+      getHoursSpy.mockReturnValue(14);
+      getMinutesSpy.mockReturnValue(8);
+
+      expect(formatUnixTimestampAsDateTimeLocalValue(1730671680)).toBe(
+        "2027-11-03T14:08"
+      );
+    } finally {
+      getFullYearSpy.mockRestore();
+      getMonthSpy.mockRestore();
+      getDateSpy.mockRestore();
+      getHoursSpy.mockRestore();
+      getMinutesSpy.mockRestore();
+    }
+  });
+
+  it("formats the current local time for datetime-local minimums", () => {
+    const now = new Date("2026-04-13T18:42:59.999Z");
+
+    const getFullYearSpy = jest.spyOn(now, "getFullYear");
+    const getMonthSpy = jest.spyOn(now, "getMonth");
+    const getDateSpy = jest.spyOn(now, "getDate");
+    const getHoursSpy = jest.spyOn(now, "getHours");
+    const getMinutesSpy = jest.spyOn(now, "getMinutes");
+
+    try {
+      getFullYearSpy.mockReturnValue(2026);
+      getMonthSpy.mockReturnValue(3);
+      getDateSpy.mockReturnValue(13);
+      getHoursSpy.mockReturnValue(0);
+      getMinutesSpy.mockReturnValue(12);
+
+      expect(formatCurrentDateTimeLocalValue(now)).toBe("2026-04-13T00:12");
+    } finally {
+      getFullYearSpy.mockRestore();
+      getMonthSpy.mockRestore();
+      getDateSpy.mockRestore();
+      getHoursSpy.mockRestore();
+      getMinutesSpy.mockRestore();
+    }
+  });
+});

--- a/utils/datetime-local.ts
+++ b/utils/datetime-local.ts
@@ -1,0 +1,22 @@
+type DateTimeLocalParts = Pick<
+  Date,
+  "getFullYear" | "getMonth" | "getDate" | "getHours" | "getMinutes"
+>;
+
+const padDateTimePart = (value: number) => value.toString().padStart(2, "0");
+
+export const formatDateTimeLocalValue = (date: DateTimeLocalParts) => {
+  const year = date.getFullYear();
+  const month = padDateTimePart(date.getMonth() + 1);
+  const day = padDateTimePart(date.getDate());
+  const hours = padDateTimePart(date.getHours());
+  const minutes = padDateTimePart(date.getMinutes());
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+};
+
+export const formatUnixTimestampAsDateTimeLocalValue = (unixSeconds: number) =>
+  formatDateTimeLocalValue(new Date(unixSeconds * 1000));
+
+export const formatCurrentDateTimeLocalValue = (now = new Date()) =>
+  formatDateTimeLocalValue(now);


### PR DESCRIPTION
## Description

Fix expiration `datetime-local` inputs to use local wall-clock time instead of UTC-formatted strings.

The current code was building input values and `min` constraints with `toISOString().slice(0, 16)`. That converts dates to UTC first, but `datetime-local` inputs are interpreted in the browser as local time. In non-UTC timezones, this can shift the displayed expiration time and make the `min` value incorrect.

## What this changes

- add a small shared helper for formatting `datetime-local` values from local date parts
- use the local formatter for product expiration defaults when editing a listing
- use the local formatter for product expiration `min`
- use the local formatter for discount code expiration `min`
- add focused tests for the datetime-local formatting helper

## Why this matters

This keeps the read/edit path consistent with the existing submit path, which already parses `datetime-local` input values as local time.

Without this fix:
- an existing expiration can appear shifted when editing
- the `min` constraint can be offset by timezone
- users near timezone boundaries can select values that are already in the past locally

## Testing

- `npm test -- datetime-local.test.ts --runInBand`