### PR TITLE
Fixes anchor avatar upload badge in profile forms

### DIFF
--- a/components/settings/__tests__/buyer-profile-form.test.tsx
+++ b/components/settings/__tests__/buyer-profile-form.test.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import BuyerProfileForm from "../buyer-profile-form";
+import { ProfileMapContext } from "@/utils/context/context";
+import {
+  NostrContext,
+  SignerContext,
+} from "@/components/utility-components/nostr-context-provider";
+import { FileUploaderButton } from "@/components/utility-components/file-uploader";
+import { AVATARBADGEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
+}));
+
+jest.mock(
+  "@heroui/react",
+  () => ({
+    Button: ({ children, type, onClick, onKeyDown }: any) => (
+      <button type={type || "button"} onClick={onClick} onKeyDown={onKeyDown}>
+        {children}
+      </button>
+    ),
+    Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
+      <label>
+        {label}
+        <input
+          aria-label={label}
+          type={type}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </label>
+    ),
+    Image: ({ src, alt, className }: any) => (
+      <img src={src} alt={alt} className={className} />
+    ),
+  }),
+  { virtual: true }
+);
+
+jest.mock("@/components/utility-components/file-uploader", () => ({
+  FileUploaderButton: jest.fn(() => <button data-testid="upload-picture-btn" />),
+}));
+const mockFileUploaderButton = FileUploaderButton as jest.Mock;
+
+jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  createNostrProfileEvent: jest.fn(),
+}));
+
+const renderWithProviders = (component: React.ReactElement) => {
+  return render(
+    <NostrContext.Provider value={{ nostr: {} as any }}>
+      <SignerContext.Provider
+        value={{ signer: {} as any, pubkey: "buyer_pubkey_123" }}
+      >
+        <ProfileMapContext.Provider
+          value={{
+            profileData: new Map(),
+            updateProfileData: jest.fn(),
+            isLoading: false,
+          }}
+        >
+          {component}
+        </ProfileMapContext.Provider>
+      </SignerContext.Provider>
+    </NostrContext.Provider>
+  );
+};
+
+describe("BuyerProfileForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("passes anchored badge props to the avatar uploader", async () => {
+    renderWithProviders(<BuyerProfileForm />);
+    await screen.findByLabelText("Display name");
+
+    expect(mockFileUploaderButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isIconOnly: true,
+        className: AVATARBADGEBUTTONCLASSNAMES,
+        containerClassName:
+          "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
+      }),
+      {}
+    );
+  });
+});

--- a/components/settings/__tests__/buyer-profile-form.test.tsx
+++ b/components/settings/__tests__/buyer-profile-form.test.tsx
@@ -43,7 +43,9 @@ jest.mock(
 );
 
 jest.mock("@/components/utility-components/file-uploader", () => ({
-  FileUploaderButton: jest.fn(() => <button data-testid="upload-picture-btn" />),
+  FileUploaderButton: jest.fn(() => (
+    <button data-testid="upload-picture-btn" />
+  )),
 }));
 const mockFileUploaderButton = FileUploaderButton as jest.Mock;
 
@@ -85,10 +87,9 @@ describe("BuyerProfileForm", () => {
       expect.objectContaining({
         isIconOnly: true,
         className: AVATARBADGEBUTTONCLASSNAMES,
-        containerClassName:
-          "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
+        containerClassName: "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
       }),
-      {}
+      undefined
     );
   });
 });

--- a/components/settings/__tests__/user-profile-form.test.tsx
+++ b/components/settings/__tests__/user-profile-form.test.tsx
@@ -6,24 +6,99 @@ import "@testing-library/jest-dom";
 import UserProfileForm from "../user-profile-form";
 import { ProfileMapContext } from "@/utils/context/context";
 import {
-  SignerContext,
   NostrContext,
+  SignerContext,
 } from "@/components/utility-components/nostr-context-provider";
