### PR TITLE
fix contrast on user-type buttons by switching to a darker yellow variant for dark theme

### DIFF
--- a/pages/onboarding/user-type.tsx
+++ b/pages/onboarding/user-type.tsx
@@ -60,7 +60,7 @@ const UserTypeSelection = () => {
                 onClick={() => setSelectedType("buyer")}
                 className={`flex flex-1 flex-col items-center justify-center rounded-lg border-2 p-8 transition-all ${
                   selectedType === "buyer"
-                    ? "border-shopstr-purple bg-shopstr-yellow dark:border-shopstr-yellow dark:bg-shopstr-yellow"
+                    ? "bg-shopstr-yellow dark:border-shopstr-yellow dark:bg-shopstr-yellow-dark"
                     : "bg-light-fg hover:bg-light-bg dark:border-dark-fg dark:bg-dark-fg dark:hover:bg-dark-bg border-gray-300"
                 }`}
               >
@@ -77,7 +77,7 @@ const UserTypeSelection = () => {
                 onClick={() => setSelectedType("seller")}
                 className={`flex flex-1 flex-col items-center justify-center rounded-lg border-2 p-8 transition-all ${
                   selectedType === "seller"
-                    ? "border-shopstr-purple bg-shopstr-yellow dark:border-shopstr-yellow dark:bg-shopstr-yellow"
+                    ? "bg-shopstr-yellow dark:border-shopstr-yellow dark:bg-shopstr-yellow-dark"
                     : "bg-light-fg hover:bg-light-bg dark:border-dark-fg dark:bg-dark-fg dark:hover:bg-dark-bg border-gray-300"
                 }`}
               >

--- a/pages/onboarding/user-type.tsx
+++ b/pages/onboarding/user-type.tsx
@@ -60,7 +60,7 @@ const UserTypeSelection = () => {
                 onClick={() => setSelectedType("buyer")}
                 className={`flex flex-1 flex-col items-center justify-center rounded-lg border-2 p-8 transition-all ${
                   selectedType === "buyer"
-                    ? "bg-shopstr-yellow dark:border-shopstr-yellow dark:bg-shopstr-yellow-dark"
+                    ? "border-shopstr-purple bg-shopstr-purple-light dark:border-shopstr-yellow dark:bg-shopstr-yellow-dark"
                     : "bg-light-fg hover:bg-light-bg dark:border-dark-fg dark:bg-dark-fg dark:hover:bg-dark-bg border-gray-300"
                 }`}
               >
@@ -77,7 +77,7 @@ const UserTypeSelection = () => {
                 onClick={() => setSelectedType("seller")}
                 className={`flex flex-1 flex-col items-center justify-center rounded-lg border-2 p-8 transition-all ${
                   selectedType === "seller"
-                    ? "bg-shopstr-yellow dark:border-shopstr-yellow dark:bg-shopstr-yellow-dark"
+                    ? "border-shopstr-purple bg-shopstr-purple-light dark:border-shopstr-yellow dark:bg-shopstr-yellow-dark"
                     : "bg-light-fg hover:bg-light-bg dark:border-dark-fg dark:bg-dark-fg dark:hover:bg-dark-bg border-gray-300"
                 }`}
               >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,7 @@ const config: Config = {
         "shopstr-purple-light": "#a655f7",
         "shopstr-yellow": "#fcd34d",
         "shopstr-yellow-light": "#fef08a",
+        "shopstr-yellow-dark": "#534e3c",
         "dark-text": "#e8e8e8",
         "accent-dark-text": "#fef08a",
         "light-text": "#212121",


### PR DESCRIPTION
### Description
White text on bright yellow background isn't very easy on eyes.
<img width="1300" height="562" alt="image" src="https://github.com/user-attachments/assets/0cc14392-202c-4587-abcb-dc997db85353" />

This pr adds a new yellow variant `shopstr-yellow-dark` set to be `#534e3c`.

Now it looks like this:
<img width="1222" height="522" alt="image" src="https://github.com/user-attachments/assets/b7b4fa92-ba60-4130-acba-a26aec10fd07" />


### Resolved or fixed issue
none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
