### PR TITLE
Stored javascript: storefront links allow seller to visitor script execution

### DIFF
--- a/components/settings/shop-profile-form.tsx
+++ b/components/settings/shop-profile-form.tsx
@@ -40,6 +40,7 @@ import SectionEditor from "./storefront/section-editor";
 import FooterEditor from "./storefront/footer-editor";
 import PageEditor from "./storefront/page-editor";
 import StorefrontPreviewModal from "./storefront/storefront-preview-modal";
+import { sanitizeStorefrontConfigLinks } from "@/utils/storefront-links";
 
 interface ShopProfileFormProps {
   isOnboarding?: boolean;
@@ -352,7 +353,7 @@ const ShopProfileForm = ({ isOnboarding = false }: ShopProfileFormProps) => {
       transformedData.freeShippingCurrency = freeShippingCurrency;
     }
     if (shopSlug) {
-      const storefrontConfig: StorefrontConfig = {
+      const storefrontConfig = sanitizeStorefrontConfigLinks({
         colorScheme: colors,
         productLayout,
         landingPageStyle,
@@ -367,7 +368,7 @@ const ShopProfileForm = ({ isOnboarding = false }: ShopProfileFormProps) => {
         showCommunityPage: showCommunityPage || undefined,
         showWalletPage: showWalletPage || undefined,
         contactEmail: contactEmail || undefined,
-      };
+      });
       transformedData.storefront = storefrontConfig;
     }
     await createNostrShopEvent(
@@ -500,22 +501,23 @@ const ShopProfileForm = ({ isOnboarding = false }: ShopProfileFormProps) => {
     }
   };
 
-  const buildStorefrontConfig = (): StorefrontConfig => ({
-    colorScheme: colors,
-    productLayout,
-    landingPageStyle,
-    shopSlug: shopSlug || undefined,
-    customDomain: customDomain || undefined,
-    fontHeading: fontHeading || undefined,
-    fontBody: fontBody || undefined,
-    sections: sections.length > 0 ? sections : undefined,
-    pages: pages.length > 0 ? pages : undefined,
-    footer,
-    navLinks: navLinks.length > 0 ? navLinks : undefined,
-    showCommunityPage: showCommunityPage || undefined,
-    showWalletPage: showWalletPage || undefined,
-    contactEmail: contactEmail || undefined,
-  });
+  const buildStorefrontConfig = (): StorefrontConfig =>
+    sanitizeStorefrontConfigLinks({
+      colorScheme: colors,
+      productLayout,
+      landingPageStyle,
+      shopSlug: shopSlug || undefined,
+      customDomain: customDomain || undefined,
+      fontHeading: fontHeading || undefined,
+      fontBody: fontBody || undefined,
+      sections: sections.length > 0 ? sections : undefined,
+      pages: pages.length > 0 ? pages : undefined,
+      footer,
+      navLinks: navLinks.length > 0 ? navLinks : undefined,
+      showCommunityPage: showCommunityPage || undefined,
+      showWalletPage: showWalletPage || undefined,
+      contactEmail: contactEmail || undefined,
+    });
 
   const saveStorefront = async () => {
     const newSf = buildStorefrontConfig();

--- a/components/storefront/sections/section-about.tsx
+++ b/components/storefront/sections/section-about.tsx
@@ -1,5 +1,6 @@
 import { StorefrontSection, StorefrontColorScheme } from "@/utils/types/types";
 import { sanitizeUrl } from "@braintree/sanitize-url";
+import { sanitizeStorefrontSectionLink } from "@/utils/storefront-links";
 
 interface SectionAboutProps {
   section: StorefrontSection;
@@ -42,7 +43,7 @@ export default function SectionAbout({ section, colors }: SectionAboutProps) {
           )}
           {section.ctaText && (
             <a
-              href={section.ctaLink || "#products"}
+              href={sanitizeStorefrontSectionLink(section.ctaLink)}
               className="mt-6 inline-block rounded-lg px-6 py-3 font-bold transition-transform hover:-translate-y-0.5"
               style={{
                 backgroundColor: colors.primary,

--- a/components/storefront/sections/section-hero.tsx
+++ b/components/storefront/sections/section-hero.tsx
@@ -1,6 +1,7 @@
 import { StorefrontSection, StorefrontColorScheme } from "@/utils/types/types";
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import { getNavTextColor } from "@/utils/storefront-colors";
+import { sanitizeStorefrontSectionLink } from "@/utils/storefront-links";
 
 interface SectionHeroProps {
   section: StorefrontSection;
@@ -77,7 +78,7 @@ export default function SectionHero({
 
         {section.ctaText && (
           <a
-            href={section.ctaLink || "#products"}
+            href={sanitizeStorefrontSectionLink(section.ctaLink)}
             className="mt-8 inline-block rounded-lg px-8 py-3 text-base font-bold transition-transform hover:-translate-y-0.5"
             style={{
               backgroundColor: colors.primary,

--- a/components/storefront/storefront-footer.tsx
+++ b/components/storefront/storefront-footer.tsx
@@ -7,6 +7,11 @@ import {
 } from "@/utils/storefront-policies";
 import Link from "next/link";
 import { getNavTextColor } from "@/utils/storefront-colors";
+import {
+  isExternalStorefrontHref,
+  sanitizeStorefrontNavHref,
+  sanitizeStorefrontSocialLink,
+} from "@/utils/storefront-links";
 
 interface StorefrontFooterProps {
   footer: StorefrontFooter;
@@ -70,9 +75,27 @@ export default function StorefrontFooterComponent({
           {navLinks.length > 0 && (
             <div className="flex flex-wrap justify-center gap-x-6 gap-y-2">
               {navLinks.map((link, idx) => {
-                const href = link.isPage
-                  ? `/shop/${shopSlug}/${link.href}`
-                  : link.href;
+                const href = sanitizeStorefrontNavHref(link, shopSlug);
+
+                if (isExternalStorefrontHref(href)) {
+                  return (
+                    <a
+                      key={idx}
+                      href={href}
+                      target={href.startsWith("http") ? "_blank" : undefined}
+                      rel={
+                        href.startsWith("http")
+                          ? "noopener noreferrer"
+                          : undefined
+                      }
+                      className="font-body text-sm opacity-60 transition-opacity hover:opacity-100"
+                      style={{ color: footerTextColor }}
+                    >
+                      {link.label}
+                    </a>
+                  );
+                }
+
                 return (
                   <Link
                     key={idx}
@@ -89,22 +112,30 @@ export default function StorefrontFooterComponent({
 
           {socialLinks.length > 0 && (
             <div className="flex gap-4">
-              {socialLinks.map((social, idx) => (
-                <a
-                  key={idx}
-                  href={social.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex h-10 w-10 items-center justify-center rounded-full text-lg transition-transform hover:scale-110"
-                  style={{
-                    backgroundColor: colors.primary + "22",
-                    color: colors.primary,
-                  }}
-                  title={social.label || social.platform}
-                >
-                  {SOCIAL_ICONS[social.platform] || SOCIAL_ICONS.other}
-                </a>
-              ))}
+              {socialLinks.map((social, idx) => {
+                const href = sanitizeStorefrontSocialLink(social.url);
+
+                return (
+                  <a
+                    key={idx}
+                    href={href}
+                    target={href.startsWith("http") ? "_blank" : undefined}
+                    rel={
+                      href.startsWith("http")
+                        ? "noopener noreferrer"
+                        : undefined
+                    }
+                    className="flex h-10 w-10 items-center justify-center rounded-full text-lg transition-transform hover:scale-110"
+                    style={{
+                      backgroundColor: colors.primary + "22",
+                      color: colors.primary,
+                    }}
+                    title={social.label || social.platform}
+                  >
+                    {SOCIAL_ICONS[social.platform] || SOCIAL_ICONS.other}
+                  </a>
+                );
+              })}
             </div>
           )}
         </div>

--- a/components/storefront/storefront-layout.tsx
+++ b/components/storefront/storefront-layout.tsx
@@ -42,6 +42,10 @@ import StorefrontWallet from "./storefront-wallet";
 import StorefrontMyListings from "./storefront-my-listings";
 import StorefrontOrderConfirmation from "./storefront-order-confirmation";
 import StorefrontPolicyPage from "./storefront-policy-page";
+import {
+  isExternalStorefrontHref,
+  sanitizeStorefrontNavHref,
+} from "@/utils/storefront-links";
 
 const DEFAULT_COLORS: StorefrontColorScheme = {
   primary: "#a438ba",
@@ -349,20 +353,6 @@ export default function StorefrontLayout({
 
   const homeHref = shopSlug ? `/shop/${shopSlug}` : "/marketplace";
 
-  const resolveNavHref = (link: StorefrontNavLink) => {
-    if (link.isPage) return `/shop/${shopSlug}/${link.href}`;
-    if (
-      link.href.startsWith("/") ||
-      link.href.startsWith("http") ||
-      link.href.startsWith("mailto:")
-    )
-      return link.href;
-    return `/shop/${shopSlug}/${link.href}`;
-  };
-
-  const isExternalNavHref = (href: string) =>
-    href.startsWith("http") || href.startsWith("mailto:");
-
   const themedCss = `
     body.sf-active [data-overlay-container] .border-black { border-color: var(--sf-secondary) !important; }
     body.sf-active [data-overlay-container] .bg-white { background-color: var(--sf-bg) !important; }
@@ -432,7 +422,7 @@ export default function StorefrontLayout({
             {defaultNavLinks.length > 0 && (
               <div className="hidden items-center gap-1 lg:flex">
                 {defaultNavLinks.map((link, idx) => {
-                  const href = resolveNavHref(link);
+                  const href = sanitizeStorefrontNavHref(link, shopSlug, homeHref);
                   const isActive = currentPage
                     ? link.href === currentPage
                     : link.href === "" || link.href === "/";
@@ -441,7 +431,7 @@ export default function StorefrontLayout({
                   };
                   const linkClass =
                     "rounded-md px-3 py-2 text-sm font-medium transition-colors";
-                  if (isExternalNavHref(href)) {
+                  if (isExternalStorefrontHref(href)) {
                     return (
                       <a
                         key={idx}
@@ -544,10 +534,10 @@ export default function StorefrontLayout({
             >
               {defaultNavLinks.length > 0 &&
                 defaultNavLinks.map((link, idx) => {
-                  const href = resolveNavHref(link);
+                  const href = sanitizeStorefrontNavHref(link, shopSlug, homeHref);
                   const mobileClass = "block px-6 py-3 text-sm font-medium";
                   const mobileStyle = { color: navTextColor + "CC" };
-                  if (isExternalNavHref(href)) {
+                  if (isExternalStorefrontHref(href)) {
                     return (
                       <a
                         key={idx}

--- a/utils/__tests__/storefront-links.test.ts
+++ b/utils/__tests__/storefront-links.test.ts
@@ -1,0 +1,81 @@
+import {
+  isExternalStorefrontHref,
+  sanitizeStorefrontConfigLinks,
+  sanitizeStorefrontNavHref,
+  sanitizeStorefrontSectionLink,
+  sanitizeStorefrontSocialLink,
+} from "@/utils/storefront-links";
+
+describe("storefront link sanitization", () => {
+  it("blocks javascript urls in section CTAs", () => {
+    expect(sanitizeStorefrontSectionLink("javascript:alert(1)")).toBe(
+      "#products"
+    );
+  });
+
+  it("blocks javascript urls in social links", () => {
+    expect(sanitizeStorefrontSocialLink("javascript:alert(1)")).toBe("#");
+  });
+
+  it("converts page nav links into shop-relative routes", () => {
+    expect(
+      sanitizeStorefrontNavHref(
+        { label: "Orders", href: "orders", isPage: true },
+        "securityshop"
+      )
+    ).toBe("/shop/securityshop/orders");
+  });
+
+  it("falls back when custom nav links use blocked schemes", () => {
+    expect(
+      sanitizeStorefrontNavHref(
+        { label: "Malicious", href: "javascript:alert(1)" },
+        "securityshop"
+      )
+    ).toBe("/shop/securityshop");
+  });
+
+  it("preserves safe external href detection", () => {
+    expect(isExternalStorefrontHref("https://shopstr.market")).toBe(true);
+    expect(isExternalStorefrontHref("mailto:test@shopstr.market")).toBe(true);
+    expect(isExternalStorefrontHref("/shop/securityshop")).toBe(false);
+  });
+
+  it("sanitizes stored storefront config links before publish", () => {
+    const sanitized = sanitizeStorefrontConfigLinks({
+      shopSlug: "securityshop",
+      sections: [
+        {
+          type: "hero",
+          ctaText: "Click",
+          ctaLink: "javascript:alert(1)",
+        },
+      ],
+      pages: [
+        {
+          id: "terms",
+          title: "Terms",
+          slug: "terms",
+          sections: [
+            {
+              type: "about",
+              ctaText: "Learn more",
+              ctaLink: "javascript:alert(1)",
+            },
+          ],
+        },
+      ],
+      navLinks: [{ label: "Docs", href: "javascript:alert(1)" }],
+      footer: {
+        socialLinks: [{ platform: "website", url: "javascript:alert(1)" }],
+        navLinks: [{ label: "Custom", href: "javascript:alert(1)" }],
+      },
+    });
+
+    expect(sanitized.sections?.[0]?.ctaLink).toBe("#products");
+    expect(sanitized.pages?.[0]?.sections[0]?.ctaLink).toBe("#products");
+    expect(sanitized.navLinks?.[0]?.href).toBe("/shop/securityshop");
+    expect(sanitized.footer?.socialLinks?.[0]?.url).toBe("#");
+    expect(sanitized.footer?.navLinks?.[0]?.href).toBe("/shop/securityshop");
+  });
+});

--- a/utils/storefront-links.ts
+++ b/utils/storefront-links.ts
@@ -1,0 +1,132 @@
+import { sanitizeUrl } from "@braintree/sanitize-url";
+import {
+  StorefrontConfig,
+  StorefrontFooter,
+  StorefrontNavLink,
+  StorefrontPage,
+  StorefrontSection,
+  StorefrontSocialLink,
+} from "@/utils/types/types";
+
+const BLOCKED_URL = "about:blank";
+const ABSOLUTE_SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+const EXTERNAL_HREF_RE = /^(https?:|mailto:|tel:)/i;
+
+function hasBlockedScheme(value: string): boolean {
+  return /^(javascript|vbscript|data|file):/i.test(value.trim());
+}
+
+function normalizeRelativeShopPath(value: string, shopSlug: string): string {
+  const trimmed = value.trim().replace(/^\/+/, "");
+  return shopSlug ? `/shop/${shopSlug}/${trimmed}` : `/${trimmed}`;
+}
+
+export function sanitizeStorefrontHref(
+  value: string | undefined,
+  fallback: string
+): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return fallback;
+  if (trimmed.startsWith("#")) return trimmed;
+  if (hasBlockedScheme(trimmed)) return fallback;
+
+  const sanitized = sanitizeUrl(trimmed);
+  if (!sanitized || sanitized === BLOCKED_URL) return fallback;
+
+  return sanitized;
+}
+
+export function sanitizeStorefrontSectionLink(
+  value: string | undefined,
+  fallback = "#products"
+): string {
+  return sanitizeStorefrontHref(value, fallback);
+}
+
+export function sanitizeStorefrontSocialLink(
+  value: string | undefined,
+  fallback = "#"
+): string {
+  return sanitizeStorefrontHref(value, fallback);
+}
+
+export function sanitizeStorefrontNavHref(
+  link: StorefrontNavLink,
+  shopSlug: string,
+  fallback?: string
+): string {
+  const safeFallback = fallback || (shopSlug ? `/shop/${shopSlug}` : "/");
+  const trimmed = link.href?.trim();
+
+  if (!trimmed) return safeFallback;
+  if (link.isPage) return normalizeRelativeShopPath(trimmed, shopSlug);
+  if (trimmed.startsWith("#")) return trimmed;
+  if (trimmed.startsWith("/")) return sanitizeStorefrontHref(trimmed, safeFallback);
+  if (ABSOLUTE_SCHEME_RE.test(trimmed)) {
+    return sanitizeStorefrontHref(trimmed, safeFallback);
+  }
+
+  return sanitizeStorefrontHref(
+    normalizeRelativeShopPath(trimmed, shopSlug),
+    safeFallback
+  );
+}
+
+export function isExternalStorefrontHref(href: string): boolean {
+  return EXTERNAL_HREF_RE.test(href);
+}
+
+function sanitizeSection(section: StorefrontSection): StorefrontSection {
+  if (!section.ctaLink) return section;
+
+  return {
+    ...section,
+    ctaLink: sanitizeStorefrontSectionLink(section.ctaLink),
+  };
+}
+
+function sanitizePage(page: StorefrontPage): StorefrontPage {
+  return {
+    ...page,
+    sections: page.sections.map(sanitizeSection),
+  };
+}
+
+function sanitizeFooter(footer: StorefrontFooter, shopSlug: string): StorefrontFooter {
+  return {
+    ...footer,
+    socialLinks: footer.socialLinks?.map(
+      (link): StorefrontSocialLink => ({
+        ...link,
+        url: sanitizeStorefrontSocialLink(link.url),
+      })
+    ),
+    navLinks: footer.navLinks?.map(
+      (link): StorefrontNavLink => ({
+        ...link,
+        href: sanitizeStorefrontNavHref(link, shopSlug),
+      })
+    ),
+  };
+}
+
+export function sanitizeStorefrontConfigLinks(
+  storefront: StorefrontConfig
+): StorefrontConfig {
+  const shopSlug = storefront.shopSlug || "";
+
+  return {
+    ...storefront,
+    sections: storefront.sections?.map(sanitizeSection),
+    pages: storefront.pages?.map(sanitizePage),
+    navLinks: storefront.navLinks?.map(
+      (link): StorefrontNavLink => ({
+        ...link,
+        href: sanitizeStorefrontNavHref(link, shopSlug),
+      })
+    ),
+    footer: storefront.footer
+      ? sanitizeFooter(storefront.footer, shopSlug)
+      : storefront.footer,
+  };
+}


### PR DESCRIPTION
The security issue here was that seller controlled storefront links were being saved and then rendered back into the public storefront without proper sanitisation. Because of that, a malicious seller could put a javascript: URL into a CTA button, nav link, or footer/social link, and when a visitor clicked it, that script would run in the Shopstr site origin.

Continue.. https://github.com/shopstr-eng/shopstr/pull/417

This Pr fixes a different path: seller controlled href values in CTA, nav, footer nav, and social links. Here the issue was not raw HTML inside policy text, but dangerous javascript: URLs being rendered into clickable links on public storefront pages.

I've removed the stored `javascript`: storefront link execution path by sanitising seller controlled CTA, nav, footer nav, and social links at render time. It also sanitises storefront config before publish and adds focused tests so unsafe links do not keep getting saved back into public storefront data.

https://shopstr.market/shop/securityshop/terms-of-service

<img width="700" height="700" alt="Screenshot 2026-04-19 at 3 24 48 AM" src="https://github.com/user-attachments/assets/bcfd5f5c-fcdb-436e-a550-5b8be07facde" />

That made it a stored client side script injection issue on a public storefront page. In practice, it meant seller supplied data was crossing the boundary from normal content into executable code inside another user’s browser session.