-import { createNostrProfileEvent } from "@/utils/nostr/nostr-helper-functions";
+import {
+  createNostrProfileEvent,
+} from "@/utils/nostr/nostr-helper-functions";
+import { FileUploaderButton } from "@/components/utility-components/file-uploader";
+import { AVATARBADGEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
 
 const mockRouterPush = jest.fn();
 jest.mock("next/router", () => ({
   useRouter: jest.fn(() => ({ push: mockRouterPush })),
 }));
 
-jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
-  createNostrProfileEvent: jest.fn(),
-}));
+jest.mock(
+  "@heroui/react",
+  () => ({
+    Button: ({
+      children,
+      isDisabled,
+      isLoading,
+      onClick,
+      onKeyDown,
+      type,
+    }: any) => (
+      <button
+        type={type || "button"}
+        disabled={isDisabled || isLoading}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+      >
+        {children}
+      </button>
+    ),
+    Input: ({ label, value, onChange, onBlur, type = "text" }: any) => (
+      <label>
+        {label}
+        <input
+          aria-label={label}
+          type={type}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </label>
+    ),
+    Image: ({ src, alt, className }: any) => (
+      <img src={src} alt={alt} className={className} />
+    ),
+    Select: ({ label, selectedKeys, onChange, onBlur, children }: any) => (
+      <label>
+        {label}
+        <select
+          aria-label={label}
+          value={selectedKeys?.[0] ?? ""}
+          onChange={onChange}
+          onBlur={onBlur}
+        >
+          {children}
+        </select>
+      </label>
+    ),
+    SelectItem: ({ children, value, ...props }: any) => {
+      const optionLabel = Array.isArray(children) ? children.join("") : children;
+      const optionValue =
+        value ??
+        (typeof optionLabel === "string" && optionLabel.includes("Lightning")
+          ? "lightning"
+          : "ecash");
+
+      return (
+        <option value={optionValue} {...props}>
+          {children}
+        </option>
+      );
+    },
+    Tooltip: ({ children }: any) => <>{children}</>,
+  }),
+  { virtual: true }
+);
+
+jest.mock("@/utils/nostr/nostr-helper-functions", () => {
+  const actual = jest.requireActual("@/utils/nostr/nostr-helper-functions");
+  return {
+    ...actual,
+    createNostrProfileEvent: jest.fn(),
+  };
+});
 const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
 
 jest.mock("@/components/utility-components/file-uploader", () => ({
   FileUploaderButton: jest.fn(
-    ({ children, imgCallbackOnUpload, isIconOnly }) => (
+    ({ children, imgCallbackOnUpload, isIconOnly }: any) => (
       <button
         data-testid={isIconOnly ? "upload-picture-btn" : "upload-banner-btn"}
         onClick={() => imgCallbackOnUpload("https://new.image/url")}
@@ -33,6 +108,7 @@ jest.mock("@/components/utility-components/file-uploader", () => ({
     )
   ),
 }));
+const mockFileUploaderButton = FileUploaderButton as jest.Mock;
 
 jest.mock("@/components/utility-components/shopstr-spinner", () => () => null);
 
@@ -75,6 +151,7 @@ const renderWithProviders = (
       </SignerContext.Provider>
     </NostrContext.Provider>
   );
+
   return { mockUpdateProfileData };
 };
 
@@ -82,6 +159,21 @@ describe("UserProfileForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+  });
+
+  test("passes anchored badge props to the avatar uploader", async () => {
+    renderWithProviders(<UserProfileForm />);
+    await screen.findByLabelText("Display name");
+
+    expect(mockFileUploaderButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isIconOnly: true,
+        className: AVATARBADGEBUTTONCLASSNAMES,
+        containerClassName:
+          "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
+      }),
+      {}
+    );
   });
 
   test("displays the form after initial data load", async () => {
@@ -174,18 +266,10 @@ describe("UserProfileForm", () => {
     renderWithProviders(<UserProfileForm />);
     await screen.findByLabelText("Display name");
 
-    const paymentSelect = screen.getByRole("button", {
-      name: /Payment preference \(for sellers\)/i,
-    });
-    await user.click(paymentSelect);
-    const lightningOption = await screen.findByRole("option", {
-      name: "Lightning (Bitcoin)",
-    });
-    await user.click(lightningOption);
-
-    await waitFor(() => {
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-    });
+    const paymentSelect = screen.getByLabelText(
+      /Payment preference \(for sellers\)/i
+    );
+    await user.selectOptions(paymentSelect, "lightning");
 
     const donationInput = screen.getByLabelText(/Shopstr donation %/);
     await user.clear(donationInput);

--- a/components/settings/__tests__/user-profile-form.test.tsx
+++ b/components/settings/__tests__/user-profile-form.test.tsx
@@ -9,9 +9,7 @@ import {
   NostrContext,
   SignerContext,
 } from "@/components/utility-components/nostr-context-provider";
-import {
-  createNostrProfileEvent,
-} from "@/utils/nostr/nostr-helper-functions";
+import { createNostrProfileEvent } from "@/utils/nostr/nostr-helper-functions";
 import { FileUploaderButton } from "@/components/utility-components/file-uploader";
 import { AVATARBADGEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
 
@@ -19,6 +17,14 @@ const mockRouterPush = jest.fn();
 jest.mock("next/router", () => ({
   useRouter: jest.fn(() => ({ push: mockRouterPush })),
 }));
+
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  createNostrProfileEvent: jest.fn(),
+  getLocalUserProfileKey: (pubkey: string) => `shopstr:user-profile:${pubkey}`,
+  parseLocalProfileFallback: (raw: string | null) =>
+    raw ? { content: JSON.parse(raw), updatedAt: 0 } : null,
+}));
+const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
 
 jest.mock(
   "@heroui/react",
@@ -69,7 +75,9 @@ jest.mock(
       </label>
     ),
     SelectItem: ({ children, value, ...props }: any) => {
-      const optionLabel = Array.isArray(children) ? children.join("") : children;
+      const optionLabel = Array.isArray(children)
+        ? children.join("")
+        : children;
       const optionValue =
         value ??
         (typeof optionLabel === "string" && optionLabel.includes("Lightning")
@@ -86,15 +94,6 @@ jest.mock(
   }),
   { virtual: true }
 );
-
-jest.mock("@/utils/nostr/nostr-helper-functions", () => {
-  const actual = jest.requireActual("@/utils/nostr/nostr-helper-functions");
-  return {
-    ...actual,
-    createNostrProfileEvent: jest.fn(),
-  };
-});
-const mockCreateNostrProfileEvent = createNostrProfileEvent as jest.Mock;
 
 jest.mock("@/components/utility-components/file-uploader", () => ({
   FileUploaderButton: jest.fn(
@@ -169,10 +168,9 @@ describe("UserProfileForm", () => {
       expect.objectContaining({
         isIconOnly: true,
         className: AVATARBADGEBUTTONCLASSNAMES,
-        containerClassName:
-          "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
+        containerClassName: "absolute right-[-0.5rem] bottom-[-0.5rem] z-20",
       }),
-      {}
+      undefined
     );
   });
 

--- a/components/settings/buyer-profile-form.tsx
+++ b/components/settings/buyer-profile-form.tsx
@@ -3,7 +3,10 @@ import { useRouter } from "next/router";
 import { useForm, Controller } from "react-hook-form";
 import { Button, Input, Image } from "@heroui/react";
 import { ProfileMapContext } from "@/utils/context/context";
-import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import {
+  AVATARBADGEBUTTONCLASSNAMES,
+  SHOPSTRBUTTONCLASSNAMES,
+} from "@/utils/STATIC-VARIABLES";
 import {
   SignerContext,
   NostrContext,
@@ -94,23 +97,24 @@ const BuyerProfileForm = ({ isOnboarding }: BuyerProfileFormProps) => {
   return (
     <>
       <div className="mb-16 flex items-center justify-center">
-        <div className="relative h-24 w-24">
+        <div className="relative h-24 w-24 overflow-visible">
           <FileUploaderButton
             isIconOnly
-            className={`absolute right-[-0.5rem] bottom-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
+            className={AVATARBADGEBUTTONCLASSNAMES}
+            containerClassName="absolute right-[-0.5rem] bottom-[-0.5rem] z-20"
             imgCallbackOnUpload={(imgUrl) => setValue("picture", imgUrl)}
           />
           {watchPicture ? (
             <Image
               src={watchPicture}
               alt="User Profile Picture"
-              className="rounded-full"
+              className="h-24 w-24 rounded-full object-cover"
             />
           ) : (
             <Image
               src={defaultImage}
               alt="User Profile Picture"
-              className="rounded-full"
+              className="h-24 w-24 rounded-full object-cover"
             />
           )}
         </div>

--- a/components/settings/user-profile-form.tsx
+++ b/components/settings/user-profile-form.tsx
@@ -10,7 +10,10 @@ import {
   Tooltip,
 } from "@heroui/react";
 import { ProfileMapContext } from "@/utils/context/context";
-import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import {
+  AVATARBADGEBUTTONCLASSNAMES,
+  SHOPSTRBUTTONCLASSNAMES,
+} from "@/utils/STATIC-VARIABLES";
 import {
   SignerContext,
   NostrContext,
@@ -198,17 +201,18 @@ const UserProfileForm = ({ isOnboarding }: UserProfileFormProps) => {
   return (
     <>
       <div className="mb-8 flex items-center justify-center">
-        <div className="relative h-24 w-24">
+        <div className="relative h-24 w-24 overflow-visible">
           <FileUploaderButton
             isIconOnly
-            className={`absolute right-[-0.5rem] bottom-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
+            className={AVATARBADGEBUTTONCLASSNAMES}
+            containerClassName="absolute right-[-0.5rem] bottom-[-0.5rem] z-20"
             imgCallbackOnUpload={(imgUrl) => setValue("picture", imgUrl)}
           />
           <Image
             key={profileImageSrc}
             src={profileImageSrc}
             alt="user profile picture"
-            className="rounded-full"
+            className="h-24 w-24 rounded-full object-cover"
           />
         </div>
       </div>

--- a/components/utility-components/__tests__/file-uploader.test.tsx
+++ b/components/utility-components/__tests__/file-uploader.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { FileUploaderButton } from "../file-uploader";
+
+jest.mock(
+  "@heroui/react",
+  () => ({
+    Button: ({ children, className, onClick, type = "button", ...props }: any) => (
+      <button
+        type={type}
+        className={className}
+        onClick={onClick}
+        {...props}
+      >
+        {children}
+      </button>
+    ),
+    Progress: (props: any) => <div data-testid="progress" {...props} />,
+  }),
+  { virtual: true }
+);
+
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  blossomUploadImages: jest.fn(),
+  getLocalStorageData: jest.fn(() => ({})),
+}));
+
+jest.mock("@heroicons/react/24/outline", () => ({
+  PhotoIcon: (props: any) => <svg data-testid="photo-icon" {...props} />,
+  ArrowUpTrayIcon: (props: any) => (
+    <svg data-testid="arrow-up-tray-icon" {...props} />
+  ),
+  XCircleIcon: (props: any) => <svg data-testid="x-circle-icon" {...props} />,
+  XMarkIcon: (props: any) => <svg data-testid="x-mark-icon" {...props} />,
+}));
+
+describe("FileUploaderButton", () => {
+  test("applies containerClassName to the outer wrapper and keeps className on the inner button", () => {
+    const { container } = render(
+      <FileUploaderButton
+        className="inner-button-class"
+        containerClassName="outer-wrapper-class"
+        imgCallbackOnUpload={jest.fn()}
+      >
+        Upload Avatar
+      </FileUploaderButton>
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const button = screen.getByRole("button", { name: /Upload Avatar/i });
+
+    expect(root).toHaveClass("outer-wrapper-class");
+    expect(root).toHaveClass("w-fit");
+    expect(root).not.toHaveClass("inner-button-class");
+    expect(button).toHaveClass("inner-button-class");
+    expect(button).not.toHaveClass("outer-wrapper-class");
+  });
+
+  test("uses the default full-width wrapper behavior when containerClassName is omitted", () => {
+    const { container } = render(
+      <FileUploaderButton
+        className="inner-button-class"
+        imgCallbackOnUpload={jest.fn()}
+      >
+        Upload Banner
+      </FileUploaderButton>
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const button = screen.getByRole("button", { name: /Upload Banner/i });
+
+    expect(root).toHaveClass("flex", "w-full", "flex-col", "gap-4");
+    expect(root).not.toHaveClass("w-fit");
+    expect(button).toHaveClass("inner-button-class");
+  });
+});

--- a/components/utility-components/__tests__/file-uploader.test.tsx
+++ b/components/utility-components/__tests__/file-uploader.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
@@ -7,13 +6,14 @@ import { FileUploaderButton } from "../file-uploader";
 jest.mock(
   "@heroui/react",
   () => ({
-    Button: ({ children, className, onClick, type = "button", ...props }: any) => (
-      <button
-        type={type}
-        className={className}
-        onClick={onClick}
-        {...props}
-      >
+    Button: ({
+      children,
+      className,
+      onClick,
+      type = "button",
+      ...props
+    }: any) => (
+      <button type={type} className={className} onClick={onClick} {...props}>
         {children}
       </button>
     ),

--- a/components/utility-components/file-uploader.tsx
+++ b/components/utility-components/file-uploader.tsx
@@ -42,6 +42,7 @@ export const FileUploaderButton = ({
   disabled,
   isIconOnly,
   className,
+  containerClassName,
   children,
   imgCallbackOnUpload,
   isPlaceholder,
@@ -50,6 +51,7 @@ export const FileUploaderButton = ({
   disabled?: boolean;
   isIconOnly?: boolean;
   className?: string;
+  containerClassName?: string;
   children?: React.ReactNode;
   imgCallbackOnUpload: (imgUrl: string) => void;
   isPlaceholder?: boolean;
@@ -421,8 +423,13 @@ export const FileUploaderButton = ({
     }, 0);
   };
 
+  const wrapperClassName = containerClassName
+    ? `flex w-fit flex-col gap-4 ${containerClassName}`
+    : "flex w-full flex-col gap-4";
+  const dropZoneWidthClassName = containerClassName ? "w-fit" : "w-full";
+
   return (
-    <div className="flex w-full flex-col gap-4">
+    <div className={wrapperClassName}>
       {/* Drag and Drop Zone */}
       <div
         ref={dropZoneRef}
@@ -431,7 +438,7 @@ export const FileUploaderButton = ({
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        className={`relative w-full transition-all duration-300 ${
+        className={`relative ${dropZoneWidthClassName} transition-all duration-300 ${
           isPlaceholder
             ? "border-shopstr-purple dark:border-shopstr-yellow flex h-full min-h-[250px] items-center justify-center rounded-xl border-2 border-dashed p-6"
             : !isDragging && "border-2 border-dashed border-transparent"

--- a/pages/settings/user-profile.tsx
+++ b/pages/settings/user-profile.tsx
@@ -16,7 +16,10 @@ import {
   EyeSlashIcon,
   EyeIcon,
 } from "@heroicons/react/24/outline";
-import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import {
+  AVATARBADGEBUTTONCLASSNAMES,
+  SHOPSTRBUTTONCLASSNAMES,
+} from "@/utils/STATIC-VARIABLES";
 import {
   SignerContext,
   NostrContext,
@@ -196,23 +199,22 @@ const UserProfilePage = () => {
                   </FileUploaderButton>
                 </div>
                 <div className="flex items-center justify-center">
-                  <div className="relative z-20 mt-[-3rem] h-24 w-24">
-                    <div className="">
-                      <FileUploaderButton
-                        isIconOnly
-                        className={`absolute right-[-0.5rem] bottom-[-0.5rem] z-20 ${SHOPSTRBUTTONCLASSNAMES}`}
-                        imgCallbackOnUpload={(imgUrl) =>
-                          setValue("picture", imgUrl)
-                        }
-                      />
-                      <Image
-                        key={profileImageSrc}
-                        src={profileImageSrc}
-                        alt="user profile picture"
-                        radius="full"
-                        className="h-24 w-24 object-cover"
-                      />
-                    </div>
+                  <div className="relative z-20 mt-[-3rem] h-24 w-24 overflow-visible">
+                    <FileUploaderButton
+                      isIconOnly
+                      className={AVATARBADGEBUTTONCLASSNAMES}
+                      containerClassName="absolute right-[-0.5rem] bottom-[-0.5rem] z-20"
+                      imgCallbackOnUpload={(imgUrl) =>
+                        setValue("picture", imgUrl)
+                      }
+                    />
+                    <Image
+                      key={profileImageSrc}
+                      src={profileImageSrc}
+                      alt="user profile picture"
+                      radius="full"
+                      className="h-24 w-24 rounded-full object-cover"
+                    />
                   </div>
                 </div>
               </div>

--- a/utils/STATIC-VARIABLES.ts
+++ b/utils/STATIC-VARIABLES.ts
@@ -42,6 +42,9 @@ export const SHIPPING_OPTIONS = [
 export const SHOPSTRBUTTONCLASSNAMES =
   "text-dark-text dark:text-light-text shadow-lg bg-gradient-to-tr from-shopstr-purple via-shopstr-purple-light to-shopstr-purple min-w-fit dark:from-shopstr-yellow dark:via-shopstr-yellow-light dark:to-shopstr-yellow";
 
+export const AVATARBADGEBUTTONCLASSNAMES =
+  "h-10 w-10 min-w-0 rounded-full border-2 border-white p-0 text-dark-text shadow-md bg-gradient-to-tr from-shopstr-purple via-shopstr-purple-light to-shopstr-purple dark:text-light-text dark:from-shopstr-yellow dark:via-shopstr-yellow-light dark:to-shopstr-yellow";
+
 export const WHITEBUTTONCLASSNAMES =
   "bg-white border-2 border-black text-black font-bold hover:bg-gray-100 transition-colors";
 


### PR DESCRIPTION
### Description
- Fixes the misplaced avatar upload badge in onboarding and profile settings by updating the shared `FileUploaderButton` layout path instead of relying on per-screen absolute button styling.
- Adds `containerClassName` to `FileUploaderButton` so badge-style upload buttons can anchor from the outer wrapper while preserving the existing `className` behavior for the inner HeroUI button.
- Introduces a dedicated `AVATARBADGEBUTTONCLASSNAMES` style so circular avatar badges no longer inherit generic CTA sizing like `min-w-fit`.
- Updates the affected avatar upload surfaces in:
  - seller onboarding profile form
  - buyer onboarding profile form
  - user profile settings page
- Normalizes avatar image sizing to stable circular `24x24` frames with `object-cover` so the badge anchor point stays consistent.
- Adds focused regression coverage for:
  - shared uploader wrapper-vs-button class behavior
  - seller profile avatar badge props
  - buyer profile avatar badge props

### Resolved or fixed issue
Fixes #287

### Screenshots (if applicable)
none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
