### PR TITLE
Hide the created api key by default with a button to toggle visibility

### DIFF
--- a/pages/settings/api-keys.tsx
+++ b/pages/settings/api-keys.tsx
@@ -40,6 +40,7 @@ const ApiKeysPage = () => {
   const [newKeyName, setNewKeyName] = useState("");
   const [newKeyPermission, setNewKeyPermission] = useState("read");
   const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const [showCreatedKey, setShowCreatedKey] = useState(false);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -256,10 +257,18 @@ const ApiKeysPage = () => {
           {createdKey && (
             <div className="mx-4 mb-6 rounded-lg border border-green-400 bg-green-50 p-4 dark:bg-green-900/20">
               <p className="mb-2 text-sm font-bold text-green-800 dark:text-green-300">
-                API key created! Copy it now — it won&apos;t be shown again.
+                API key created! Copy it now — it won&apos;t be shown again.{" "}
+                <button
+                  className="text-blue-500 underline hover:text-blue-700"
+                  onClick={() => setShowCreatedKey((prev) => !prev)}
+                >
+                  {showCreatedKey ? "Hide" : "Show"}
+                </button>
               </p>
               <div className="flex items-center gap-2">
-                <code className="bg-light-bg text-light-text dark:bg-dark-bg dark:text-dark-text flex-1 rounded-lg px-3 py-2 font-mono text-sm break-all">
+                <code
+                  className={`bg-light-bg text-light-text dark:bg-dark-bg dark:text-dark-text flex-1 rounded-lg px-3 py-2 font-mono text-sm break-all ${showCreatedKey ? "" : "blur-sm"}`}
+                >
                   {createdKey}
                 </code>
                 <button

--- a/pages/settings/api-keys.tsx
+++ b/pages/settings/api-keys.tsx
@@ -100,6 +100,7 @@ const ApiKeysPage = () => {
     setIsCreating(true);
     setError(null);
     setCreatedKey(null);
+    setShowCreatedKey(false);
     try {
       const trimmedName = newKeyName.trim();
       const permissions = normalizeApiKeysPermission(newKeyPermission);


### PR DESCRIPTION
### Description
When the api key is created, it is visible by default which is not the standard way I see on most websites. It should be hidden by default with a button to toggle visibility. Most of the time a user is gonna just copy it without seeing it anyway.

### Screenshots (if applicable)  
<img width="554" height="150" alt="Screenshot 2026-04-17 at 19 57 40" src="https://github.com/user-attachments/assets/d9f703c0-c5cb-4f4a-92fe-46b97b43816f" />

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines