### PR TITLE
fix: guard chat npub decoding against malformed content

### DIFF
--- a/components/messages/__tests__/chat-message.test.tsx
+++ b/components/messages/__tests__/chat-message.test.tsx
@@ -143,6 +143,17 @@ describe("ChatMessage", () => {
       expect(setBuyerPubkey).toHaveBeenCalledWith("");
     });
 
+    test("falls back to empty buyer pubkey when npub decoding fails", () => {
+      mockNip19Decode.mockImplementation(() => {
+        throw new Error("invalid npub");
+      });
+      const { setBuyerPubkey } = renderComponent({
+        messageEvent: { content: "Broken npub npub1abcde..." },
+      });
+      expect(mockNip19Decode).toHaveBeenCalledWith("npub1abcde");
+      expect(setBuyerPubkey).toHaveBeenCalledWith("");
+    });
+
     test("calls setCanReview(true) for order-related subjects", () => {
       const { setCanReview } = renderComponent({
         messageEvent: { tags: [["subject", "order-receipt"]] },

--- a/components/messages/__tests__/chat-message.test.tsx
+++ b/components/messages/__tests__/chat-message.test.tsx
@@ -183,6 +183,7 @@ describe("ChatMessage", () => {
 
     test("renders a clickable npub link that calls router.replace", () => {
       const npub = "npub1testtest";
+      mockNip19Decode.mockReturnValue({ type: "npub", data: "decoded" });
       renderComponent({ messageEvent: { content: `Check out ${npub}` } });
       const link = screen.getByText(npub);
       expect(link).toBeInTheDocument();
@@ -191,6 +192,18 @@ describe("ChatMessage", () => {
         pathname: "/orders",
         query: { pk: npub, isInquiry: true },
       });
+    });
+
+    test("does not render malformed npub text as a clickable link", () => {
+      mockNip19Decode.mockImplementation(() => {
+        throw new Error("invalid npub");
+      });
+      renderComponent({
+        messageEvent: { content: "Broken npub npub1abcde" },
+      });
+
+      fireEvent.click(screen.getByText("Broken npub npub1abcde"));
+      expect(mockRouterReplace).not.toHaveBeenCalled();
     });
 
     test("renders a ClaimButton and copy icon for a valid cashu token", () => {

--- a/components/messages/__tests__/messages.test.tsx
+++ b/components/messages/__tests__/messages.test.tsx
@@ -236,6 +236,22 @@ describe("Messages Component", () => {
     });
   });
 
+  it("should ignore malformed pubkeys from router query", async () => {
+    mockRouter.query.pk = "broken_npub";
+    mockChatsContextValue.isLoading = false;
+    mockChatsContextValue.chatsMap = mockChatsMap;
+    mockNostrHelper.decryptNpub.mockReturnValue(null as any);
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`chat-button-${mockChatPubkey1}`)
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("chat-button-null")).not.toBeInTheDocument();
+    });
+  });
+
   it("should send a gift-wrapped message successfully", async () => {
     mockChatsContextValue.isLoading = false;
     mockChatsContextValue.chatsMap = mockChatsMap;

--- a/components/messages/chat-message.tsx
+++ b/components/messages/chat-message.tsx
@@ -18,6 +18,22 @@ function isDecodableToken(token: string): boolean {
   }
 }
 
+function decodeBuyerPubkeyFromContent(content: string): string | null {
+  const npubMatch = content.match(/npub[a-zA-Z0-9]+/);
+  if (!npubMatch) {
+    return null;
+  }
+
+  try {
+    const decoded = nip19.decode(npubMatch[0]);
+    return decoded.type === "npub" && typeof decoded.data === "string"
+      ? decoded.data
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 const ChatMessage = ({
   messageEvent,
   index = 0,
@@ -41,12 +57,8 @@ const ChatMessage = ({
 
   useEffect(() => {
     if (messageEvent?.content && messageEvent.content.includes("npub1")) {
-      // Find word containing npub using regex
-      const npubMatch = messageEvent.content.match(/npub[a-zA-Z0-9]+/);
-      if (npubMatch && setBuyerPubkey) {
-        const { data: buyerPubkey } = nip19.decode(npubMatch[0]);
-        setBuyerPubkey(buyerPubkey as string);
-      }
+      const buyerPubkey = decodeBuyerPubkeyFromContent(messageEvent.content);
+      setBuyerPubkey(buyerPubkey || "");
     } else {
       setBuyerPubkey("");
     }

--- a/components/messages/chat-message.tsx
+++ b/components/messages/chat-message.tsx
@@ -34,6 +34,15 @@ function decodeBuyerPubkeyFromContent(content: string): string | null {
   }
 }
 
+function isDecodableNpub(value: string): boolean {
+  try {
+    const decoded = nip19.decode(value);
+    return decoded.type === "npub" && typeof decoded.data === "string";
+  } catch {
+    return false;
+  }
+}
+
 const ChatMessage = ({
   messageEvent,
   index = 0,
@@ -133,7 +142,7 @@ const ChatMessage = ({
       const subParts = part.split(/(\s+)/);
       return subParts.map((sub, subIndex) => {
         const npubMatch = sub.match(/npub[a-zA-Z0-9]+/);
-        if (npubMatch) {
+        if (npubMatch && isDecodableNpub(npubMatch[0])) {
           return (
             <span
               key={`${index}-${subIndex}`}

--- a/components/messages/messages.tsx
+++ b/components/messages/messages.tsx
@@ -86,21 +86,23 @@ const Messages = ({ isPayment }: { isPayment: boolean }) => {
         const decryptedChats = await getDecryptedChatsFromContext();
         const passedNPubkey = router.query.pk ? router.query.pk : null;
         if (passedNPubkey) {
-          const pubkey = decryptNpub(passedNPubkey as string) as string;
-          if (!decryptedChats.has(pubkey)) {
-            decryptedChats.set(pubkey as string, {
-              unreadCount: 0,
-              decryptedChat: [],
-            });
-          }
-          enterChat(pubkey);
-          const productTitle = router.query.productTitle as string | undefined;
-          const productUrl = router.query.productUrl as string | undefined;
-          if (productTitle) {
-            const draftText = productUrl
-              ? `Re: "${productTitle}" — ${productUrl}\n\n`
-              : `Re: "${productTitle}"\n\n`;
-            setInitialMessage(draftText);
+          const pubkey = decryptNpub(passedNPubkey as string);
+          if (pubkey) {
+            if (!decryptedChats.has(pubkey)) {
+              decryptedChats.set(pubkey, {
+                unreadCount: 0,
+                decryptedChat: [],
+              });
+            }
+            enterChat(pubkey);
+            const productTitle = router.query.productTitle as string | undefined;
+            const productUrl = router.query.productUrl as string | undefined;
+            if (productTitle) {
+              const draftText = productUrl
+                ? `Re: "${productTitle}" — ${productUrl}\n\n`
+                : `Re: "${productTitle}"\n\n`;
+              setInitialMessage(draftText);
+            }
           }
         }
         setChatsMap(decryptedChats);

--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -1641,9 +1641,15 @@ export const LogOut = () => {
   window.dispatchEvent(new Event("storage"));
 };
 
-export const decryptNpub = (npub: string) => {
-  const { data } = nip19.decode(npub);
-  return data;
+export const decryptNpub = (npub: string): string | null => {
+  try {
+    const decoded = nip19.decode(npub);
+    return decoded.type === "npub" && typeof decoded.data === "string"
+      ? decoded.data
+      : null;
+  } catch {
+    return null;
+  }
 };
 
 export function nostrExtensionLoaded() {


### PR DESCRIPTION
## Summary
- guard buyer pubkey extraction in chat messages when npub-like text is malformed
- fall back to an empty buyer pubkey instead of letting nip19.decode throw
- add a regression test for malformed npub content

## Testing
- npm test -- chat-message.test.tsx --runInBand