### PR TITLE
Speed up shared profile saves

### DIFF
--- a/components/settings/__tests__/buyer-profile-form.test.tsx
+++ b/components/settings/__tests__/buyer-profile-form.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import BuyerProfileForm from "../buyer-profile-form";
+import { ProfileMapContext } from "@/utils/context/context";
+import {
+  NostrContext,
+  SignerContext,
+} from "@/components/utility-components/nostr-context-provider";
+import { createNostrProfileEvent } from "@/utils/nostr/nostr-helper-functions";
+
+const mockRouterPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(() => ({ push: mockRouterPush })),
+}));
+
+jest.mock("@heroui/react", () => ({
+  Button: ({ children, isDisabled, isLoading, onClick, onKeyDown, type }: any) => (
+    <button
+      type={type || "button"}
+      disabled={isDisabled || isLoading}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+    >
+      {children}
+    </button>
+  ),
+  Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
+    <label>
+      {label}
+      <input
+        aria-label={label}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        type={type}
+      />
+    </label>
+  ),
+  Image: ({ src, alt }: any) => <img src={src} alt={alt} />,
+}), { virtual: true });
+
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  createNostrProfileEvent: jest.fn(),
+}));
+const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
+
+jest.mock("@/components/utility-components/file-uploader", () => ({
+  FileUploaderButton: jest.fn(
+    ({ children, imgCallbackOnUpload, isIconOnly }) => (
+      <button
+        data-testid={isIconOnly ? "upload-picture-btn" : "upload-banner-btn"}
+        onClick={() => imgCallbackOnUpload("https://new.image/url")}
+      >
+        {children}
+      </button>
+    )
+  ),
+}));
+
+jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
+
+const mockUserPubkey = "buyer_pubkey_123";
+const mockSavedProfileEvent = {
+  id: "buyer-profile-event-1",
+  pubkey: mockUserPubkey,
+  created_at: 54321,
+  kind: 0,
+  tags: [],
+  content: "{}",
+  sig: "sig",
+};
+
+const renderWithProviders = (component: React.ReactElement) => {
+  const mockUpdateProfileData = jest.fn();
+  render(
+    <NostrContext.Provider value={{ nostr: {} as any }}>
+      <SignerContext.Provider value={{ signer: {} as any, pubkey: mockUserPubkey }}>
+        <ProfileMapContext.Provider
+          value={{
+            profileData: new Map(),
+            updateProfileData: mockUpdateProfileData,
+            isLoading: false,
+          }}
+        >
+          {component}
+        </ProfileMapContext.Provider>
+      </SignerContext.Provider>
+    </NostrContext.Provider>
+  );
+
+  return { mockUpdateProfileData };
+};
+
+describe("BuyerProfileForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("updates context with the returned created_at and clears save loading state", async () => {
+    mockCreateNostrProfileEvent.mockResolvedValue(mockSavedProfileEvent);
+    const user = userEvent.setup();
+    const { mockUpdateProfileData } = renderWithProviders(<BuyerProfileForm />);
+
+    await user.type(await screen.findByLabelText("Display name"), "Buyer Name");
+    const saveButton = screen.getByRole("button", { name: /Save Profile/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateProfileData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pubkey: mockUserPubkey,
+          created_at: mockSavedProfileEvent.created_at,
+        })
+      );
+      expect(saveButton).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: /Saved!/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/components/settings/__tests__/buyer-profile-form.test.tsx
+++ b/components/settings/__tests__/buyer-profile-form.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import BuyerProfileForm from "../buyer-profile-form";
@@ -9,79 +8,62 @@ import {
   NostrContext,
   SignerContext,
 } from "@/components/utility-components/nostr-context-provider";
-import { createNostrProfileEvent } from "@/utils/nostr/nostr-helper-functions";
+import { FileUploaderButton } from "@/components/utility-components/file-uploader";
+import { AVATARBADGEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
 
-const mockRouterPush = jest.fn();
 jest.mock("next/router", () => ({
-  useRouter: jest.fn(() => ({ push: mockRouterPush })),
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
 }));
 
-jest.mock("@heroui/react", () => ({
-  Button: ({ children, isDisabled, isLoading, onClick, onKeyDown, type }: any) => (
-    <button
-      type={type || "button"}
-      disabled={isDisabled || isLoading}
-      onClick={onClick}
-      onKeyDown={onKeyDown}
-    >
-      {children}
-    </button>
-  ),
-  Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
-    <label>
-      {label}
-      <input
-        aria-label={label}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        type={type}
-      />
-    </label>
-  ),
-  Image: ({ src, alt }: any) => <img src={src} alt={alt} />,
-}), { virtual: true });
+jest.mock(
+  "@heroui/react",
+  () => ({
+    Button: ({ children, type, onClick, onKeyDown }: any) => (
+      <button type={type || "button"} onClick={onClick} onKeyDown={onKeyDown}>
+        {children}
+      </button>
+    ),
+    Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
+      <label>
+        {label}
+        <input
+          aria-label={label}
+          type={type}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </label>
+    ),
+    Image: ({ src, alt, className }: any) => (
+      <img src={src} alt={alt} className={className} />
+    ),
+  }),
+  { virtual: true }
+);
 
+jest.mock("@/components/utility-components/file-uploader", () => ({
+  FileUploaderButton: jest.fn(() => (
+    <button data-testid="upload-picture-btn" />
+  )),
+}));
+const mockFileUploaderButton = FileUploaderButton as jest.Mock;
+
+jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
 jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
   createNostrProfileEvent: jest.fn(),
 }));
