### PR TITLE
Escape storefront policy HTML rendering

### DIFF
--- a/components/storefront/__tests__/storefront-policy-page.test.tsx
+++ b/components/storefront/__tests__/storefront-policy-page.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import StorefrontPolicyPage from "@/components/storefront/storefront-policy-page";
+
+const colors = {
+  primary: "#000000",
+  secondary: "#ffffff",
+  accent: "#111111",
+  background: "#ffffff",
+  text: "#000000",
+};
+
+describe("StorefrontPolicyPage", () => {
+  it("renders the supported markdown subset without injecting HTML", () => {
+    render(
+      <StorefrontPolicyPage
+        policy={{
+          enabled: true,
+          content: "# Terms\n\nPlain **bold** and *italic* text.\n\n- First\n- Second",
+        }}
+        colors={colors}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Terms" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("bold")).toContainHTML("<strong>bold</strong>");
+    expect(screen.getByText("italic")).toContainHTML("<em>italic</em>");
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("renders attacker HTML as inert text", () => {
+    render(
+      <StorefrontPolicyPage
+        policy={{
+          enabled: true,
+          content:
+            '<img alt="proof" src="x" onerror="window.__shopstrXss = 1">',
+        }}
+        colors={colors}
+      />
+    );
+
+    expect(screen.queryByAltText("proof")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '<img alt="proof" src="x" onerror="window.__shopstrXss = 1">'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/components/storefront/storefront-policy-page.tsx
+++ b/components/storefront/storefront-policy-page.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from "react";
+import { Fragment, type ReactElement, type ReactNode } from "react";
 import { StorefrontColorScheme, StorefrontPolicy } from "@/utils/types/types";
 
 interface StorefrontPolicyPageProps {
@@ -6,10 +6,41 @@ interface StorefrontPolicyPageProps {
   colors: StorefrontColorScheme;
 }
 
-function inlineFormat(text: string): string {
-  return text
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>");
+function renderInline(text: string): ReactNode[] {
+  const segments: ReactNode[] = [];
+  const inlinePattern = /\*\*(.+?)\*\*|\*(.+?)\*/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = inlinePattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push(text.slice(lastIndex, match.index));
+    }
+
+    if (match[1] !== undefined) {
+      segments.push(<strong key={`strong-${match.index}`}>{match[1]}</strong>);
+    } else if (match[2] !== undefined) {
+      segments.push(<em key={`em-${match.index}`}>{match[2]}</em>);
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push(text.slice(lastIndex));
+  }
+
+  if (segments.length === 0) {
+    return [text];
+  }
+
+  return segments.map((segment, index) =>
+    typeof segment === "string" ? (
+      <Fragment key={`text-${index}`}>{segment}</Fragment>
+    ) : (
+      segment
+    )
+  );
 }
 
 function renderMarkdown(content: string, colors: StorefrontColorScheme) {
@@ -28,7 +59,7 @@ function renderMarkdown(content: string, colors: StorefrontColorScheme) {
         >
           {listItems.map((item, i) => (
             <li key={i} className="text-sm leading-relaxed">
-              <span dangerouslySetInnerHTML={{ __html: inlineFormat(item) }} />
+              <span>{renderInline(item)}</span>
             </li>
           ))}
         </ul>
@@ -84,8 +115,9 @@ function renderMarkdown(content: string, colors: StorefrontColorScheme) {
           key={i}
           className="font-body mb-4 text-sm leading-relaxed"
           style={{ color: colors.text + "CC" }}
-          dangerouslySetInnerHTML={{ __html: inlineFormat(line) }}
-        />
+        >
+          {renderInline(line)}
+        </p>
       );
     }
   }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -48,7 +48,7 @@ jest.mock("@heroui/ripple", () => {
       onPress: jest.fn(),
     }),
   };
-});
+}, { virtual: true });
 
 jest.mock("framer-motion", () => {
   const actual = jest.requireActual("framer-motion");
@@ -167,4 +167,4 @@ jest.mock("@heroui/modal", () => {
     ModalFooter,
     ModalHeader,
   };
-});
+}, { virtual: true });


### PR DESCRIPTION
**Security Issue**: policy.content is treated like markdown text, but inlineFormat() does not escape HTML before passing it into dangerouslySetInnerHTML. That means raw attacker HTML survives unchanged into a public storefront page. The same origin also exposes sensitive client side state in localStorage, including serialised signer objects and NIP 46 app keys.

The full exploitation process is demonstrated in the attached video:
 https://www.notion.so/Security-Vulnerabilities-3367d68f8c31800394d6d88b56674914?source=copy_link

<img width="700" height="700" alt="Screenshot 2026-04-16 at 8 47 40 PM" 
src="https://github.com/user-attachments/assets/6c8ecbff-5fe1-4dc2-80b8-d0881fcb8b42" />

<img width="700" height="700" alt="Screenshot 2026-04-16 at 8 47 55 PM" src="https://github.com/user-attachments/assets/daed1dbd-15b7-4137-ba4c-4e5a56fca090" />
<img width="700" height="700" alt="Screenshot 2026-04-16 at 8 48 06 PM" src="https://github.com/user-attachments/assets/87ea0d3d-e715-4d7c-8e2d-ba198cce8d12" />

So basically, a seller account was able to save a malicious JavaScript payload inside the storefront’s Terms of Service page. Then when another user (the victim) opened that public policy page, the script automatically ran in their browser session. Because of that, the payload could access and read data from the victim’s localStorage within their browser.

