### PR TITLE
Secure storefront mutation and event cache endpoints

### DIFF
--- a/components/settings/shop-profile-form.tsx
+++ b/components/settings/shop-profile-form.tsx
@@ -18,6 +18,12 @@ import {
   NostrContext,
 } from "@/components/utility-components/nostr-context-provider";
 import { createNostrShopEvent } from "@/utils/nostr/nostr-helper-functions";
+import {
+  buildSignedHttpRequestProofTemplate,
+  buildStorefrontSlugCreateProof,
+  buildStorefrontSlugDeleteProof,
+  SIGNED_EVENT_HEADER,
+} from "@/utils/nostr/request-auth";
 import { FileUploaderButton } from "@/components/utility-components/file-uploader";
 import ShopstrSpinner from "@/components/utility-components/shopstr-spinner";
 import currencySelection from "@/public/currencySelection.json";
@@ -381,6 +387,12 @@ const ShopProfileForm = ({ isOnboarding = false }: ShopProfileFormProps) => {
   };
 
   const registerSlug = async () => {
+    if (!userPubkey || !signer) {
+      setSlugStatus("error");
+      setSlugMessage("You must be signed in to save your storefront");
+      return;
+    }
+
     const s = sanitizeSlug(slugInput);
     if (!s || s.length < 2) {
       setSlugStatus("error");
@@ -395,9 +407,20 @@ const ShopProfileForm = ({ isOnboarding = false }: ShopProfileFormProps) => {
     setSlugStatus("checking");
     setSlugMessage("Saving...");
     try {
+      const signedEvent = await signer.sign(
+        buildSignedHttpRequestProofTemplate(
+          buildStorefrontSlugCreateProof({
+            pubkey: userPubkey,
+            slug: s,
+          })
+        )
+      );
       const res = await fetch("/api/storefront/register-slug", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+        },
         body: JSON.stringify({ pubkey: userPubkey, slug: s }),
       });
       const data = await res.json();
@@ -420,15 +443,23 @@ const ShopProfileForm = ({ isOnboarding = false }: ShopProfileFormProps) => {
   };
 
   const handleRemoveStorefront = async () => {
-    if (!userPubkey) return;
+    if (!userPubkey || !signer) return;
     const confirmed = window.confirm(
       "Are you sure you want to remove your storefront? This will delete your shop URL, custom domain, and reset all storefront settings."
     );
     if (!confirmed) return;
     try {
+      const signedEvent = await signer.sign(
+        buildSignedHttpRequestProofTemplate(
+          buildStorefrontSlugDeleteProof(userPubkey)
+        )
+      );
       await fetch("/api/storefront/register-slug", {
         method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+        },
         body: JSON.stringify({ pubkey: userPubkey }),
       });
       setShopSlug("");

--- a/pages/api/db/__tests__/cache-event.test.ts
+++ b/pages/api/db/__tests__/cache-event.test.ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const verifyEventMock = jest.fn();
+const cacheEventMock = jest.fn();
+const cacheEventsMock = jest.fn();
+
+jest.mock("nostr-tools", () => ({
+  verifyEvent: (...args: unknown[]) => verifyEventMock(...args),
+}));
+
+jest.mock("@/utils/db/db-service", () => ({
+  cacheEvent: (...args: unknown[]) => cacheEventMock(...args),
+  cacheEvents: (...args: unknown[]) => cacheEventsMock(...args),
+}));
+
+import cacheEventHandler from "@/pages/api/db/cache-event";
+import cacheEventsHandler from "@/pages/api/db/cache-events";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      return this;
+    },
+  };
+}
+
+function createRequest(
+  method: string,
+  body: unknown
+): NextApiRequest {
+  return {
+    method,
+    body,
+  } as unknown as NextApiRequest;
+}
+
+describe("/api/db/cache-event", () => {
+  beforeEach(() => {
+    verifyEventMock.mockReset();
+    cacheEventMock.mockReset();
+    cacheEventsMock.mockReset();
+  });
+
+  it("rejects forged single-event cache writes", async () => {
+    verifyEventMock.mockReturnValue(false);
+
+    const req = createRequest("POST", {
+        id: "evt-forged",
+        pubkey: "attacker-pubkey",
+        kind: 30019,
+        content: "{}",
+      });
+    const res = createResponse();
+
+    await cacheEventHandler(req, res as unknown as NextApiResponse);
+
+    expect(cacheEventMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.jsonBody).toEqual({
+      error: "Invalid or unsigned Nostr event",
+    });
+  });
+
+  it("rejects forged batch cache writes", async () => {
+    verifyEventMock.mockImplementation((event: { id: string }) => {
+      return event.id !== "evt-forged";
+    });
+
+    const req = createRequest("POST", [
+        {
+          id: "evt-good",
+          pubkey: "pubkey-1",
+          kind: 30019,
+          content: "{}",
+        },
+        {
+          id: "evt-forged",
+          pubkey: "pubkey-2",
+          kind: 30019,
+          content: "{}",
+        },
+      ]);
+    const res = createResponse();
+
+    await cacheEventsHandler(req, res as unknown as NextApiResponse);
+
+    expect(cacheEventsMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.jsonBody).toEqual({
+      error: "Invalid or unsigned Nostr event",
+    });
+  });
+});

