### PR TITLE
Potential fix for code scanning alert no. 39: Server-side request forgery

### DIFF
--- a/pages/api/og-preview.ts
+++ b/pages/api/og-preview.ts
@@ -133,6 +133,9 @@ export default async function handler(
     if (!["http:", "https:"].includes(parsedUrl.protocol)) {
       return res.status(400).json({ error: "Invalid protocol" });
     }
+    if (parsedUrl.port && !["80", "443"].includes(parsedUrl.port)) {
+      return res.status(400).json({ error: "Invalid port" });
+    }
   } catch {
     return res.status(400).json({ error: "Invalid URL" });
   }
@@ -154,6 +157,7 @@ export default async function handler(
     const timeout = setTimeout(() => controller.abort(), 6000);
     const response = await fetch(normalizedUrl, {
       signal: controller.signal,
+      redirect: "manual",
       headers: {
         "User-Agent":
           "Mozilla/5.0 (compatible; Shopstr/1.0; +https://shopstr.store)",


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/39](https://github.com/shopstr-eng/shopstr/security/code-scanning/39)

General fix approach: keep user-provided URL support, but constrain outbound request behavior so the request cannot be pivoted to internal targets through redirects or unusual network paths. The safest minimal hardening here is:
1. Restrict destination ports to standard web ports only (empty/default, 80, 443).
2. Disable automatic redirect following (`redirect: "manual"`) so the initial validated host cannot bounce the server into an internal/private destination.

Best single fix in this file:
- In `pages/api/og-preview.ts`, after protocol validation (around lines 133–135), add a port allowlist check.
- In the `fetch` options (around line 155), add `redirect: "manual"`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
