### PR TITLE
Require auth for cached message reads

### DIFF
--- a/pages/api/db/__tests__/fetch-messages.test.ts
+++ b/pages/api/db/__tests__/fetch-messages.test.ts
@@ -1,0 +1,186 @@
+const fetchAllMessagesFromDbMock = jest.fn();
+const applyRateLimitMock = jest.fn();
+const extractSignedEventFromRequestMock = jest.fn();
+const verifySignedHttpRequestProofMock = jest.fn();
+
+jest.mock("@/utils/db/db-service", () => ({
+  fetchAllMessagesFromDb: (...args: unknown[]) =>
+    fetchAllMessagesFromDbMock(...args),
+}));
+
+jest.mock("@/utils/rate-limit", () => ({
+  applyRateLimit: (...args: unknown[]) => applyRateLimitMock(...args),
+}));
+
+jest.mock("@/utils/nostr/request-auth", () => ({
+  buildMessagesListProof: (pubkey: string) => ({ pubkey }),
+  extractSignedEventFromRequest: (...args: unknown[]) =>
+    extractSignedEventFromRequestMock(...args),
+  verifySignedHttpRequestProof: (...args: unknown[]) =>
+    verifySignedHttpRequestProofMock(...args),
+}));
+
+import type { NextApiRequest, NextApiResponse } from "next";
+import handler from "@/pages/api/db/fetch-messages";
+
+type MockApiResponse = NextApiResponse & {
+  body: unknown;
+  headers: Record<string, string>;
+  statusCode: number;
+};
+
+const createResponse = () => {
+  const response = {
+    headers: {} as Record<string, string>,
+    statusCode: 200,
+    body: undefined as unknown,
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return response as unknown as MockApiResponse;
+};
+
+const makeRequest = (
+  query: NextApiRequest["query"],
+  method = "GET"
+): NextApiRequest =>
+  ({
+    method,
+    query,
+    headers: {},
+  }) as Partial<NextApiRequest> as NextApiRequest;
+
+const VALID_PUBKEY = "a".repeat(64);
+
+describe("/api/db/fetch-messages", () => {
+  beforeEach(() => {
+    fetchAllMessagesFromDbMock.mockReset();
+    applyRateLimitMock.mockReset();
+    extractSignedEventFromRequestMock.mockReset();
+    verifySignedHttpRequestProofMock.mockReset();
+    applyRateLimitMock.mockReturnValue(true);
+    verifySignedHttpRequestProofMock.mockReturnValue({ ok: true, status: 200 });
+  });
+
+  it("returns 405 for non-GET requests", async () => {
+    const res = createResponse();
+
+    await handler(makeRequest({}, "POST"), res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toEqual({ error: "Method not allowed" });
+    expect(fetchAllMessagesFromDbMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when pubkey is missing", async () => {
+    const res = createResponse();
+
+    await handler(makeRequest({}), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid pubkey parameter" });
+    expect(extractSignedEventFromRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when pubkey is invalid", async () => {
+    const res = createResponse();
+
+    await handler(makeRequest({ pubkey: "not-a-pubkey" }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid pubkey parameter" });
+    expect(extractSignedEventFromRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the signed request proof is missing or invalid", async () => {
+    extractSignedEventFromRequestMock.mockReturnValue(undefined);
+    verifySignedHttpRequestProofMock.mockReturnValue({
+      ok: false,
+      status: 401,
+      error: "A signed Nostr request proof is required to prove pubkey ownership.",
+    });
+    const res = createResponse();
+
+    await handler(makeRequest({ pubkey: VALID_PUBKEY }), res);
+
+    expect(extractSignedEventFromRequestMock).toHaveBeenCalledTimes(1);
+    expect(verifySignedHttpRequestProofMock).toHaveBeenCalledWith(undefined, {
+      pubkey: VALID_PUBKEY,
+    });
+    expect(fetchAllMessagesFromDbMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      error:
+        "A signed Nostr request proof is required to prove pubkey ownership.",
+    });
+  });
+
+  it("normalizes the pubkey before verifying ownership and querying", async () => {
+    fetchAllMessagesFromDbMock.mockResolvedValue([]);
+    extractSignedEventFromRequestMock.mockReturnValue({ pubkey: VALID_PUBKEY });
+    const res = createResponse();
+
+    await handler(makeRequest({ pubkey: `  ${"A".repeat(64)}  ` }), res);
+
+    expect(verifySignedHttpRequestProofMock).toHaveBeenCalledWith(
+      { pubkey: VALID_PUBKEY },
+      { pubkey: VALID_PUBKEY }
+    );
+    expect(fetchAllMessagesFromDbMock).toHaveBeenCalledWith(VALID_PUBKEY);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("returns messages for an authorized pubkey", async () => {
+    const messages = [
+      {
+        id: "msg-1",
+        pubkey: VALID_PUBKEY,
+        created_at: 1,
+        kind: 1059,
+        tags: [],
+        content: "encrypted",
+        sig: "sig",
+        is_read: false,
+      },
+    ];
+    fetchAllMessagesFromDbMock.mockResolvedValue(messages);
+    extractSignedEventFromRequestMock.mockReturnValue({ pubkey: VALID_PUBKEY });
+    const res = createResponse();
+
+    await handler(makeRequest({ pubkey: VALID_PUBKEY }), res);
+
+    expect(fetchAllMessagesFromDbMock).toHaveBeenCalledWith(VALID_PUBKEY);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(messages);
+  });
+
+  it("returns 500 when the database call throws", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    fetchAllMessagesFromDbMock.mockRejectedValue(new Error("db down"));
+    extractSignedEventFromRequestMock.mockReturnValue({ pubkey: VALID_PUBKEY });
+    const res = createResponse();
+
+    await handler(makeRequest({ pubkey: VALID_PUBKEY }), res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "Failed to fetch messages" });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to fetch messages from database:",
+      expect.any(Error)
+    );
+  });
+});

--- a/pages/api/db/fetch-messages.ts
+++ b/pages/api/db/fetch-messages.ts
@@ -1,10 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fetchAllMessagesFromDb } from "@/utils/db/db-service";
+import {
+  buildMessagesListProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
 import { applyRateLimit } from "@/utils/rate-limit";
 
 // Polled by the messages dashboard during active conversations; per-IP cap
 // is high enough to cover normal use while bounding a single client.
 const RATE_LIMIT = { limit: 600, windowMs: 60 * 1000 };
+const HEX_PUBKEY_REGEX = /^[0-9a-f]{64}$/;
 
 export default async function handler(
   req: NextApiRequest,
@@ -22,7 +28,24 @@ export default async function handler(
       return res.status(400).json({ error: "Invalid pubkey parameter" });
     }
 
-    const messages = await fetchAllMessagesFromDb(pubkey);
+    const normalizedPubkey = pubkey.trim().toLowerCase();
+    if (!HEX_PUBKEY_REGEX.test(normalizedPubkey)) {
+      return res.status(400).json({ error: "Invalid pubkey parameter" });
+    }
+
+    const signedEvent = extractSignedEventFromRequest(req);
+    const verification = verifySignedHttpRequestProof(
+      signedEvent,
+      buildMessagesListProof(normalizedPubkey)
+    );
+
+    if (!verification.ok) {
+      return res
+        .status(verification.status)
+        .json({ error: verification.error });
+    }
+
+    const messages = await fetchAllMessagesFromDb(normalizedPubkey);
     res.status(200).json(messages);
   } catch (error) {
     console.error("Failed to fetch messages from database:", error);

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -26,6 +26,11 @@ import { hashToCurve } from "@cashu/cashu-ts";
 import { NostrManager } from "@/utils/nostr/nostr-manager";
 import { NostrSigner } from "@/utils/nostr/signers/nostr-signer";
 import { cacheEventsToDatabase } from "@/utils/db/db-client";
+import {
+  buildMessagesListProof,
+  buildSignedHttpRequestProofTemplate,
+  SIGNED_EVENT_HEADER,
+} from "@/utils/nostr/request-auth";
 
 interface NipProfile {
   pubkey: string;
@@ -568,8 +573,22 @@ export const fetchGiftWrappedChatsAndMessages = async (
       const chatMessagesFromCache = new Map<string, NostrMessageEvent>();
 
       try {
+        const responseInit: RequestInit = {};
+
+        if (signer) {
+          const signedEvent = await signer.sign(
+            buildSignedHttpRequestProofTemplate(
+              buildMessagesListProof(userPubkey)
+            )
+          );
+          responseInit.headers = {
+            [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+          };
+        }
+
         const response = await fetch(
-          `/api/db/fetch-messages?pubkey=${userPubkey}`
+          `/api/db/fetch-messages?pubkey=${userPubkey}`,
+          responseInit
         );
         if (response.ok) {
           const messagesFromDb = await response.json();

--- a/utils/nostr/request-auth.ts
+++ b/utils/nostr/request-auth.ts
@@ -163,6 +163,15 @@ export function buildDiscountCodesListProof(
   };
 }
 
+export function buildMessagesListProof(pubkey: string): SignedHttpRequestProof {
+  return {
+    action: "list_messages",
+    method: "GET",
+    path: "/api/db/fetch-messages",
+    pubkey,
+  };
+}
+
 export function buildDiscountCodeCreateProof({
   code,
   pubkey,


### PR DESCRIPTION
The server trusts the caller-supplied `pubkey` on `/api/db/fetch-messages` and returns cached gift-wrapped message records plus per-message `is_read` state without proving ownership of that pubkey. A browser user can swap the query parameter in DevTools and read another Shopstr user's private inbox metadata from the live deployment.

Reproduction steps

1. Open `https://shopstr.market` in a browser.
2. Open DevTools and run:
   `fetch('/api/db/fetch-messages?pubkey=0000000287d80000b421da1ef9556a969689c1c21d45582b6184cc5162799156').then((r) => r.json()).then(console.log)`
3. Observe that the response returns cached kind `1059` gift-wrapped messages for that victim pubkey.
4. Observe that each row also exposes the private `is_read` flag.

I safely reproduced this on the live deployment on April 19, 2026. The endpoint returned two cached message records for `0000000287d80000b421da1ef9556a969689c1c21d45582b6184cc5162799156`, both with `is_read: false`, confirming that another user's inbox metadata is readable without authentication.

This patch requires the same signed request proof pattern already used by other private cache endpoints, and updates the message bootstrap path to attach that proof before reading from the DB. It also adds regression coverage for unauthorized reads, pubkey normalization, and the authorized success path.