--- a/pages/api/db/cache-event.ts
+++ b/pages/api/db/cache-event.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { type Event, verifyEvent } from "nostr-tools";
 import { cacheEvent } from "@/utils/db/db-service";
 import { NostrEvent } from "@/utils/types/types";
 
@@ -12,6 +13,9 @@ export default async function handler(
 
   try {
     const event: NostrEvent = req.body;
+    if (!event || typeof event !== "object" || !verifyEvent(event as Event)) {
+      return res.status(401).json({ error: "Invalid or unsigned Nostr event" });
+    }
     await cacheEvent(event);
     res.status(200).json({ success: true });
   } catch (error) {

--- a/pages/api/db/cache-events.ts
+++ b/pages/api/db/cache-events.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { type Event, verifyEvent } from "nostr-tools";
 import { cacheEvents } from "@/utils/db/db-service";
 import { NostrEvent } from "@/utils/types/types";
 
@@ -24,6 +25,10 @@ export default async function handler(
       return res
         .status(400)
         .json({ error: "Invalid request body: expected an array of events" });
+    }
+
+    if (events.some((event) => !event || !verifyEvent(event as Event))) {
+      return res.status(401).json({ error: "Invalid or unsigned Nostr event" });
     }
 
     // Handle large batches by splitting them

--- a/pages/api/storefront/__tests__/register-slug.test.ts
+++ b/pages/api/storefront/__tests__/register-slug.test.ts
@@ -1,0 +1,101 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const queryMock = jest.fn();
+const extractSignedEventFromRequestMock = jest.fn();
+const verifySignedHttpRequestProofMock = jest.fn();
+
+jest.mock("@/utils/db/db-service", () => ({
+  getDbPool: () => ({
+    query: (...args: unknown[]) => queryMock(...args),
+  }),
+}));
+
+jest.mock("@/utils/nostr/request-auth", () => ({
+  extractSignedEventFromRequest: (...args: unknown[]) =>
+    extractSignedEventFromRequestMock(...args),
+  verifySignedHttpRequestProof: (...args: unknown[]) =>
+    verifySignedHttpRequestProofMock(...args),
+  buildStorefrontSlugCreateProof: (payload: unknown) => payload,
+  buildStorefrontSlugDeleteProof: (pubkey: string) => ({ pubkey }),
+}));
+
+import handler from "@/pages/api/storefront/register-slug";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      return this;
+    },
+  };
+}
+
+function createRequest(
+  method: string,
+  body: unknown
+): NextApiRequest {
+  return {
+    method,
+    body,
+  } as unknown as NextApiRequest;
+}
+
+describe("/api/storefront/register-slug", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    extractSignedEventFromRequestMock.mockReset();
+    verifySignedHttpRequestProofMock.mockReset();
+  });
+
+  it("rejects unsigned slug registration attempts", async () => {
+    verifySignedHttpRequestProofMock.mockReturnValue({
+      ok: false,
+      status: 401,
+      error: "A signed Nostr request proof is required to prove pubkey ownership.",
+    });
+
+    const req = createRequest("POST", {
+        pubkey: "victim-pubkey",
+        slug: "victim-shop",
+      });
+    const res = createResponse();
+
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.jsonBody).toEqual({
+      error:
+        "A signed Nostr request proof is required to prove pubkey ownership.",
+    });
+  });
+
+  it("allows signed slug registration for the matching owner", async () => {
+    verifySignedHttpRequestProofMock.mockReturnValue({
+      ok: true,
+      status: 200,
+    });
+    queryMock.mockResolvedValue({ rows: [] });
+
+    const req = createRequest("POST", {
+        pubkey: "owner-pubkey",
+        slug: "Owner Shop!!",
+      });
+    const res = createResponse();
+
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO shop_slugs"),
+      ["owner-pubkey", "owner-shop"]
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody).toEqual({ slug: "owner-shop" });
+  });
+});

