### PR TITLE
Fix broken wallet events fetch

### DIFF
--- a/pages/api/db/fetch-wallet.ts
+++ b/pages/api/db/fetch-wallet.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { fetchCachedEvents } from "@/utils/db/db-service";
+import { fetchAllWalletEventsFromDb } from "@/utils/db/db-service";
 import { applyRateLimit } from "@/utils/rate-limit";
 
 const RATE_LIMIT = { limit: 600, windowMs: 60 * 1000 };
@@ -20,7 +20,12 @@ export default async function handler(
       return res.status(400).json({ error: "Invalid pubkey parameter" });
     }
 
-    const walletEvents = await fetchCachedEvents(null as any, { pubkey });
+    const normalizedPubkey = pubkey.trim();
+    if (!normalizedPubkey) {
+      return res.status(400).json({ error: "Invalid pubkey parameter" });
+    }
+
+    const walletEvents = await fetchAllWalletEventsFromDb(normalizedPubkey);
     res.status(200).json(walletEvents);
   } catch (error) {
     console.error("Failed to fetch wallet events from database:", error);


### PR DESCRIPTION
### Description
 `fetch-wallet` handler currently calls `getCachedEvents` with `null` kind which immediately returns empty response. this commit fixes that replacing `getCachedEvents` with `fetchAllWalletEventsFromDb` which correctly fetches the wallet events.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines