### PR TITLE
Potential fix for code scanning alert no. 37: Double escaping or unescaping

### DIFF
--- a/pages/api/og-preview.ts
+++ b/pages/api/og-preview.ts
@@ -12,7 +12,6 @@ const CACHE_TTL = 1000 * 60 * 30;
 
 function decodeHTMLEntities(str: string): string {
   return str
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
@@ -20,6 +19,7 @@ function decodeHTMLEntities(str: string): string {
     .replace(/&apos;/g, "'")
     .replace(/&#x27;/g, "'")
     .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
     .trim();
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/37](https://github.com/shopstr-eng/shopstr/security/code-scanning/37)

To fix double-unescaping, reorder replacements in `decodeHTMLEntities` so ampersand (`&amp;`) is decoded **after** all other entities. This preserves single-pass semantics and prevents `&amp;...;` sequences from being turned into additional entities that are immediately decoded again.

Best minimal fix (no behavior changes beyond removing the bug): in `pages/api/og-preview.ts`, move `.replace(/&amp;/g, "&")` to the end of the replacement chain (just before `.trim()`), leaving all other replacements unchanged.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