--- a/pages/api/storefront/custom-domain.ts
+++ b/pages/api/storefront/custom-domain.ts
@@ -1,5 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getDbPool } from "@/utils/db/db-service";
+import {
+  buildCustomDomainCreateProof,
+  buildCustomDomainDeleteProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
 
 const pool = getDbPool();
 
@@ -15,6 +21,17 @@ export default async function handler(
     }
 
     const cleanDomain = domain.toLowerCase().trim();
+    const verification = verifySignedHttpRequestProof(
+      extractSignedEventFromRequest(req),
+      buildCustomDomainCreateProof({
+        pubkey,
+        domain: cleanDomain,
+      })
+    );
+
+    if (!verification.ok) {
+      return res.status(verification.status).json({ error: verification.error });
+    }
 
     const slugResult = await pool.query(
       "SELECT slug FROM shop_slugs WHERE pubkey = $1",
@@ -80,6 +97,15 @@ export default async function handler(
     const { pubkey } = req.body;
     if (!pubkey) {
       return res.status(400).json({ error: "pubkey is required" });
+    }
+
+    const verification = verifySignedHttpRequestProof(
+      extractSignedEventFromRequest(req),
+      buildCustomDomainDeleteProof(pubkey)
+    );
+
+    if (!verification.ok) {
+      return res.status(verification.status).json({ error: verification.error });
     }
 
     try {

--- a/pages/api/storefront/register-slug.ts
+++ b/pages/api/storefront/register-slug.ts
@@ -1,5 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getDbPool } from "@/utils/db/db-service";
+import {
+  buildStorefrontSlugCreateProof,
+  buildStorefrontSlugDeleteProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
 
 const pool = getDbPool();
 
@@ -46,6 +52,16 @@ export default async function handler(
     if (!pubkey) {
       return res.status(400).json({ error: "pubkey is required" });
     }
+
+    const verification = verifySignedHttpRequestProof(
+      extractSignedEventFromRequest(req),
+      buildStorefrontSlugDeleteProof(pubkey)
+    );
+
+    if (!verification.ok) {
+      return res.status(verification.status).json({ error: verification.error });
+    }
+
     try {
       await pool.query("DELETE FROM shop_slugs WHERE pubkey = $1", [pubkey]);
       await pool.query("DELETE FROM custom_domains WHERE pubkey = $1", [
@@ -78,6 +94,18 @@ export default async function handler(
 
   if (RESERVED_SLUGS.includes(sanitized)) {
     return res.status(400).json({ error: "This shop name is reserved" });
+  }
+
+  const verification = verifySignedHttpRequestProof(
+    extractSignedEventFromRequest(req),
+    buildStorefrontSlugCreateProof({
+      pubkey,
+      slug: sanitized,
+    })
+  );
+
+  if (!verification.ok) {
+    return res.status(verification.status).json({ error: verification.error });
   }
 
   try {

--- a/utils/nostr/request-auth.ts
+++ b/utils/nostr/request-auth.ts
@@ -204,3 +204,61 @@ export function buildDiscountCodeDeleteProof({
     },
   };
 }
+
+export function buildStorefrontSlugCreateProof({
+  pubkey,
+  slug,
+}: {
+  pubkey: string;
+  slug: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "register_storefront_slug",
+    method: "POST",
+    path: "/api/storefront/register-slug",
+    pubkey,
+    fields: {
+      slug,
+    },
+  };
+}
+
+export function buildStorefrontSlugDeleteProof(
+  pubkey: string
+): SignedHttpRequestProof {
+  return {
+    action: "delete_storefront_slug",
+    method: "DELETE",
+    path: "/api/storefront/register-slug",
+    pubkey,
+  };
+}
+
+export function buildCustomDomainCreateProof({
+  pubkey,
+  domain,
+}: {
+  pubkey: string;
+  domain: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "set_storefront_custom_domain",
+    method: "POST",
+    path: "/api/storefront/custom-domain",
+    pubkey,
+    fields: {
+      domain,
+    },
+  };
+}
+
+export function buildCustomDomainDeleteProof(
+  pubkey: string
+): SignedHttpRequestProof {
+  return {
+    action: "delete_storefront_custom_domain",
+    method: "DELETE",
+    path: "/api/storefront/custom-domain",
+    pubkey,
+  };
+}


### PR DESCRIPTION
The server trusts attacker-supplied pubkey, event fields, and slug values on public mutation endpoints. The event cache route writes directly into the DB without verifying the Nostr event signature at all, and the slug route updates shop_slugs using only the caller provided pubkey. The read side then treats that DB state as authoritative storefront data.

Reproduction steps

1. Choose a random unused 64-hex pubkey, a unique slug, and an event id.
2. POST a forged kind 30019 shop profile to https://shopstr.store/api/db/cache-event with that random pubkey.
3. POST the same pubkey and chosen slug to https://shopstr.store/api/storefront/register-slug.
4. GET https://shopstr.store/api/storefront/lookup?pubkey=<pubkey> or ?slug=<slug>.
5. Visit https://shopstr.store/shop/<slug>

I reproduced this safely on the live deployment using a random unused pubkey, then cleaned it up afterward. The server returned {"success":true} for the forged cache write, {"slug":"sec-audit-9330c384"} for slug registration, and the lookup endpoints returned my injected shop config. The public shop page also served the injected storefront name, confirming the forged data was trusted by the public web layer.