-const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
-
-jest.mock("@/components/utility-components/file-uploader", () => ({
-  FileUploaderButton: jest.fn(
-    ({ children, imgCallbackOnUpload, isIconOnly }) => (
-      <button
-        data-testid={isIconOnly ? "upload-picture-btn" : "upload-banner-btn"}
-        onClick={() => imgCallbackOnUpload("https://new.image/url")}
-      >
-        {children}
-      </button>
-    )
-  ),
-}));
-
-jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
-
-const mockUserPubkey = "buyer_pubkey_123";
-const mockSavedProfileEvent = {
-  id: "buyer-profile-event-1",
-  pubkey: mockUserPubkey,
-  created_at: 54321,
-  kind: 0,
-  tags: [],
-  content: "{}",
-  sig: "sig",
-};
 
 const renderWithProviders = (component: React.ReactElement) => {
-  const mockUpdateProfileData = jest.fn();
-  render(
+  return render(
     <NostrContext.Provider value={{ nostr: {} as any }}>
-      <SignerContext.Provider value={{ signer: {} as any, pubkey: mockUserPubkey }}>
+      <SignerContext.Provider
+        value={{ signer: {} as any, pubkey: "buyer_pubkey_123" }}
+      >
         <ProfileMapContext.Provider
           value={{
             profileData: new Map(),
-            updateProfileData: mockUpdateProfileData,
+            updateProfileData: jest.fn(),
             isLoading: false,
           }}
         >
@@ -90,8 +72,6 @@ const renderWithProviders = (component: React.ReactElement) => {
       </SignerContext.Provider>
     </NostrContext.Provider>
   );
-
-  return { mockUpdateProfileData };
 };
 
 describe("BuyerProfileForm", () => {
@@ -99,24 +79,17 @@ describe("BuyerProfileForm", () => {
     jest.clearAllMocks();
   });
 
-  test("updates context with the returned created_at and clears save loading state", async () => {
-    mockCreateNostrProfileEvent.mockResolvedValue(mockSavedProfileEvent);
-    const user = userEvent.setup();
-    const { mockUpdateProfileData } = renderWithProviders(<BuyerProfileForm />);
+  test("passes anchored badge props to the avatar uploader", async () => {
+    renderWithProviders(<BuyerProfileForm />);
+    await screen.findByLabelText("Display name");
 
-    await user.type(await screen.findByLabelText("Display name"), "Buyer Name");
-    const saveButton = screen.getByRole("button", { name: /Save Profile/i });
-    await user.click(saveButton);
-
-    await waitFor(() => {
-      expect(mockUpdateProfileData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pubkey: mockUserPubkey,
-          created_at: mockSavedProfileEvent.created_at,
-        })
-      );
-      expect(saveButton).not.toBeDisabled();
-      expect(screen.getByRole("button", { name: /Saved!/i })).toBeInTheDocument();
-    });
+    expect(mockFileUploaderButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isIconOnly: true,
+        className: AVATARBADGEBUTTONCLASSNAMES,
+        containerClassName: "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
+      }),
+      undefined
+    );
   });
 });

