### PR TITLE
Add feature to toggle between show and hide password on passphrase challenge

### DIFF
--- a/components/utility-components/request-passphrase-modal.tsx
+++ b/components/utility-components/request-passphrase-modal.tsx
@@ -11,6 +11,7 @@ import {
 import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
 import { useRouter } from "next/router";
 import ShopstrSpinner from "@/components/utility-components/shopstr-spinner";
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
 
 export default function PassphraseChallengeModal({
   actionOnSubmit,
@@ -29,6 +30,7 @@ export default function PassphraseChallengeModal({
 }) {
   const [remindToggled, setRemindToggled] = useState(false);
   const [passphraseInput, setPassphraseInput] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const isButtonDisabled = useMemo(() => {
     return passphraseInput.trim().length === 0;
@@ -99,20 +101,33 @@ export default function PassphraseChallengeModal({
           Enter Passphrase
         </ModalHeader>
         <ModalBody>
-          <Input
-            className="text-light-text dark:text-dark-text"
-            autoFocus
-            ref={passphraseInputRef}
-            variant="flat"
-            label="Passphrase"
-            labelPlacement="inside"
-            type="password"
-            onChange={(e) => setPassphraseInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") onSubmit();
-            }}
-            value={passphraseInput}
-          />
+          <div className="flex items-center gap-1">
+            <Input
+              className="text-light-text dark:text-dark-text"
+              autoFocus
+              ref={passphraseInputRef}
+              variant="flat"
+              label="Passphrase"
+              labelPlacement="inside"
+              type={showPassword ? "text" : "password"}
+              onChange={(e) => setPassphraseInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onSubmit();
+              }}
+              value={passphraseInput}
+            />
+            <button
+              className="cursor-pointer"
+              onClick={() => setShowPassword((prev) => !prev)}
+            >
+              {" "}
+              {showPassword ? (
+                <EyeSlashIcon className="h-6 w-6" />
+              ) : (
+                <EyeIcon className="h-6 w-6" />
+              )}
+            </button>
+          </div>
           <div className="mt-4 flex items-center gap-2">
             <input
               type="checkbox"

--- a/components/utility-components/request-passphrase-modal.tsx
+++ b/components/utility-components/request-passphrase-modal.tsx
@@ -101,33 +101,33 @@ export default function PassphraseChallengeModal({
           Enter Passphrase
         </ModalHeader>
         <ModalBody>
-          <div className="flex items-center gap-1">
-            <Input
-              className="text-light-text dark:text-dark-text"
-              autoFocus
-              ref={passphraseInputRef}
-              variant="flat"
-              label="Passphrase"
-              labelPlacement="inside"
-              type={showPassword ? "text" : "password"}
-              onChange={(e) => setPassphraseInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") onSubmit();
-              }}
-              value={passphraseInput}
-            />
-            <button
-              className="cursor-pointer"
-              onClick={() => setShowPassword((prev) => !prev)}
-            >
-              {" "}
-              {showPassword ? (
-                <EyeSlashIcon className="h-6 w-6" />
-              ) : (
-                <EyeIcon className="h-6 w-6" />
-              )}
-            </button>
-          </div>
+          <Input
+            className="text-light-text dark:text-dark-text"
+            autoFocus
+            ref={passphraseInputRef}
+            variant="flat"
+            label="Passphrase"
+            labelPlacement="inside"
+            type={showPassword ? "text" : "password"}
+            onChange={(e) => setPassphraseInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onSubmit();
+            }}
+            value={passphraseInput}
+            endContent={
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className="text-gray-400"
+              >
+                {showPassword ? (
+                  <EyeSlashIcon className="h-5 w-5" />
+                ) : (
+                  <EyeIcon className="h-5 w-5" />
+                )}
+              </button>
+            }
+          />
           <div className="mt-4 flex items-center gap-2">
             <input
               type="checkbox"


### PR DESCRIPTION
### Description
This pr adds the standard feature of show and hide password by switching the input type between text and password as needed.
Input type of password doesn't give any security benefits other than the visual hiding, so this has no security impact.

### Screenshots (if applicable)  
<img width="685" height="303" alt="Screenshot 2026-04-15 at 19 50 25" src="https://github.com/user-attachments/assets/672343fa-6d7d-4a5d-948f-d7156b7e3f60" />
<img width="692" height="315" alt="Screenshot 2026-04-15 at 19 51 10" src="https://github.com/user-attachments/assets/93ea790a-7cae-472d-990c-46bf41ef540e" />


### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines