### PR TITLE
Harden order status API input validation and request bounds

### DIFF
--- a/pages/api/db/__tests__/get-order-statuses.test.ts
+++ b/pages/api/db/__tests__/get-order-statuses.test.ts
@@ -1,0 +1,84 @@
+const getOrderStatusesMock = jest.fn();
+
+jest.mock("@/utils/db/db-service", () => ({
+  getOrderStatuses: (...args: unknown[]) => getOrderStatusesMock(...args),
+}));
+
+import handler from "@/pages/api/db/get-order-statuses";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    setHeader(key: string, value: string) {
+      this.headers[key] = value;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      return this;
+    },
+  };
+}
+
+describe("/api/db/get-order-statuses", () => {
+  beforeEach(() => {
+    getOrderStatusesMock.mockReset();
+  });
+
+  it("rejects non-string orderIds payloads", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: { orderIds: ["order-1", 123] },
+    } as any;
+    const res = createResponse();
+
+    await handler(req, res as any);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonBody).toEqual({
+      error: "Invalid orderIds. Expected a string or array of strings.",
+    });
+  });
+
+  it("rejects requests with too many order IDs", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: {
+        orderIds: Array.from({ length: 201 }, (_, index) => `order-${index}`),
+      },
+    } as any;
+    const res = createResponse();
+
+    await handler(req, res as any);
+
+    expect(res.statusCode).toBe(413);
+    expect(res.jsonBody).toEqual({
+      error: "Too many order IDs. Maximum allowed is 200.",
+    });
+  });
+
+  it("dedupes IDs before querying", async () => {
+    getOrderStatusesMock.mockResolvedValue({ "order-1": "shipped" });
+
+    const req = {
+      method: "POST",
+      headers: {},
+      body: { orderIds: ["order-1", "order-1", " order-2 "] },
+    } as any;
+    const res = createResponse();
+
+    await handler(req, res as any);
+
+    expect(getOrderStatusesMock).toHaveBeenCalledWith(["order-1", "order-2"]);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody).toEqual({ statuses: { "order-1": "shipped" } });
+  });
+});

--- a/pages/api/db/__tests__/get-order-statuses.test.ts
+++ b/pages/api/db/__tests__/get-order-statuses.test.ts
@@ -6,6 +6,14 @@ jest.mock("@/utils/db/db-service", () => ({
 
 import handler from "@/pages/api/db/get-order-statuses";
 
+const getExpectedMaxOrderIds = () => {
+  const configured = Number.parseInt(
+    process.env.MAX_ORDER_IDS_PER_REQUEST || "",
+    10
+  );
+  return Number.isFinite(configured) && configured > 0 ? configured : 200;
+};
+
 function createResponse() {
   return {
     statusCode: 200,
@@ -48,11 +56,15 @@ describe("/api/db/get-order-statuses", () => {
   });
 
   it("rejects requests with too many order IDs", async () => {
+    const maxOrderIds = getExpectedMaxOrderIds();
     const req = {
       method: "POST",
       headers: {},
       body: {
-        orderIds: Array.from({ length: 201 }, (_, index) => `order-${index}`),
+        orderIds: Array.from(
+          { length: maxOrderIds + 1 },
+          (_, index) => `order-${index}`
+        ),
       },
     } as any;
     const res = createResponse();
@@ -61,8 +73,23 @@ describe("/api/db/get-order-statuses", () => {
 
     expect(res.statusCode).toBe(413);
     expect(res.jsonBody).toEqual({
-      error: "Too many order IDs. Maximum allowed is 200.",
+      error: `Too many order IDs. Maximum allowed is ${maxOrderIds}.`,
     });
+  });
+
+  it("returns empty statuses when orderIds is omitted", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: {},
+    } as any;
+    const res = createResponse();
+
+    await handler(req, res as any);
+
+    expect(getOrderStatusesMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody).toEqual({ statuses: {} });
   });
 
   it("dedupes IDs before querying", async () => {

--- a/pages/api/db/get-order-statuses.ts
+++ b/pages/api/db/get-order-statuses.ts
@@ -16,6 +16,10 @@ const MAX_ORDER_IDS_PER_REQUEST = (() => {
 const MAX_ORDER_ID_LENGTH = 128;
 
 function normalizeOrderIds(orderIds: unknown): string[] | null {
+  if (orderIds === null || orderIds === undefined) {
+    return [];
+  }
+
   if (typeof orderIds === "string") {
     const trimmed = orderIds.trim();
     return trimmed ? [trimmed] : [];

--- a/pages/api/db/get-order-statuses.ts
+++ b/pages/api/db/get-order-statuses.ts
@@ -6,7 +6,13 @@ import { applyRateLimit } from "@/utils/rate-limit";
 // so a tab opened on multiple orders does not throttle, but bounded so a
 // single client can't keep this hot path saturated.
 const RATE_LIMIT = { limit: 600, windowMs: 60 * 1000 };
-const MAX_ORDER_IDS_PER_REQUEST = 200;
+const MAX_ORDER_IDS_PER_REQUEST = (() => {
+  const configured = Number.parseInt(
+    process.env.MAX_ORDER_IDS_PER_REQUEST || "",
+    10
+  );
+  return Number.isFinite(configured) && configured > 0 ? configured : 200;
+})();
 const MAX_ORDER_ID_LENGTH = 128;
 
 function normalizeOrderIds(orderIds: unknown): string[] | null {
@@ -24,6 +30,7 @@ function normalizeOrderIds(orderIds: unknown): string[] | null {
     if (typeof value !== "string") {
       return null;
     }
+    // Normalize whitespace to avoid accidental client-side mismatches.
     const trimmed = value.trim();
     if (trimmed) {
       normalized.push(trimmed);

--- a/pages/api/db/get-order-statuses.ts
+++ b/pages/api/db/get-order-statuses.ts
@@ -6,6 +6,32 @@ import { applyRateLimit } from "@/utils/rate-limit";
 // so a tab opened on multiple orders does not throttle, but bounded so a
 // single client can't keep this hot path saturated.
 const RATE_LIMIT = { limit: 600, windowMs: 60 * 1000 };
+const MAX_ORDER_IDS_PER_REQUEST = 200;
+const MAX_ORDER_ID_LENGTH = 128;
+
+function normalizeOrderIds(orderIds: unknown): string[] | null {
+  if (typeof orderIds === "string") {
+    const trimmed = orderIds.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  if (!Array.isArray(orderIds)) {
+    return null;
+  }
+
+  const normalized: string[] = [];
+  for (const value of orderIds) {
+    if (typeof value !== "string") {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      normalized.push(trimmed);
+    }
+  }
+
+  return normalized;
+}
 
 export default async function handler(
   req: NextApiRequest,
@@ -20,11 +46,30 @@ export default async function handler(
   const orderIds =
     req.method === "POST" ? req.body.orderIds : req.query.orderIds;
 
-  if (!orderIds || (Array.isArray(orderIds) && orderIds.length === 0)) {
+  const normalizedOrderIds = normalizeOrderIds(orderIds);
+  if (normalizedOrderIds === null) {
+    return res.status(400).json({
+      error: "Invalid orderIds. Expected a string or array of strings.",
+    });
+  }
+
+  if (normalizedOrderIds.length === 0) {
     return res.status(200).json({ statuses: {} });
   }
 
-  const orderIdArray = Array.isArray(orderIds) ? orderIds : [orderIds];
+  if (normalizedOrderIds.length > MAX_ORDER_IDS_PER_REQUEST) {
+    return res.status(413).json({
+      error: `Too many order IDs. Maximum allowed is ${MAX_ORDER_IDS_PER_REQUEST}.`,
+    });
+  }
+
+  if (normalizedOrderIds.some((id) => id.length > MAX_ORDER_ID_LENGTH)) {
+    return res.status(400).json({
+      error: `Invalid order ID length. Maximum length is ${MAX_ORDER_ID_LENGTH}.`,
+    });
+  }
+
+  const orderIdArray = Array.from(new Set(normalizedOrderIds));
 
   try {
     const statuses = await getOrderStatuses(orderIdArray);


### PR DESCRIPTION
## Description
This PR strengthens the order status read endpoint against malformed or abusive payloads while preserving existing behaviour for valid clients.

1. Added strict normalisation and validation of orderIds input in get-order-statuses.ts.
2. Enforced request-size protection with a maximum number of IDs per request.
3. Added order ID length validation to prevent oversized identifiers from hitting DB queries.
4. Added deduplication before DB access to reduce redundant query work.
5. Preserved clean response semantics:
 - 400 for invalid payload shape or invalid ID length
 - 413 for oversized request batches
 - 200 with empty statuses for empty valid input
6. Made max batch size configurable via env with a safe default fallback.
7. Documented normalization intent (whitespace trimming) in code comments.

## Why this matters
1. Reduces hot-path DB pressure for a frequently polled endpoint.
2. Prevents easy payload-amplification patterns.
3. Improves API contract clarity for clients and maintainers.
4. Increases operational safety without changing successful client flows.

## Tests
Added focused API tests in get-order-statuses.test.ts to verify:

1. Rejection of non-string orderIds payloads.
2. Rejection of oversized ID batches.
3. Deduplication behaviour before querying DB.

### Resolved or fixed issue
#428 