--- a/components/settings/__tests__/buyer-profile-save.test.tsx
+++ b/components/settings/__tests__/buyer-profile-save.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import BuyerProfileForm from "../buyer-profile-form";
+import { ProfileMapContext } from "@/utils/context/context";
+import {
+  NostrContext,
+  SignerContext,
+} from "@/components/utility-components/nostr-context-provider";
+import { createNostrProfileEvent } from "@/utils/nostr/nostr-helper-functions";
+
+const mockRouterPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(() => ({ push: mockRouterPush })),
+}));
+
+jest.mock(
+  "@heroui/react",
+  () => ({
+    Button: ({
+      children,
+      isDisabled,
+      isLoading,
+      onClick,
+      onKeyDown,
+      type,
+    }: any) => (
+      <button
+        type={type || "button"}
+        disabled={isDisabled || isLoading}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+      >
+        {children}
+      </button>
+    ),
+    Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
+      <label>
+        {label}
+        <input
+          aria-label={label}
+          type={type}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </label>
+    ),
+    Image: ({ src, alt, className }: any) => (
+      <img src={src} alt={alt} className={className} />
+    ),
+  }),
+  { virtual: true }
+);
+
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  createNostrProfileEvent: jest.fn(),
+}));
+const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
+
+jest.mock("@/components/utility-components/file-uploader", () => ({
+  FileUploaderButton: jest.fn(
+    ({ children, imgCallbackOnUpload, isIconOnly }: any) => (
+      <button
+        data-testid={isIconOnly ? "upload-picture-btn" : "upload-banner-btn"}
+        onClick={() => imgCallbackOnUpload("https://new.image/url")}
+      >
+        {children}
+      </button>
+    )
+  ),
+}));
+
+jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
+
+const mockUserPubkey = "buyer_pubkey_123";
+const mockSavedProfileEvent = {
+  id: "buyer-profile-event-1",
+  pubkey: mockUserPubkey,
+  created_at: 54321,
+  kind: 0,
+  tags: [],
+  content: "{}",
+  sig: "sig",
+};
+
+const renderWithProviders = (component: React.ReactElement) => {
+  const mockUpdateProfileData = jest.fn();
+  render(
+    <NostrContext.Provider value={{ nostr: {} as any }}>
+      <SignerContext.Provider
+        value={{ signer: {} as any, pubkey: mockUserPubkey }}
+      >
+        <ProfileMapContext.Provider
+          value={{
+            profileData: new Map(),
+            updateProfileData: mockUpdateProfileData,
+            isLoading: false,
+          }}
+        >
+          {component}
+        </ProfileMapContext.Provider>
+      </SignerContext.Provider>
+    </NostrContext.Provider>
+  );
+
+  return { mockUpdateProfileData };
+};
+
+describe("BuyerProfileForm fast saves", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("updates context with the returned created_at and clears save loading state", async () => {
+    mockCreateNostrProfileEvent.mockResolvedValue(mockSavedProfileEvent);
+    const user = userEvent.setup();
+    const { mockUpdateProfileData } = renderWithProviders(<BuyerProfileForm />);
+
+    await user.type(await screen.findByLabelText("Display name"), "Buyer Name");
+    const saveButton = screen.getByRole("button", { name: /Save Profile/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateProfileData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pubkey: mockUserPubkey,
+          created_at: mockSavedProfileEvent.created_at,
+        })
+      );
+      expect(saveButton).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /Saved!/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/components/settings/__tests__/user-profile-form.test.tsx
+++ b/components/settings/__tests__/user-profile-form.test.tsx
@@ -16,9 +16,67 @@ jest.mock("next/router", () => ({
   useRouter: jest.fn(() => ({ push: mockRouterPush })),
 }));
 
-jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
-  createNostrProfileEvent: jest.fn(),
-}));
+jest.mock("@heroui/react", () => ({
+  Button: ({ children, isDisabled, isLoading, onClick, onKeyDown, type }: any) => (
+    <button
+      type={type || "button"}
+      disabled={isDisabled || isLoading}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+    >
+      {children}
+    </button>
+  ),
+  Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
+    <label>
+      {label}
+      <input
+        aria-label={label}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        type={type}
+      />
+    </label>
+  ),
+  Image: ({ src, alt }: any) => <img src={src} alt={alt} />,
+  Select: ({ label, selectedKeys, onChange, onBlur, children }: any) => (
+    <label>
+      {label}
+      <select
+        aria-label={label}
+        value={selectedKeys?.[0] ?? ""}
+        onChange={onChange}
+        onBlur={onBlur}
+      >
+        {children}
+      </select>
+    </label>
+  ),
+  SelectItem: ({ children, value, ...props }: any) => {
+    const optionLabel = Array.isArray(children) ? children.join("") : children;
+    const optionValue =
+      value ??
+      (typeof optionLabel === "string" && optionLabel.includes("Lightning")
+        ? "lightning"
+        : "ecash");
+
+    return (
+      <option value={optionValue} {...props}>
+        {children}
+      </option>
+    );
+  },
+  Tooltip: ({ children }: any) => <>{children}</>,
+}), { virtual: true });
+
+jest.mock("@/utils/nostr/nostr-helper-functions", () => {
+  const actual = jest.requireActual("@/utils/nostr/nostr-helper-functions");
+  return {
+    ...actual,
+    createNostrProfileEvent: jest.fn(),
+  };
+});
 const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
 
 jest.mock("@/components/utility-components/file-uploader", () => ({
@@ -37,6 +95,15 @@ jest.mock("@/components/utility-components/file-uploader", () => ({
 jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
 
 const mockUserPubkey = "test_pubkey_123";
+const mockSavedProfileEvent = {
+  id: "profile-event-1",
+  pubkey: mockUserPubkey,
+  created_at: 12345,
+  kind: 0,
+  tags: [],
+  content: "{}",
+  sig: "sig",
+};
 const mockProfileData = new Map([
   [
     mockUserPubkey,
@@ -113,7 +180,7 @@ describe("UserProfileForm", () => {
   });
 
   test("submits form data and calls update functions", async () => {
-    mockCreateNostrProfileEvent.mockResolvedValue({});
+    mockCreateNostrProfileEvent.mockResolvedValue(mockSavedProfileEvent);
     const user = userEvent.setup();
     const { mockUpdateProfileData } = renderWithProviders(<UserProfileForm />);
 
@@ -122,12 +189,17 @@ describe("UserProfileForm", () => {
 
     await waitFor(() => {
       expect(mockCreateNostrProfileEvent).toHaveBeenCalledTimes(1);
-      expect(mockUpdateProfileData).toHaveBeenCalledTimes(1);
+      expect(mockUpdateProfileData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pubkey: mockUserPubkey,
+          created_at: mockSavedProfileEvent.created_at,
+        })
+      );
     });
   });
 
   test("redirects after submission if isOnboarding is true", async () => {
-    mockCreateNostrProfileEvent.mockResolvedValue({});
+    mockCreateNostrProfileEvent.mockResolvedValue(mockSavedProfileEvent);
     const user = userEvent.setup();
     renderWithProviders(<UserProfileForm isOnboarding={true} />);
 
@@ -169,23 +241,15 @@ describe("UserProfileForm", () => {
   });
 
   test("updates payment preference and shopstr donation", async () => {
-    mockCreateNostrProfileEvent.mockResolvedValue({});
+    mockCreateNostrProfileEvent.mockResolvedValue(mockSavedProfileEvent);
     const user = userEvent.setup();
     renderWithProviders(<UserProfileForm />);
     await screen.findByLabelText("Display name");
 
-    const paymentSelect = screen.getByRole("button", {
-      name: /Payment preference \(for sellers\)/i,
-    });
-    await user.click(paymentSelect);
-    const lightningOption = await screen.findByRole("option", {
-      name: "Lightning (Bitcoin)",
-    });
-    await user.click(lightningOption);
-
-    await waitFor(() => {
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-    });
+    const paymentSelect = screen.getByLabelText(
+      /Payment preference \(for sellers\)/i
+    );
+    await user.selectOptions(paymentSelect, "lightning");
 
     const donationInput = screen.getByLabelText(/Shopstr donation %/);
     await user.clear(donationInput);

--- a/components/settings/__tests__/user-profile-form.test.tsx
+++ b/components/settings/__tests__/user-profile-form.test.tsx
@@ -10,78 +10,94 @@ import {
   NostrContext,
 } from "@/components/utility-components/nostr-context-provider";
 import { createNostrProfileEvent } from "@/utils/nostr/nostr-helper-functions";
+import { FileUploaderButton } from "@/components/utility-components/file-uploader";
+import { AVATARBADGEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
 
 const mockRouterPush = jest.fn();
 jest.mock("next/router", () => ({
   useRouter: jest.fn(() => ({ push: mockRouterPush })),
 }));
 
-jest.mock("@heroui/react", () => ({
-  Button: ({ children, isDisabled, isLoading, onClick, onKeyDown, type }: any) => (
-    <button
-      type={type || "button"}
-      disabled={isDisabled || isLoading}
-      onClick={onClick}
-      onKeyDown={onKeyDown}
-    >
-      {children}
-    </button>
-  ),
-  Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
-    <label>
-      {label}
-      <input
-        aria-label={label}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        type={type}
-      />
-    </label>
-  ),
-  Image: ({ src, alt }: any) => <img src={src} alt={alt} />,
-  Select: ({ label, selectedKeys, onChange, onBlur, children }: any) => (
-    <label>
-      {label}
-      <select
-        aria-label={label}
-        value={selectedKeys?.[0] ?? ""}
-        onChange={onChange}
-        onBlur={onBlur}
+jest.mock(
+  "@heroui/react",
+  () => ({
+    Button: ({
+      children,
+      isDisabled,
+      isLoading,
+      onClick,
+      onKeyDown,
+      type,
+    }: any) => (
+      <button
+        type={type || "button"}
+        disabled={isDisabled || isLoading}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
       >
         {children}
-      </select>
-    </label>
-  ),
-  SelectItem: ({ children, value, ...props }: any) => {
-    const optionLabel = Array.isArray(children) ? children.join("") : children;
-    const optionValue =
-      value ??
-      (typeof optionLabel === "string" && optionLabel.includes("Lightning")
-        ? "lightning"
-        : "ecash");
+      </button>
+    ),
+    Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
+      <label>
+        {label}
+        <input
+          aria-label={label}
+          type={type}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </label>
+    ),
+    Image: ({ src, alt, className }: any) => (
+      <img src={src} alt={alt} className={className} />
+    ),
+    Select: ({ label, selectedKeys, onChange, onBlur, children }: any) => (
+      <label>
+        {label}
+        <select
+          aria-label={label}
+          value={selectedKeys?.[0] ?? ""}
+          onChange={onChange}
+          onBlur={onBlur}
+        >
+          {children}
+        </select>
+      </label>
+    ),
+    SelectItem: ({ children, value, ...props }: any) => {
+      const optionLabel = Array.isArray(children)
+        ? children.join("")
+        : children;
+      const optionValue =
+        value ??
+        (typeof optionLabel === "string" && optionLabel.includes("Lightning")
+          ? "lightning"
+          : "ecash");
 
-    return (
-      <option value={optionValue} {...props}>
-        {children}
-      </option>
-    );
-  },
-  Tooltip: ({ children }: any) => <>{children}</>,
-}), { virtual: true });
+      return (
+        <option value={optionValue} {...props}>
+          {children}
+        </option>
+      );
+    },
+    Tooltip: ({ children }: any) => <>{children}</>,
+  }),
+  { virtual: true }
+);
 
-jest.mock("@/utils/nostr/nostr-helper-functions", () => {
-  const actual = jest.requireActual("@/utils/nostr/nostr-helper-functions");
-  return {
-    ...actual,
-    createNostrProfileEvent: jest.fn(),
-  };
-});
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  createNostrProfileEvent: jest.fn(),
+  getLocalUserProfileKey: (pubkey: string) => `shopstr:user-profile:${pubkey}`,
+  parseLocalProfileFallback: (raw: string | null) =>
+    raw ? { content: JSON.parse(raw), updatedAt: 0 } : null,
+}));
 const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
 
 jest.mock("@/components/utility-components/file-uploader", () => ({
   FileUploaderButton: jest.fn(
-    ({ children, imgCallbackOnUpload, isIconOnly }) => (
+    ({ children, imgCallbackOnUpload, isIconOnly }: any) => (
       <button
         data-testid={isIconOnly ? "upload-picture-btn" : "upload-banner-btn"}
         onClick={() => imgCallbackOnUpload("https://new.image/url")}
@@ -91,6 +107,7 @@ jest.mock("@/components/utility-components/file-uploader", () => ({
     )
   ),
 }));
+const mockFileUploaderButton = FileUploaderButton as jest.Mock;
 
 jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
 
@@ -149,6 +166,20 @@ describe("UserProfileForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+  });
+
+  test("passes anchored badge props to the avatar uploader", async () => {
+    renderWithProviders(<UserProfileForm />);
+    await screen.findByLabelText("Display name");
+
+    expect(mockFileUploaderButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isIconOnly: true,
+        className: AVATARBADGEBUTTONCLASSNAMES,
+        containerClassName: "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
+      }),
+      undefined
+    );
   });
 
   test("displays the form after initial data load", async () => {

--- a/components/settings/buyer-profile-form.tsx
+++ b/components/settings/buyer-profile-form.tsx
@@ -57,33 +57,49 @@ const BuyerProfileForm = ({ isOnboarding }: BuyerProfileFormProps) => {
   }, [profileContext, userPubkey, reset]);
 
   const onSubmit = async (data: { [x: string]: string }) => {
-    if (!userPubkey) throw new Error("pubkey is undefined");
+    if (!userPubkey) {
+      console.error("Cannot save profile: pubkey is undefined");
+      return;
+    }
     setIsUploadingProfile(true);
+    try {
+      const profileMap = profileContext.profileData;
+      const existingProfile = profileMap.has(userPubkey)
+        ? profileMap.get(userPubkey)?.content
+        : {};
 
-    const profileMap = profileContext.profileData;
-    const existingProfile = profileMap.has(userPubkey)
-      ? profileMap.get(userPubkey)?.content
-      : {};
+      const updatedData = {
+        ...existingProfile,
+        picture: data.picture || "",
+        display_name: data.display_name || "",
+        name: data.name || "",
+      };
 
-    const updatedData = {
-      ...existingProfile,
-      picture: data.picture || "",
-      display_name: data.display_name || "",
-      name: data.name || "",
-    };
+      if (!nostr || !signer) {
+        console.error("Cannot save profile: nostr or signer is unavailable");
+        return;
+      }
 
-    await createNostrProfileEvent(nostr!, signer!, JSON.stringify(updatedData));
-    profileContext.updateProfileData({
-      pubkey: userPubkey!,
-      content: updatedData,
-      created_at: 0,
-    });
-    setIsUploadingProfile(false);
-    setIsSaved(true);
-    setTimeout(() => setIsSaved(false), 3000);
+      const signedProfileEvent = await createNostrProfileEvent(
+        nostr,
+        signer,
+        JSON.stringify(updatedData)
+      );
+      profileContext.updateProfileData({
+        pubkey: userPubkey,
+        content: updatedData,
+        created_at: signedProfileEvent.created_at,
+      });
+      setIsSaved(true);
+      setTimeout(() => setIsSaved(false), 3000);
 
-    if (isOnboarding) {
-      router.push("/onboarding/wallet?type=buyer");
+      if (isOnboarding) {
+        router.push("/onboarding/wallet?type=buyer");
+      }
+    } catch (error) {
+      console.error("Failed to save user profile:", error);
+    } finally {
+      setIsUploadingProfile(false);
     }
   };
 

--- a/components/settings/buyer-profile-form.tsx
+++ b/components/settings/buyer-profile-form.tsx
@@ -3,7 +3,10 @@ import { useRouter } from "next/router";
 import { useForm, Controller } from "react-hook-form";
 import { Button, Input, Image } from "@heroui/react";
 import { ProfileMapContext } from "@/utils/context/context";
-import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import {
+  AVATARBADGEBUTTONCLASSNAMES,
+  SHOPSTRBUTTONCLASSNAMES,
+} from "@/utils/STATIC-VARIABLES";
 import {
   SignerContext,
   NostrContext,
@@ -110,23 +113,24 @@ const BuyerProfileForm = ({ isOnboarding }: BuyerProfileFormProps) => {
   return (
     <>
       <div className="mb-16 flex items-center justify-center">
-        <div className="relative h-24 w-24">
+        <div className="relative h-24 w-24 overflow-visible">
           <FileUploaderButton
             isIconOnly
-            className={`absolute right-[-0.5rem] bottom-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
+            className={AVATARBADGEBUTTONCLASSNAMES}
+            containerClassName="absolute right-[-0.5rem] bottom-[-0.5rem] z-20"
             imgCallbackOnUpload={(imgUrl) => setValue("picture", imgUrl)}
           />
           {watchPicture ? (
             <Image
               src={watchPicture}
               alt="User Profile Picture"
-              className="rounded-full"
+              className="h-24 w-24 rounded-full object-cover"
             />
           ) : (
             <Image
               src={defaultImage}
               alt="User Profile Picture"
-              className="rounded-full"
+              className="h-24 w-24 rounded-full object-cover"
             />
           )}
         </div>

--- a/components/settings/user-profile-form.tsx
+++ b/components/settings/user-profile-form.tsx
@@ -174,11 +174,15 @@ const UserProfileForm = ({ isOnboarding }: UserProfileFormProps) => {
         return;
       }
 
-      await createNostrProfileEvent(nostr, signer, JSON.stringify(updatedData));
+      const signedProfileEvent = await createNostrProfileEvent(
+        nostr,
+        signer,
+        JSON.stringify(updatedData)
+      );
       profileContext.updateProfileData({
         pubkey: userPubkey,
         content: updatedData,
-        created_at: Math.floor(Date.now() / 1000),
+        created_at: signedProfileEvent.created_at,
       });
 
       if (isOnboarding) {

--- a/components/settings/user-profile-form.tsx
+++ b/components/settings/user-profile-form.tsx
@@ -10,7 +10,10 @@ import {
   Tooltip,
 } from "@heroui/react";
 import { ProfileMapContext } from "@/utils/context/context";
-import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import {
+  AVATARBADGEBUTTONCLASSNAMES,
+  SHOPSTRBUTTONCLASSNAMES,
+} from "@/utils/STATIC-VARIABLES";
 import {
   SignerContext,
   NostrContext,
@@ -202,17 +205,18 @@ const UserProfileForm = ({ isOnboarding }: UserProfileFormProps) => {
   return (
     <>
       <div className="mb-8 flex items-center justify-center">
-        <div className="relative h-24 w-24">
+        <div className="relative h-24 w-24 overflow-visible">
           <FileUploaderButton
             isIconOnly
-            className={`absolute right-[-0.5rem] bottom-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
+            className={AVATARBADGEBUTTONCLASSNAMES}
+            containerClassName="absolute right-[-0.5rem] bottom-[-0.5rem] z-20"
             imgCallbackOnUpload={(imgUrl) => setValue("picture", imgUrl)}
           />
           <Image
             key={profileImageSrc}
             src={profileImageSrc}
             alt="user profile picture"
-            className="rounded-full"
+            className="h-24 w-24 rounded-full object-cover"
           />
         </div>
       </div>

--- a/components/utility-components/file-uploader.tsx
+++ b/components/utility-components/file-uploader.tsx
@@ -42,6 +42,7 @@ export const FileUploaderButton = ({
   disabled,
   isIconOnly,
   className,
+  containerClassName,
   children,
   imgCallbackOnUpload,
   isPlaceholder,
@@ -50,6 +51,7 @@ export const FileUploaderButton = ({
   disabled?: boolean;
   isIconOnly?: boolean;
   className?: string;
+  containerClassName?: string;
   children?: React.ReactNode;
   imgCallbackOnUpload: (imgUrl: string) => void;
   isPlaceholder?: boolean;
@@ -421,8 +423,13 @@ export const FileUploaderButton = ({
     }, 0);
   };
 
+  const wrapperClassName = containerClassName
+    ? `flex w-fit flex-col gap-4 ${containerClassName}`
+    : "flex w-full flex-col gap-4";
+  const dropZoneWidthClassName = containerClassName ? "w-fit" : "w-full";
+
   return (
-    <div className="flex w-full flex-col gap-4">
+    <div className={wrapperClassName}>
       {/* Drag and Drop Zone */}
       <div
         ref={dropZoneRef}
@@ -431,7 +438,7 @@ export const FileUploaderButton = ({
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        className={`relative w-full transition-all duration-300 ${
+        className={`relative ${dropZoneWidthClassName} transition-all duration-300 ${
           isPlaceholder
             ? "border-shopstr-purple dark:border-shopstr-yellow flex h-full min-h-[250px] items-center justify-center rounded-xl border-2 border-dashed p-6"
             : !isDragging && "border-2 border-dashed border-transparent"

--- a/pages/settings/user-profile.tsx
+++ b/pages/settings/user-profile.tsx
@@ -157,11 +157,15 @@ const UserProfilePage = () => {
         return;
       }
 
-      await createNostrProfileEvent(nostr, signer, JSON.stringify(updatedData));
+      const signedProfileEvent = await createNostrProfileEvent(
+        nostr,
+        signer,
+        JSON.stringify(updatedData)
+      );
       profileContext.updateProfileData({
         pubkey: userPubkey,
         content: updatedData,
-        created_at: Math.floor(Date.now() / 1000),
+        created_at: signedProfileEvent.created_at,
       });
     } catch (error) {
       console.error("Failed to save user profile:", error);

--- a/pages/settings/user-profile.tsx
+++ b/pages/settings/user-profile.tsx
@@ -16,7 +16,10 @@ import {
   EyeSlashIcon,
   EyeIcon,
 } from "@heroicons/react/24/outline";
-import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import {
+  AVATARBADGEBUTTONCLASSNAMES,
+  SHOPSTRBUTTONCLASSNAMES,
+} from "@/utils/STATIC-VARIABLES";
 import {
   SignerContext,
   NostrContext,
@@ -200,23 +203,22 @@ const UserProfilePage = () => {
                   </FileUploaderButton>
                 </div>
                 <div className="flex items-center justify-center">
-                  <div className="relative z-20 mt-[-3rem] h-24 w-24">
-                    <div className="">
-                      <FileUploaderButton
-                        isIconOnly
-                        className={`absolute right-[-0.5rem] bottom-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
-                        imgCallbackOnUpload={(imgUrl) =>
-                          setValue("picture", imgUrl)
-                        }
-                      />
-                      <Image
-                        key={profileImageSrc}
-                        src={profileImageSrc}
-                        alt="user profile picture"
-                        radius="full"
-                        className="h-24 w-24 object-cover"
-                      />
-                    </div>
+                  <div className="relative z-20 mt-[-3rem] h-24 w-24 overflow-visible">
+                    <FileUploaderButton
+                      isIconOnly
+                      className={AVATARBADGEBUTTONCLASSNAMES}
+                      containerClassName="absolute right-[-0.5rem] bottom-[-0.5rem] z-20"
+                      imgCallbackOnUpload={(imgUrl) =>
+                        setValue("picture", imgUrl)
+                      }
+                    />
+                    <Image
+                      key={profileImageSrc}
+                      src={profileImageSrc}
+                      alt="user profile picture"
+                      radius="full"
+                      className="h-24 w-24 rounded-full object-cover"
+                    />
                   </div>
                 </div>
               </div>

--- a/utils/STATIC-VARIABLES.ts
+++ b/utils/STATIC-VARIABLES.ts
@@ -42,6 +42,9 @@ export const SHIPPING_OPTIONS = [
 export const SHOPSTRBUTTONCLASSNAMES =
   "text-dark-text dark:text-light-text shadow-lg bg-gradient-to-tr from-shopstr-purple via-shopstr-purple-light to-shopstr-purple min-w-fit dark:from-shopstr-yellow dark:via-shopstr-yellow-light dark:to-shopstr-yellow";
 
+export const AVATARBADGEBUTTONCLASSNAMES =
+  "h-10 w-10 min-w-0 rounded-full border-2 border-white p-0 text-dark-text shadow-md bg-gradient-to-tr from-shopstr-purple via-shopstr-purple-light to-shopstr-purple dark:text-light-text dark:from-shopstr-yellow dark:via-shopstr-yellow-light dark:to-shopstr-yellow";
+
 export const WHITEBUTTONCLASSNAMES =
   "bg-white border-2 border-black text-black font-bold hover:bg-gray-100 transition-colors";
 

--- a/utils/nostr/__tests__/nostr-manager.test.ts
+++ b/utils/nostr/__tests__/nostr-manager.test.ts
@@ -1,9 +1,13 @@
 const verifyEventMock = jest.fn();
+let relayConnectMock: jest.Mock;
+let relayCloseMock: jest.Mock;
 const fakePoolInstance = {
-  ensureRelay: jest.fn().mockResolvedValue({
-    connect: jest.fn().mockResolvedValue(undefined),
-    close: jest.fn().mockResolvedValue(undefined),
-  }),
+  ensureRelay: jest.fn(() =>
+    Promise.resolve({
+      connect: relayConnectMock,
+      close: relayCloseMock,
+    })
+  ),
   subscribeMap: jest.fn().mockReturnValue({ close: jest.fn() }),
   publish: jest.fn().mockReturnValue([Promise.resolve("ok")]),
 };
@@ -19,6 +23,8 @@ describe("NostrManager", () => {
   beforeEach(async () => {
     jest.resetModules();
     jest.clearAllMocks();
+    relayConnectMock = jest.fn().mockResolvedValue(undefined);
+    relayCloseMock = jest.fn().mockResolvedValue(undefined);
 
     jest.doMock("nostr-tools", () => ({
       SimplePool: FakePool,
@@ -130,6 +136,25 @@ describe("NostrManager", () => {
       await sub.close();
       expect(mgr.relays[0].activeSubs).not.toContain(sub);
     });
+
+    it("awaits reconnect before subscribing on sleeping relays", async () => {
+      let resolveConnect!: () => void;
+      relayConnectMock.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveConnect = resolve;
+        })
+      );
+
+      const subscribePromise = mgr.subscribe([], {}, ["u1"]);
+      await Promise.resolve();
+
+      expect(fakePoolInstance.subscribeMap).not.toHaveBeenCalled();
+
+      resolveConnect();
+      await subscribePromise;
+
+      expect(fakePoolInstance.subscribeMap).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("publish()", () => {
@@ -146,6 +171,25 @@ describe("NostrManager", () => {
 
     it("publishes and resolves", async () => {
       await expect(mgr.publish(evt, ["p1"])).resolves.toBeUndefined();
+
+      expect(fakePoolInstance.publish).toHaveBeenCalledWith(["p1"], evt);
+    });
+
+    it("awaits reconnect before publishing on sleeping relays", async () => {
+      let resolveConnect!: () => void;
+      relayConnectMock.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveConnect = resolve;
+        })
+      );
+
+      const publishPromise = mgr.publish(evt, ["p1"]);
+      await Promise.resolve();
+
+      expect(fakePoolInstance.publish).not.toHaveBeenCalled();
+
+      resolveConnect();
+      await publishPromise;
 
       expect(fakePoolInstance.publish).toHaveBeenCalledWith(["p1"], evt);
     });

--- a/utils/nostr/__tests__/profile-save.test.ts
+++ b/utils/nostr/__tests__/profile-save.test.ts
@@ -1,0 +1,92 @@
+import { waitFor } from "@testing-library/react";
+import { createNostrProfileEvent } from "../nostr-helper-functions";
+import {
+  cacheEventToDatabase,
+  trackFailedRelayPublish,
+} from "@/utils/db/db-client";
+
+jest.mock("@/utils/db/db-client", () => ({
+  cacheEventToDatabase: jest.fn().mockResolvedValue(undefined),
+  deleteEventsFromDatabase: jest.fn(),
+  trackFailedRelayPublish: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/utils/timeout", () => ({
+  newPromiseWithTimeout: (fn: any) =>
+    new Promise((resolve, reject) => fn(resolve, reject)),
+}));
+
+const mockCacheEventToDatabase = cacheEventToDatabase as jest.Mock;
+const mockTrackFailedRelayPublish = trackFailedRelayPublish as jest.Mock;
+
+describe("createNostrProfileEvent", () => {
+  const signedEvent = {
+    id: "profile-event-1",
+    pubkey: "user-pubkey",
+    created_at: 12345,
+    kind: 0,
+    tags: [],
+    content: "{\"name\":\"alice\"}",
+    sig: "sig",
+  };
+
+  const signer = {
+    sign: jest.fn().mockResolvedValue(signedEvent),
+    getPubKey: jest.fn().mockResolvedValue("user-pubkey"),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem("writeRelays", JSON.stringify(["wss://relay.example"]));
+    localStorage.setItem("relays", JSON.stringify([]));
+  });
+
+  test("caches the signed profile event once and resolves before relay publish settles", async () => {
+    let resolvePublish!: () => void;
+    const nostr = {
+      publish: jest.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolvePublish = resolve;
+        })
+      ),
+    } as any;
+
+    const profileSavePromise = createNostrProfileEvent(
+      nostr,
+      signer,
+      signedEvent.content
+    );
+    const result = await profileSavePromise;
+
+    expect(result).toEqual(signedEvent);
+    expect(mockCacheEventToDatabase).toHaveBeenCalledTimes(1);
+    expect(mockCacheEventToDatabase).toHaveBeenCalledWith(signedEvent);
+    expect(nostr.publish).toHaveBeenCalledTimes(1);
+
+    resolvePublish();
+  });
+
+  test("tracks failed relay publishes in the background without rejecting the caller", async () => {
+    const publishError = new Error("relay failed");
+    const nostr = {
+      publish: jest.fn().mockRejectedValue(publishError),
+    } as any;
+
+    await expect(
+      createNostrProfileEvent(nostr, signer, signedEvent.content)
+    ).resolves.toEqual(signedEvent);
+
+    await waitFor(() => {
+      expect(mockTrackFailedRelayPublish).toHaveBeenCalledWith(
+        signedEvent.id,
+        signedEvent,
+        expect.arrayContaining([
+          "wss://relay.example",
+          "wss://sendit.nosflare.com",
+        ]),
+        signer
+      );
+    });
+  });
+});

--- a/utils/nostr/__tests__/profile-save.test.ts
+++ b/utils/nostr/__tests__/profile-save.test.ts
@@ -26,7 +26,7 @@ describe("createNostrProfileEvent", () => {
     created_at: 12345,
     kind: 0,
     tags: [],
-    content: "{\"name\":\"alice\"}",
+    content: '{"name":"alice"}',
     sig: "sig",
   };
 
@@ -38,7 +38,10 @@ describe("createNostrProfileEvent", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
-    localStorage.setItem("writeRelays", JSON.stringify(["wss://relay.example"]));
+    localStorage.setItem(
+      "writeRelays",
+      JSON.stringify(["wss://relay.example"])
+    );
     localStorage.setItem("relays", JSON.stringify([]));
   });
 

--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -139,25 +139,16 @@ export async function createNostrProfileEvent(
   nostr: NostrManager,
   signer: NostrSigner,
   stringifiedContent: string
-) {
+): Promise<NostrEvent> {
   const profileContent: EventTemplate = {
     created_at: Math.floor(Date.now() / 1000),
     content: stringifiedContent,
     kind: 0,
     tags: [],
   };
-  const signedEvent = await finalizeAndSendNostrEvent(
-    signer,
-    nostr,
-    profileContent
-  );
-
-  // Cache profile event to database
-  if (signedEvent) {
-    await cacheEventToDatabase(signedEvent).catch((error) =>
-      console.error("Failed to cache profile event to database:", error)
-    );
-  }
+  return await finalizeAndSendNostrEvent(signer, nostr, profileContent, {
+    waitForRelayPublish: false,
+  });
 }
 
 export async function PostListing(
@@ -1002,34 +993,30 @@ export async function retractApproval(
   return await finalizeAndSendNostrEvent(signer, nostr, eventTemplate);
 }
 
-export async function finalizeAndSendNostrEvent(
-  signer: NostrSigner,
+type FinalizeAndSendOptions = {
+  waitForRelayPublish?: boolean;
+};
+
+async function publishEventWithRetryTracking(
   nostr: NostrManager,
-  eventTemplate: EventTemplate
-) {
+  signer: NostrSigner,
+  signedEvent: NostrEvent,
+  relayUrls: string[]
+): Promise<void> {
   try {
-    const { writeRelays, relays } = getLocalStorageData();
-    const signedEvent = await signer.sign(eventTemplate);
-
-    // Cache to database first and wait for confirmation
-    await cacheEventToDatabase(signedEvent);
-
-    // After DB confirmation, attempt to publish to relays with timeout
-    const allWriteRelays = withBlastr([...writeRelays, ...relays]);
     try {
       await newPromiseWithTimeout(
         async (resolve, reject) => {
           try {
-            await nostr.publish(signedEvent, allWriteRelays);
+            await nostr.publish(signedEvent, relayUrls);
             resolve(undefined);
           } catch (err) {
             reject(err as Error);
           }
         },
-        { timeout: 21000 } // 21 second timeout
+        { timeout: 21000 }
       );
     } catch (error) {
-      // Timeout or relay publish error - track for retry
       console.warn(
         "Relay publish timed out or failed, but event is saved to database:",
         error
@@ -1038,15 +1025,43 @@ export async function finalizeAndSendNostrEvent(
       await trackFailedRelayPublish(
         signedEvent.id,
         signedEvent,
-        allWriteRelays,
+        relayUrls,
         signer
       ).catch(console.error);
     }
+  } catch (error) {
+    console.error("Failed to publish signed Nostr event:", error);
+  }
+}
 
-    // return the signed event to caller so we know generated IDs
+export async function finalizeAndSendNostrEvent(
+  signer: NostrSigner,
+  nostr: NostrManager,
+  eventTemplate: EventTemplate,
+  options: FinalizeAndSendOptions = {}
+): Promise<NostrEvent> {
+  try {
+    const { writeRelays, relays } = getLocalStorageData();
+    const signedEvent = await signer.sign(eventTemplate);
+
+    // Cache to database first and wait for confirmation
+    await cacheEventToDatabase(signedEvent);
+
+    const allWriteRelays = withBlastr([...writeRelays, ...relays]);
+
+    if (options.waitForRelayPublish === false) {
+      void publishEventWithRetryTracking(
+        nostr,
+        signer,
+        signedEvent,
+        allWriteRelays
+      );
+      return signedEvent;
+    }
+
+    await publishEventWithRetryTracking(nostr, signer, signedEvent, allWriteRelays);
     return signedEvent;
   } catch (error) {
-    // Log the actual error and re-throw it so the calling function knows something went wrong
     throw error;
   }
 }

--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -1059,7 +1059,12 @@ export async function finalizeAndSendNostrEvent(
       return signedEvent;
     }
 
-    await publishEventWithRetryTracking(nostr, signer, signedEvent, allWriteRelays);
+    await publishEventWithRetryTracking(
+      nostr,
+      signer,
+      signedEvent,
+      allWriteRelays
+    );
     return signedEvent;
   } catch (error) {
     throw error;

--- a/utils/nostr/nostr-manager.ts
+++ b/utils/nostr/nostr-manager.ts
@@ -82,18 +82,20 @@ export class NostrManager {
     return signer;
   }
 
-  private keepAlive(relays: NostrRelay[]) {
-    for (const relay of relays) {
-      if (relay.sleeping) {
-        try {
-          relay.connect();
-          relay.sleeping = false;
-        } catch (e) {
-          console.error(e);
+  private async keepAlive(relays: NostrRelay[]) {
+    await Promise.all(
+      relays.map(async (relay) => {
+        if (relay.sleeping) {
+          try {
+            await relay.connect();
+            relay.sleeping = false;
+          } catch (e) {
+            console.error(e);
+          }
         }
-      }
-      relay.lastActive = Date.now();
-    }
+        relay.lastActive = Date.now();
+      })
+    );
   }
 
   private async gc() {
@@ -144,6 +146,7 @@ export class NostrManager {
     const relays = relayUrls
       ? this.relays.filter((r) => relayUrls.includes(r.url))
       : this.relays;
+    await this.keepAlive(relays);
     const requests = relays.flatMap((r) =>
       filters.map((f) => ({ url: r.url, filter: f }))
     );
@@ -161,7 +164,6 @@ export class NostrManager {
     for (const relay of relays) {
       relay.activeSubs.push(sub);
     }
-    this.keepAlive(relays);
     return sub;
   }
 
@@ -213,7 +215,7 @@ export class NostrManager {
     const relays = relayUrls
       ? this.relays.filter((r) => relayUrls.includes(r.url))
       : this.relays;
-    this.keepAlive(relays);
+    await this.keepAlive(relays);
     await Promise.allSettled(
       this.pool.publish(
         relays.map((r) => r.url),

--- a/utils/nostr/nostr-manager.ts
+++ b/utils/nostr/nostr-manager.ts
@@ -164,6 +164,7 @@ export class NostrManager {
     for (const relay of relays) {
       relay.activeSubs.push(sub);
     }
+    await this.keepAlive(relays);
     return sub;
   }
 
@@ -188,6 +189,15 @@ export class NostrManager {
       const onEvent = params.onevent;
       const onEose = params.oneose;
       const fetchedEvents: Array<NostrEvent> = [];
+      let sub: NostrSub | undefined;
+      let didCloseSub = false;
+      let didResolve = false;
+
+      const closeSubIfNeeded = async () => {
+        if (!sub || didCloseSub) return;
+        didCloseSub = true;
+        await sub.close();
+      };
 
       params.onevent = (event: NostrEvent) => {
         fetchedEvents.push(event);
@@ -195,12 +205,15 @@ export class NostrManager {
       };
 
       params.oneose = () => {
-        sub!.close();
-        resolve(fetchedEvents);
+        closeSubIfNeeded().catch(console.error);
+        if (!didResolve) {
+          didResolve = true;
+          resolve(fetchedEvents);
+        }
         return onEose!();
       };
 
-      const sub = await this.subscribe(filters, params, relayUrls);
+      sub = await this.subscribe(filters, params, relayUrls);
     });
   }
 


### PR DESCRIPTION
### Description
- Speeds up shared kind `0` profile saves by shortening the critical path to signing plus a single DB cache write, while relay publish continues in the background.
- Updates `createNostrProfileEvent(...)` to return the signed event so profile save flows can immediately use the real `created_at` for optimistic `ProfileContext` updates.
- Removes the duplicate profile-event cache write from the shared Nostr helper.
- Awaits relay reconnects in `NostrManager.publish(...)` and `NostrManager.subscribe(...)` so background profile publishing does not race sleeping or closing relay sockets.
- Applies the shared save-path improvement across settings profile save flows and buyer onboarding so loading state clears sooner while keeping existing redirects and saved-state UX intact.
- Adds focused regression coverage for:
  - fast profile save behavior and background publish retry tracking
  - awaited relay reconnect behavior
  - `created_at` propagation into profile context updates for profile forms
- Targeted tests for this change pass. Full `npm test` still has unrelated pre-existing failures on `main`.

### Resolved or fixed issue
Fixes #288

### Screenshots (if applicable)
none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
