### PR TITLE
fix: use JSONB d-tag matching for reviews and add review tags GIN index

### DIFF
--- a/utils/__tests__/db-service.test.ts
+++ b/utils/__tests__/db-service.test.ts
@@ -1,0 +1,9 @@
+import { buildReviewDTagFilter } from "../db/db-service";
+
+describe("db-service review helpers", () => {
+  it("builds a JSONB containment filter for review d tags", () => {
+    expect(buildReviewDTagFilter("30402:merchant-pubkey:listing-d-tag")).toBe(
+      '[["d","30402:merchant-pubkey:listing-d-tag"]]'
+    );
+  });
+});

--- a/utils/db/db-service.ts
+++ b/utils/db/db-service.ts
@@ -104,6 +104,7 @@ async function initializeTables(): Promise<void> {
       );
 
       CREATE INDEX IF NOT EXISTS idx_review_events_pubkey ON review_events(pubkey);
+      CREATE INDEX IF NOT EXISTS idx_review_events_tags ON review_events USING gin (tags jsonb_path_ops);
 
       -- Messages table (kind 1059 - gift wrapped DM)
       CREATE TABLE IF NOT EXISTS message_events (
@@ -350,6 +351,10 @@ function isReviewEvent(kind: number): boolean {
   return kind === 31555;
 }
 
+export function buildReviewDTagFilter(dTag: string): string {
+  return JSON.stringify([["d", dTag]]);
+}
+
 // Cache a single event to the database
 export async function cacheEvent(event: NostrEvent): Promise<void> {
   const table = getTableForKind(event.kind);
@@ -401,8 +406,8 @@ export async function cacheEvent(event: NostrEvent): Promise<void> {
       if (dTag) {
         // Delete older reviews from the same pubkey for the same product
         const deleteQuery = {
-          text: `DELETE FROM ${table} WHERE pubkey = $1 AND kind = $2 AND tags::text LIKE $3`,
-          values: [event.pubkey, event.kind, `%"d","${dTag}"%`] as any[],
+          text: `DELETE FROM ${table} WHERE pubkey = $1 AND kind = $2 AND tags @> $3::jsonb`,
+          values: [event.pubkey, event.kind, buildReviewDTagFilter(dTag)] as any[],
         };
         await client.query(deleteQuery);
       }
@@ -595,8 +600,8 @@ async function cacheEventsTransaction(events: NostrEvent[]): Promise<void> {
         if (dTag) {
           // First, lock and delete old rows
           await client.query(
-            `DELETE FROM ${table} WHERE pubkey = $1 AND kind = $2 AND tags::text LIKE $3 AND id != $4`,
-            [event.pubkey, event.kind, `%"d","${dTag}"%`, event.id] as any[]
+            `DELETE FROM ${table} WHERE pubkey = $1 AND kind = $2 AND tags @> $3::jsonb AND id != $4`,
+            [event.pubkey, event.kind, buildReviewDTagFilter(dTag), event.id] as any[]
           );
 
           // Then insert/update with ON CONFLICT


### PR DESCRIPTION
This PR tightens how we handle cached review replace/dedup logic in the DB layer.

What was there before:
- reviews were already stored in their own `review_events` table with a `pubkey` index
- normal review fetches were not using `LIKE`
- but the review replace/dedup delete path was still matching the `d` tag using `tags::text LIKE`
- `review_events.tags` also did not have a GIN index

What this PR changes:
- replaces review `d`-tag matching from `tags::text LIKE` to proper JSONB containment (`tags @> ...`)
- adds a GIN index on `review_events.tags`
- adds a small regression test for the review `d`-tag JSONB filter helper

Why:
- avoids text-based matching on JSON tags
- makes the review dedup path cleaner and more index-friendly
- aligns the review path better with how we should query structured tag data
