### PR TITLE
Add dedicated seller orders dashboard at /my-listings/orders

### DIFF
--- a/components/messages/__tests__/message-feed.test.tsx
+++ b/components/messages/__tests__/message-feed.test.tsx
@@ -13,6 +13,22 @@ jest.mock("../messages", () => {
   };
 });
 
+jest.mock("../orders-dashboard", () => {
+  return function MockOrdersDashboard({
+    sellerOnly,
+    buyerOnly,
+  }: {
+    sellerOnly?: boolean;
+    buyerOnly?: boolean;
+  }) {
+    return (
+      <div data-testid="orders-dashboard-props">
+        sellerOnly:{String(!!sellerOnly)} buyerOnly:{String(!!buyerOnly)}
+      </div>
+    );
+  };
+});
+
 jest.mock("@/components/framer", () => ({
   Framer: {
     Tabs: () => <div data-testid="framer-tabs">Mocked Tabs</div>,
@@ -62,6 +78,9 @@ describe("MessageFeed Component", () => {
     expect(mockUseTabs).toHaveBeenCalledWith(
       expect.objectContaining({ initialTabId: "orders" })
     );
+    expect(
+      mockUseTabs.mock.calls[0][0].tabs[0].children.props.buyerOnly
+    ).toBe(true);
     expect(screen.getByText("Orders Messages Content")).toBeInTheDocument();
     expect(
       screen.queryByText("Inquiries Messages Content")
@@ -95,6 +114,34 @@ describe("MessageFeed Component", () => {
     expect(
       screen.queryByText("Orders Messages Content")
     ).not.toBeInTheDocument();
+  });
+
+  test("wires the Orders tab to the buyer-only dashboard view", () => {
+    mockUseTabs.mockImplementation(({ tabs }) => ({
+      selectedTab: {
+        id: "orders",
+        children: tabs[0].children,
+      },
+      tabProps: {
+        setSelectedTab: mockSetSelectedTab,
+        selectedTabIndex: 0,
+      },
+    }));
+
+    render(<MessageFeed />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(
+      mockUseTabs.mock.calls[mockUseTabs.mock.calls.length - 1][0].tabs[0]
+        .children.props
+    ).toEqual(
+      expect.objectContaining({
+        buyerOnly: true,
+      })
+    );
   });
 
   test("subscribes to route changes on mount and cleans up on unmount", () => {

--- a/components/messages/__tests__/message-feed.test.tsx
+++ b/components/messages/__tests__/message-feed.test.tsx
@@ -78,9 +78,9 @@ describe("MessageFeed Component", () => {
     expect(mockUseTabs).toHaveBeenCalledWith(
       expect.objectContaining({ initialTabId: "orders" })
     );
-    expect(
-      mockUseTabs.mock.calls[0][0].tabs[0].children.props.buyerOnly
-    ).toBe(true);
+    expect(mockUseTabs.mock.calls[0][0].tabs[0].children.props.buyerOnly).toBe(
+      true
+    );
     expect(screen.getByText("Orders Messages Content")).toBeInTheDocument();
     expect(
       screen.queryByText("Inquiries Messages Content")

--- a/components/messages/message-feed.tsx
+++ b/components/messages/message-feed.tsx
@@ -15,7 +15,7 @@ const MessageFeed = ({ isInquiry = false }) => {
     tabs: [
       {
         label: "Orders",
-        children: <OrdersDashboard />,
+        children: <OrdersDashboard buyerOnly />,
         id: "orders",
       },
       {

--- a/components/messages/orders-dashboard.tsx
+++ b/components/messages/orders-dashboard.tsx
@@ -115,7 +115,13 @@ interface OrderData {
   returnRequestType?: string;
 }
 
-const OrdersDashboard = () => {
+const OrdersDashboard = ({
+  sellerOnly = false,
+  buyerOnly = false,
+}: {
+  sellerOnly?: boolean;
+  buyerOnly?: boolean;
+}) => {
   const chatsContext = useContext(ChatsContext);
   const productContext = useContext(ProductContext);
   const [orders, setOrders] = useState<OrderData[]>([]);
@@ -663,8 +669,14 @@ const OrdersDashboard = () => {
         }
       }
 
-      setOrders(consolidatedOrders);
-      setTotalOrders(consolidatedOrders.length);
+      const finalOrders = sellerOnly
+        ? consolidatedOrders.filter((o) => o.isSale)
+        : buyerOnly
+          ? consolidatedOrders.filter((o) => !o.isSale)
+          : consolidatedOrders;
+
+      setOrders(finalOrders);
+      setTotalOrders(finalOrders.length);
       setIsLoading(false);
 
       const statusPriorityForPersist: Record<string, number> = {
@@ -1343,7 +1355,11 @@ const OrdersDashboard = () => {
       <div className="mx-auto w-full max-w-full min-w-0">
         <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
           <h1 className="text-light-text dark:text-dark-text text-3xl font-bold">
-            Orders Dashboard
+            {sellerOnly
+              ? "Seller Orders Dashboard"
+              : buyerOnly
+                ? "My Purchases"
+                : "Orders Dashboard"}
           </h1>
           <div className="flex items-center gap-3">
             <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
@@ -1374,10 +1390,12 @@ const OrdersDashboard = () => {
           </div>
         </div>
 
-        <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
+        <div
+          className={`mb-8 grid grid-cols-1 gap-6 ${sellerOnly ? "md:grid-cols-4" : "md:grid-cols-3"}`}
+        >
           <div className="rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
             <h3 className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
-              Total Orders
+              {sellerOnly ? "Total Sales" : "Total Orders"}
             </h3>
             <p className="text-light-text dark:text-dark-text text-3xl font-bold">
               {totalOrders}
@@ -1386,7 +1404,7 @@ const OrdersDashboard = () => {
 
           <div className="rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
             <h3 className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
-              Total GMV
+              {sellerOnly ? "Total Revenue" : "Total GMV"}
             </h3>
             <p className="text-light-text dark:text-dark-text text-3xl font-bold">
               {displayCurrency === "sats"
@@ -1411,6 +1429,27 @@ const OrdersDashboard = () => {
                   })}`}
             </p>
           </div>
+
+          {sellerOnly && (
+            <div className="rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
+              <h3 className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+                Top Product
+              </h3>
+              <p className="text-light-text dark:text-dark-text truncate text-xl font-bold">
+                {(() => {
+                  const counts: Record<string, number> = {};
+                  orders.forEach((o) => {
+                    const title = o.productTitle || "Unknown";
+                    counts[title] = (counts[title] || 0) + 1;
+                  });
+                  const top = Object.entries(counts).sort(
+                    (a, b) => b[1] - a[1]
+                  )[0];
+                  return top ? `${top[0]} (×${top[1]})` : "—";
+                })()}
+              </p>
+            </div>
+          )}
         </div>
 
         {orders.length > 0 && (
@@ -1429,11 +1468,13 @@ const OrdersDashboard = () => {
                   <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-600 uppercase dark:text-gray-400">
                     Order ID
                   </th>
+                  {!sellerOnly && (
+                    <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-600 uppercase dark:text-gray-400">
+                      Type
+                    </th>
+                  )}
                   <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-600 uppercase dark:text-gray-400">
-                    Type
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-600 uppercase dark:text-gray-400">
-                    Buyer/Seller
+                    {sellerOnly ? "Customer" : "Buyer/Seller"}
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-600 uppercase dark:text-gray-400">
                     Amount
@@ -1519,17 +1560,19 @@ const OrdersDashboard = () => {
                             ) : null}
                           </div>
                         </td>
-                        <td className="px-4 py-4 text-sm whitespace-nowrap">
-                          <span
-                            className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${
-                              order.isSale
-                                ? "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
-                                : "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200"
-                            }`}
-                          >
-                            {order.isSale ? "Sale" : "Purchase"}
-                          </span>
-                        </td>
+                        {!sellerOnly && (
+                          <td className="px-4 py-4 text-sm whitespace-nowrap">
+                            <span
+                              className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${
+                                order.isSale
+                                  ? "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                                  : "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200"
+                              }`}
+                            >
+                              {order.isSale ? "Sale" : "Purchase"}
+                            </span>
+                          </td>
+                        )}
                         <td className="px-4 py-4 text-sm">
                           {(() => {
                             const displayPubkey = order.isSale

--- a/components/messages/orders-dashboard.tsx
+++ b/components/messages/orders-dashboard.tsx
@@ -1623,7 +1623,7 @@ const OrdersDashboard = ({
                             >
                               {order.status}
                             </span>
-                            {order.status === "pending" && (
+                            {order.isSale && order.status === "pending" && (
                               <button
                                 onClick={() => handleOpenShippingModal(order)}
                                 className="text-shopstr-purple-light hover:text-shopstr-purple dark:text-shopstr-yellow-light dark:hover:text-shopstr-yellow cursor-pointer text-left text-xs underline"

--- a/components/my-listings/__tests__/my-listings.test.tsx
+++ b/components/my-listings/__tests__/my-listings.test.tsx
@@ -283,7 +283,7 @@ describe("MyListingsPage", () => {
       expect(mockRouterPush).toHaveBeenCalledWith("/settings/shop-profile");
 
       fireEvent.click(screen.getAllByRole("button", { name: "Orders" })[0]!);
-      expect(mockRouterPush).toHaveBeenCalledWith("/orders");
+      expect(mockRouterPush).toHaveBeenCalledWith("/my-listings/orders");
     });
   });
 

--- a/components/my-listings/my-listings.tsx
+++ b/components/my-listings/my-listings.tsx
@@ -67,7 +67,7 @@ const MyListingsPage = () => {
 
   const handleViewOrders = () => {
     if (usersPubkey) {
-      router.push("/orders");
+      router.push("/my-listings/orders");
     } else {
       onOpen();
     }

--- a/pages/my-listings/__tests__/orders.test.tsx
+++ b/pages/my-listings/__tests__/orders.test.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import SellerOrdersView from "../orders";
+
+jest.mock("@/components/messages/orders-dashboard", () => {
+  return function MockOrdersDashboard({
+    sellerOnly,
+    buyerOnly,
+  }: {
+    sellerOnly?: boolean;
+    buyerOnly?: boolean;
+  }) {
+    return (
+      <div data-testid="orders-dashboard-props">
+        sellerOnly:{String(!!sellerOnly)} buyerOnly:{String(!!buyerOnly)}
+      </div>
+    );
+  };
+});
+
+jest.mock("@/components/utility-components/protected-route", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe("SellerOrdersView", () => {
+  it("renders the seller-only orders dashboard", () => {
+    render(<SellerOrdersView />);
+
+    expect(screen.getByTestId("orders-dashboard-props")).toHaveTextContent(
+      "sellerOnly:true buyerOnly:false"
+    );
+  });
+});

--- a/pages/my-listings/orders.tsx
+++ b/pages/my-listings/orders.tsx
@@ -1,0 +1,12 @@
+import OrdersDashboard from "@/components/messages/orders-dashboard";
+import ProtectedRoute from "@/components/utility-components/protected-route";
+
+export default function SellerOrdersView() {
+  return (
+    <ProtectedRoute>
+      <div className="bg-light-bg dark:bg-dark-bg flex min-h-screen flex-col pt-16">
+        <OrdersDashboard sellerOnly />
+      </div>
+    </ProtectedRoute>
+  );
+}


### PR DESCRIPTION
## Description

- Created `pages/my-listings/orders.tsx` as a new seller-only orders page protected by `ProtectedRoute`
- Added `sellerOnly` and `buyerOnly` props to `OrdersDashboard` component to support filtered views
- Filter orders by the `isSale` flag (`merchantPubkey === userPubkey`) based on mode: seller-only, buyer-only, or all
- Seller view displays dedicated metrics: **Total Sales**, **Total Revenue**, and **Top Product** (by order count)
- Renamed the "Buyer/Seller" column header to "Customer" in seller view for clarity
- Hidden the "Type" column in seller-only mode since all orders are sales
- Updated the "Orders" button in My Listings to route to `/my-listings/orders` (seller dashboard)
- Updated `MessageFeed` to pass `buyerOnly` to `OrdersDashboard` so the main orders tab shows only buyer purchases

## Resolved or fixed issue

Fixes #387 

## Screenshots (if applicable)

<img width="2560" height="1438" alt="Image 20-04-26 at 5 19 AM" src="https://github.com/user-attachments/assets/213e3048-cb92-4a0b-81d0-77cc6386f3c1" />


## Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
