### PR TITLE
Harden direct listing loads for relay-hinted naddr routes

### DIFF
--- a/components/__tests__/dynamic-meta-head.test.tsx
+++ b/components/__tests__/dynamic-meta-head.test.tsx
@@ -21,19 +21,15 @@ jest.mock("next/router", () => ({
 }));
 const mockUseRouter = useRouter as jest.Mock;
 
-jest.mock("nostr-tools", () => ({
-  nip19: {
-    naddrEncode: jest.fn(),
-    npubEncode: jest.fn(),
-  },
-}));
-const mockNip19 = nip19 as jest.Mocked<typeof nip19>;
-
 jest.mock("@/utils/parsers/product-parser-functions", () => ({
   __esModule: true,
   default: jest.fn(),
 }));
 const mockParseTags = parseTags as jest.Mock;
+
+const shopPubkey = "1".repeat(64);
+const fallbackShopPubkey = "2".repeat(64);
+const productPubkey = "3".repeat(64);
 
 describe("DynamicHead", () => {
   const getMetaContent = (name: string) => {
@@ -65,8 +61,7 @@ describe("DynamicHead", () => {
 
   describe("Shop Pages", () => {
     test("should render meta tags for a specific shop page when shop is found", async () => {
-      const shopPubkey = "shop_pubkey_1";
-      const shopNpub = "npub1shop";
+      const shopNpub = nip19.npubEncode(shopPubkey);
       const shopEvents = new Map<string, ShopProfile>([
         [
           shopPubkey,
@@ -91,7 +86,6 @@ describe("DynamicHead", () => {
         pathname: `/marketplace/${shopNpub}`,
         query: { npub: [shopNpub] },
       });
-      mockNip19.npubEncode.mockReturnValue(shopNpub);
       render(
         <DynamicHead
           productEvents={[]}
@@ -103,7 +97,7 @@ describe("DynamicHead", () => {
     });
 
     test("should render fallback meta tags for a shop page when shop is not found", async () => {
-      const shopNpub = "npub1shop_not_found";
+      const shopNpub = nip19.npubEncode(fallbackShopPubkey);
       mockUseRouter.mockReturnValue({
         pathname: `/marketplace/${shopNpub}`,
         query: { npub: [shopNpub] },
@@ -138,8 +132,7 @@ describe("DynamicHead", () => {
     });
 
     test("should use fallback image for a shop with picture set to null", async () => {
-      const shopPubkey = "shop_pubkey_3";
-      const shopNpub = "npub1nullpic";
+      const shopNpub = nip19.npubEncode(shopPubkey);
       const shopEvents = new Map<string, ShopProfile>([
         [
           shopPubkey,
@@ -159,7 +152,6 @@ describe("DynamicHead", () => {
         pathname: `/marketplace/${shopNpub}`,
         query: { npub: [shopNpub] },
       });
-      mockNip19.npubEncode.mockReturnValue(shopNpub);
       render(
         <DynamicHead
           productEvents={[]}
@@ -177,7 +169,6 @@ describe("DynamicHead", () => {
 
   describe("Listing Pages", () => {
     const productId = "product_123";
-    const productPubkey = "product_pubkey_1";
     const productEvent = {
       id: productId,
       pubkey: productPubkey,
@@ -186,12 +177,10 @@ describe("DynamicHead", () => {
     } as NostrEvent;
 
     test("should find a product by event id if d tag does not match", async () => {
-      const naddr = "naddr1product";
       mockUseRouter.mockReturnValue({
         pathname: `/listing/${productId}`,
         query: { productId: [productId] },
       });
-      mockNip19.naddrEncode.mockReturnValue(naddr);
       mockParseTags.mockReturnValue({ title: "Found By ID" });
       render(
         <DynamicHead
@@ -203,13 +192,33 @@ describe("DynamicHead", () => {
       await waitFor(() => expect(document.title).toBe("Found By ID"));
     });
 
+    test("should resolve relay-hinted naddr routes from the matching listing identity", async () => {
+      const relayHintedNaddr = nip19.naddrEncode({
+        identifier: "some_other_id",
+        pubkey: productPubkey,
+        kind: 30402,
+        relays: ["wss://relay.shopstr.example", "wss://relay-2.shopstr.example"],
+      });
+      mockUseRouter.mockReturnValue({
+        pathname: `/listing/${relayHintedNaddr}`,
+        query: { productId: [relayHintedNaddr] },
+      });
+      mockParseTags.mockReturnValue({ title: "Relay Hint Listing" });
+      render(
+        <DynamicHead
+          productEvents={[productEvent]}
+          shopEvents={new Map()}
+          profileData={new Map()}
+        />
+      );
+      await waitFor(() => expect(document.title).toBe("Relay Hint Listing"));
+    });
+
     test("should use fallback values for a parsed product with partial data", async () => {
-      const naddr = "naddr1product";
       mockUseRouter.mockReturnValue({
         pathname: `/listing/${productId}`,
         query: { productId: [productId] },
       });
-      mockNip19.naddrEncode.mockReturnValue(naddr);
       mockParseTags.mockReturnValue({ summary: "Only summary exists." });
       render(
         <DynamicHead
@@ -225,12 +234,10 @@ describe("DynamicHead", () => {
     });
 
     test("should render fallback tags for a listing when parsing fails", async () => {
-      const naddr = "naddr1product";
       mockUseRouter.mockReturnValue({
         pathname: `/listing/${productId}`,
         query: { productId: [productId] },
       });
-      mockNip19.naddrEncode.mockReturnValue(naddr);
       mockParseTags.mockReturnValue(null);
       render(
         <DynamicHead

--- a/components/__tests__/dynamic-meta-head.test.tsx
+++ b/components/__tests__/dynamic-meta-head.test.tsx
@@ -197,10 +197,14 @@ describe("DynamicHead", () => {
         identifier: "some_other_id",
         pubkey: productPubkey,
         kind: 30402,
-        relays: ["wss://relay.shopstr.example", "wss://relay-2.shopstr.example"],
+        relays: [
+          "wss://relay.shopstr.example",
+          "wss://relay-2.shopstr.example",
+        ],
       });
       mockUseRouter.mockReturnValue({
         pathname: `/listing/${relayHintedNaddr}`,
+        asPath: `/listing/${relayHintedNaddr}`,
         query: { productId: [relayHintedNaddr] },
       });
       mockParseTags.mockReturnValue({ title: "Relay Hint Listing" });

--- a/components/dynamic-meta-head.tsx
+++ b/components/dynamic-meta-head.tsx
@@ -8,6 +8,10 @@ import parseTags, {
 } from "@/utils/parsers/product-parser-functions";
 import { nip19 } from "nostr-tools";
 import {
+  eventMatchesListingIdentifier,
+  getListingRouteIdentifier,
+} from "@/utils/listing-identifiers";
+import {
   findProductBySlug,
   getListingSlug,
   isNpub,
@@ -47,7 +51,7 @@ const getMetaTags = (
   };
 
   if (pathname.startsWith("/listing/")) {
-    const productId = query.productId?.[0];
+    const productId = getListingRouteIdentifier(query.productId);
     if (!productId) return defaultTags;
 
     const allParsed = productEvents
@@ -60,26 +64,9 @@ const getMetaTags = (
     productData = findProductBySlug(productId, allParsed);
 
     if (!productData) {
-      const product = productEvents.find((event) => {
-        const naddrMatch = (() => {
-          try {
-            return (
-              nip19.naddrEncode({
-                identifier:
-                  event.tags.find((tag: string[]) => tag[0] === "d")?.[1] || "",
-                pubkey: event.pubkey,
-                kind: event.kind,
-              }) === productId
-            );
-          } catch {
-            return false;
-          }
-        })();
-        const dTagMatch =
-          event.tags.find((tag: string[]) => tag[0] === "d")?.[1] === productId;
-        const idMatch = event.id === productId;
-        return naddrMatch || dTagMatch || idMatch;
-      });
+      const product = productEvents.find((event) =>
+        eventMatchesListingIdentifier(event, productId)
+      );
       if (product) {
         productData = parseTags(product);
       }

--- a/pages/listing/[[...productId]].tsx
+++ b/pages/listing/[[...productId]].tsx
@@ -25,6 +25,10 @@ import {
   EventIdModal,
 } from "../../components/utility-components/modals/event-modals";
 import { findProductBySlug, getListingSlug } from "@/utils/url-slugs";
+import {
+  eventMatchesListingIdentifier,
+  getListingRouteIdentifier,
+} from "@/utils/listing-identifiers";
 import StorefrontThemeWrapper from "@/components/storefront/storefront-theme-wrapper";
 import { GetServerSideProps } from "next";
 import { OgMetaProps, DEFAULT_OG } from "@/components/og-head";
@@ -46,12 +50,6 @@ type ResolvedListingState = {
   rawEvent: NostrEvent;
   isZapsnag: boolean;
 };
-
-function getListingIdentifier(
-  productId: string | string[] | undefined
-): string {
-  return Array.isArray(productId) ? productId[0] || "" : productId || "";
-}
 
 function resolveListingStateFromEvent(
   event: NostrEvent | null | undefined
@@ -113,7 +111,7 @@ export const getServerSideProps: GetServerSideProps<ListingPageProps> = async (
   context
 ) => {
   const { productId } = context.query;
-  const identifier = getListingIdentifier(productId);
+  const identifier = getListingRouteIdentifier(productId);
 
   if (!identifier) {
     return { props: { ogMeta: LISTING_FALLBACK, initialProductEvent: null } };
@@ -230,9 +228,7 @@ const Listing = ({ initialProductEvent }: ListingPageProps) => {
   useEffect(() => {
     if (router.isReady) {
       const { productId } = router.query;
-      const resolvedProductId = Array.isArray(productId)
-        ? productId[0] || ""
-        : productId || "";
+      const resolvedProductId = getListingRouteIdentifier(productId);
       setProductIdString(resolvedProductId);
       if (!resolvedProductId) {
         router.push("/marketplace");
@@ -280,21 +276,8 @@ const Listing = ({ initialProductEvent }: ListingPageProps) => {
 
       if (!matchingEvent) {
         matchingEvent = productContext.productEvents.find(
-          (event: NostrEvent) => {
-            const naddrMatch =
-              nip19.naddrEncode({
-                identifier:
-                  event.tags.find((tag: string[]) => tag[0] === "d")?.[1] || "",
-                pubkey: event.pubkey,
-                kind: event.kind,
-              }) === productIdString;
-
-            const dTagMatch =
-              event.tags.find((tag: string[]) => tag[0] === "d")?.[1] ===
-              productIdString;
-            const idMatch = event.id === productIdString;
-            return naddrMatch || dTagMatch || idMatch;
-          }
+          (event: NostrEvent) =>
+            eventMatchesListingIdentifier(event, productIdString)
         );
       }
 

--- a/pages/listing/[[...productId]].tsx
+++ b/pages/listing/[[...productId]].tsx
@@ -275,9 +275,8 @@ const Listing = ({ initialProductEvent }: ListingPageProps) => {
       }
 
       if (!matchingEvent) {
-        matchingEvent = productContext.productEvents.find(
-          (event: NostrEvent) =>
-            eventMatchesListingIdentifier(event, productIdString)
+        matchingEvent = productContext.productEvents.find((event: NostrEvent) =>
+          eventMatchesListingIdentifier(event, productIdString)
         );
       }
 

--- a/pages/listing/__tests__/listing-page.test.tsx
+++ b/pages/listing/__tests__/listing-page.test.tsx
@@ -1,0 +1,351 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { useRouter } from "next/router";
+import { nip19 } from "nostr-tools";
+import type { ReactNode } from "react";
+
+import ListingPage from "../[[...productId]]";
+import { ProductContext } from "@/utils/context/context";
+import { NostrEvent } from "@/utils/types/types";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock(
+  "@heroui/react",
+  () => ({
+    Modal: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    ModalContent: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    ModalHeader: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    ModalBody: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Dropdown: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    DropdownTrigger: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    DropdownMenu: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    DropdownItem: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Button: ({
+      children,
+      onPress,
+    }: {
+      children: ReactNode;
+      onPress?: () => void;
+    }) => <button onClick={onPress}>{children}</button>,
+  }),
+  { virtual: true }
+);
+
+jest.mock("@heroicons/react/24/outline", () => ({
+  XCircleIcon: () => <svg data-testid="x-circle-icon" />,
+  EllipsisVerticalIcon: () => <svg data-testid="ellipsis-vertical-icon" />,
+}));
+
+jest.mock("@/utils/parsers/product-parser-functions", () => ({
+  __esModule: true,
+  default: jest.fn((event: NostrEvent) => {
+    const title = event.tags.find((tag: string[]) => tag[0] === "title")?.[1];
+    if (!title) {
+      return undefined;
+    }
+
+    return {
+      id: event.id,
+      pubkey: event.pubkey,
+      title,
+      summary:
+        event.tags.find((tag: string[]) => tag[0] === "summary")?.[1] || "",
+      images: [
+        event.tags.find((tag: string[]) => tag[0] === "image")?.[1] ||
+          "https://example.com/listing.png",
+      ],
+    };
+  }),
+}));
+
+jest.mock("@/utils/parsers/zapsnag-parser", () => ({
+  parseZapsnagNote: jest.fn(() => undefined),
+}));
+
+jest.mock(
+  "../../../components/utility-components/checkout-card",
+  () =>
+    function MockCheckoutCard({
+      productData,
+    }: {
+      productData: { title: string; summary?: string };
+    }) {
+      return (
+        <div data-testid="checkout-card">
+          <div>{productData.title}</div>
+          <div>{productData.summary}</div>
+        </div>
+      );
+    }
+);
+
+jest.mock("@/components/storefront/storefront-theme-wrapper", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="storefront-theme-wrapper">{children}</div>
+  ),
+}));
+
+jest.mock("@/components/utility-components/modals/event-modals", () => ({
+  RawEventModal: () => null,
+  EventIdModal: () => null,
+}));
+
+jest.mock("../../../components/ZapsnagButton", () => () => (
+  <div data-testid="zapsnag-button" />
+));
+
+jest.mock("@/components/utility-components/shopstr-spinner", () => ({
+  __esModule: true,
+  default: () => <div data-testid="shopstr-spinner" />,
+}));
+
+const mockUseRouter = useRouter as jest.Mock;
+
+const relayHintedIdentifier = nip19.naddrEncode({
+  identifier: "listing-d-tag",
+  pubkey: "a".repeat(64),
+  kind: 30402,
+  relays: ["wss://relay.shopstr.example", "wss://relay-2.shopstr.example"],
+});
+
+function createEvent({
+  id,
+  title,
+  summary = "",
+  pubkey = "a".repeat(64),
+  dTag = "listing-d-tag",
+}: {
+  id: string;
+  title: string;
+  summary?: string;
+  pubkey?: string;
+  dTag?: string;
+}): NostrEvent {
+  return {
+    id,
+    pubkey,
+    created_at: 1710000000,
+    kind: 30402,
+    tags: [
+      ["d", dTag],
+      ["title", title],
+      ["summary", summary],
+      ["image", "https://example.com/listing.png"],
+    ],
+    content: "",
+    sig: "f".repeat(128),
+  };
+}
+
+const defaultOgMeta = {
+  title: "Shopstr Listing",
+  description: "Check out this listing on Shopstr!",
+  image: "/shopstr-2000x2000.png",
+  url: `/listing/${relayHintedIdentifier}`,
+};
+
+function renderListingPage({
+  initialProductEvent,
+  productEvents,
+  isLoading,
+}: {
+  initialProductEvent: NostrEvent | null;
+  productEvents: NostrEvent[];
+  isLoading: boolean;
+}) {
+  return render(
+    <ProductContext.Provider
+      value={{
+        productEvents,
+        isLoading,
+        addNewlyCreatedProductEvent: jest.fn(),
+        removeDeletedProductEvent: jest.fn(),
+      }}
+    >
+      <ListingPage
+        ogMeta={defaultOgMeta}
+        initialProductEvent={initialProductEvent}
+      />
+    </ProductContext.Provider>
+  );
+}
+
+describe("Listing page direct-load reconciliation", () => {
+  let routerState: {
+    isReady: boolean;
+    push: jest.Mock;
+    replace: jest.Mock;
+    query: { productId: string[] };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    routerState = {
+      isReady: true,
+      push: jest.fn(),
+      replace: jest.fn(),
+      query: { productId: [relayHintedIdentifier] },
+    };
+    mockUseRouter.mockImplementation(() => routerState);
+  });
+
+  test("keeps the SSR-seeded listing visible for relay-hinted naddr routes after hydration", async () => {
+    const seededEvent = createEvent({
+      id: "seeded-event-id",
+      title: "SSR Relay Listing",
+      summary: "Rendered before product hydration",
+    });
+
+    const { rerender } = renderListingPage({
+      initialProductEvent: seededEvent,
+      productEvents: [],
+      isLoading: true,
+    });
+
+    expect(screen.getByTestId("checkout-card")).toHaveTextContent(
+      "SSR Relay Listing"
+    );
+
+    rerender(
+      <ProductContext.Provider
+        value={{
+          productEvents: [
+            createEvent({
+              id: "hydrated-event-id",
+              title: "SSR Relay Listing",
+              summary: "Hydrated relay listing",
+            }),
+          ],
+          isLoading: false,
+          addNewlyCreatedProductEvent: jest.fn(),
+          removeDeletedProductEvent: jest.fn(),
+        }}
+      >
+        <ListingPage
+          ogMeta={defaultOgMeta}
+          initialProductEvent={seededEvent}
+        />
+      </ProductContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("checkout-card")).toHaveTextContent(
+        "SSR Relay Listing"
+      )
+    );
+  });
+
+  test("prefers the matching hydrated context event once it becomes available", async () => {
+    const seededEvent = createEvent({
+      id: "seeded-event-id",
+      title: "SSR Relay Listing",
+      summary: "Seeded summary",
+    });
+    const hydratedEvent = createEvent({
+      id: "hydrated-event-id",
+      title: "Hydrated Relay Listing",
+      summary: "Fresh context summary",
+    });
+
+    const { rerender } = renderListingPage({
+      initialProductEvent: seededEvent,
+      productEvents: [],
+      isLoading: true,
+    });
+
+    expect(screen.getByTestId("checkout-card")).toHaveTextContent(
+      "SSR Relay Listing"
+    );
+
+    rerender(
+      <ProductContext.Provider
+        value={{
+          productEvents: [hydratedEvent],
+          isLoading: false,
+          addNewlyCreatedProductEvent: jest.fn(),
+          removeDeletedProductEvent: jest.fn(),
+        }}
+      >
+        <ListingPage
+          ogMeta={defaultOgMeta}
+          initialProductEvent={seededEvent}
+        />
+      </ProductContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("checkout-card")).toHaveTextContent(
+        "Hydrated Relay Listing"
+      )
+    );
+    expect(screen.getByTestId("checkout-card")).toHaveTextContent(
+      "Fresh context summary"
+    );
+  });
+
+  test("clears stale listing state when the route changes to a different listing", async () => {
+    const seededEvent = createEvent({
+      id: "seeded-event-id",
+      title: "Cold Load Listing",
+      summary: "Initial route listing",
+    });
+
+    const { rerender } = renderListingPage({
+      initialProductEvent: seededEvent,
+      productEvents: [],
+      isLoading: false,
+    });
+
+    expect(screen.getByTestId("checkout-card")).toHaveTextContent(
+      "Cold Load Listing"
+    );
+
+    routerState = {
+      ...routerState,
+      query: { productId: ["different-listing-route"] },
+    };
+
+    rerender(
+      <ProductContext.Provider
+        value={{
+          productEvents: [],
+          isLoading: false,
+          addNewlyCreatedProductEvent: jest.fn(),
+          removeDeletedProductEvent: jest.fn(),
+        }}
+      >
+        <ListingPage
+          ogMeta={{
+            ...defaultOgMeta,
+            url: "/listing/different-listing-route",
+          }}
+          initialProductEvent={null}
+        />
+      </ProductContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("checkout-card")).not.toBeInTheDocument()
+    );
+    expect(screen.getByTestId("shopstr-spinner")).toBeInTheDocument();
+    expect(screen.queryByText("Cold Load Listing")).not.toBeInTheDocument();
+  });
+});

--- a/pages/listing/__tests__/listing-page.test.tsx
+++ b/pages/listing/__tests__/listing-page.test.tsx
@@ -22,12 +22,8 @@ jest.mock(
     ModalHeader: ({ children }: { children: ReactNode }) => (
       <div>{children}</div>
     ),
-    ModalBody: ({ children }: { children: ReactNode }) => (
-      <div>{children}</div>
-    ),
-    Dropdown: ({ children }: { children: ReactNode }) => (
-      <div>{children}</div>
-    ),
+    ModalBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Dropdown: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     DropdownTrigger: ({ children }: { children: ReactNode }) => (
       <div>{children}</div>
     ),
@@ -44,6 +40,11 @@ jest.mock(
       children: ReactNode;
       onPress?: () => void;
     }) => <button onClick={onPress}>{children}</button>,
+    useDisclosure: () => ({
+      isOpen: false,
+      onOpen: () => undefined,
+      onClose: () => undefined,
+    }),
   }),
   { virtual: true }
 );
@@ -239,10 +240,7 @@ describe("Listing page direct-load reconciliation", () => {
           removeDeletedProductEvent: jest.fn(),
         }}
       >
-        <ListingPage
-          ogMeta={defaultOgMeta}
-          initialProductEvent={seededEvent}
-        />
+        <ListingPage ogMeta={defaultOgMeta} initialProductEvent={seededEvent} />
       </ProductContext.Provider>
     );
 
@@ -284,10 +282,7 @@ describe("Listing page direct-load reconciliation", () => {
           removeDeletedProductEvent: jest.fn(),
         }}
       >
-        <ListingPage
-          ogMeta={defaultOgMeta}
-          initialProductEvent={seededEvent}
-        />
+        <ListingPage ogMeta={defaultOgMeta} initialProductEvent={seededEvent} />
       </ProductContext.Provider>
     );
 

--- a/utils/__tests__/listing-identifiers.test.ts
+++ b/utils/__tests__/listing-identifiers.test.ts
@@ -1,0 +1,95 @@
+import { nip19 } from "nostr-tools";
+
+import {
+  eventMatchesListingIdentifier,
+  getListingRouteIdentifier,
+} from "../listing-identifiers";
+import { NostrEvent } from "../types/types";
+
+const baseEvent: NostrEvent = {
+  id: "event-id-123",
+  pubkey: "1".repeat(64),
+  created_at: 1710000000,
+  kind: 30402,
+  tags: [
+    ["d", "listing-d-tag"],
+    ["title", "Relay Hint Listing"],
+  ],
+  content: "",
+  sig: "f".repeat(128),
+};
+
+describe("listing-identifiers", () => {
+  test("normalizes route params from catch-all arrays", () => {
+    expect(getListingRouteIdentifier(["primary-id", "ignored-id"])).toBe(
+      "primary-id"
+    );
+    expect(getListingRouteIdentifier("single-id")).toBe("single-id");
+    expect(getListingRouteIdentifier(undefined)).toBe("");
+  });
+
+  test("matches a relay-hinted naddr against the same listing identity", () => {
+    const relayHintedNaddr = nip19.naddrEncode({
+      identifier: "listing-d-tag",
+      pubkey: baseEvent.pubkey,
+      kind: baseEvent.kind,
+      relays: ["wss://relay.shopstr.example", "wss://relay-2.shopstr.example"],
+    });
+
+    expect(eventMatchesListingIdentifier(baseEvent, relayHintedNaddr)).toBe(
+      true
+    );
+  });
+
+  test("matches a canonical naddr without relay hints", () => {
+    const naddr = nip19.naddrEncode({
+      identifier: "listing-d-tag",
+      pubkey: baseEvent.pubkey,
+      kind: baseEvent.kind,
+    });
+
+    expect(eventMatchesListingIdentifier(baseEvent, naddr)).toBe(true);
+  });
+
+  test("returns false when the decoded naddr identity does not fully match", () => {
+    const wrongPubkeyNaddr = nip19.naddrEncode({
+      identifier: "listing-d-tag",
+      pubkey: "2".repeat(64),
+      kind: baseEvent.kind,
+      relays: ["wss://relay.shopstr.example"],
+    });
+    const wrongKindNaddr = nip19.naddrEncode({
+      identifier: "listing-d-tag",
+      pubkey: baseEvent.pubkey,
+      kind: 30403,
+    });
+    const wrongIdentifierNaddr = nip19.naddrEncode({
+      identifier: "other-d-tag",
+      pubkey: baseEvent.pubkey,
+      kind: baseEvent.kind,
+    });
+
+    expect(eventMatchesListingIdentifier(baseEvent, wrongPubkeyNaddr)).toBe(
+      false
+    );
+    expect(eventMatchesListingIdentifier(baseEvent, wrongKindNaddr)).toBe(
+      false
+    );
+    expect(eventMatchesListingIdentifier(baseEvent, wrongIdentifierNaddr)).toBe(
+      false
+    );
+  });
+
+  test("returns false for malformed naddr identifiers without throwing", () => {
+    expect(eventMatchesListingIdentifier(baseEvent, "naddr1definitelyinvalid")).toBe(
+      false
+    );
+  });
+
+  test("still matches direct event ids and d tags", () => {
+    expect(eventMatchesListingIdentifier(baseEvent, baseEvent.id)).toBe(true);
+    expect(eventMatchesListingIdentifier(baseEvent, "listing-d-tag")).toBe(
+      true
+    );
+  });
+});

--- a/utils/__tests__/listing-identifiers.test.ts
+++ b/utils/__tests__/listing-identifiers.test.ts
@@ -81,9 +81,9 @@ describe("listing-identifiers", () => {
   });
 
   test("returns false for malformed naddr identifiers without throwing", () => {
-    expect(eventMatchesListingIdentifier(baseEvent, "naddr1definitelyinvalid")).toBe(
-      false
-    );
+    expect(
+      eventMatchesListingIdentifier(baseEvent, "naddr1definitelyinvalid")
+    ).toBe(false);
   });
 
   test("still matches direct event ids and d tags", () => {

--- a/utils/listing-identifiers.ts
+++ b/utils/listing-identifiers.ts
@@ -1,0 +1,67 @@
+import { nip19 } from "nostr-tools";
+
+import { NostrEvent } from "@/utils/types/types";
+
+type DecodedListingNaddr = {
+  identifier: string;
+  pubkey: string;
+  kind: number;
+};
+
+export function getListingRouteIdentifier(
+  productId: string | string[] | undefined
+): string {
+  return Array.isArray(productId) ? productId[0] || "" : productId || "";
+}
+
+export function decodeListingNaddr(
+  identifier: string
+): DecodedListingNaddr | null {
+  if (!identifier.startsWith("naddr1")) {
+    return null;
+  }
+
+  try {
+    const decoded = nip19.decode(identifier);
+    if (decoded.type !== "naddr") {
+      return null;
+    }
+
+    return {
+      identifier: decoded.data.identifier,
+      pubkey: decoded.data.pubkey,
+      kind: decoded.data.kind,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function eventMatchesListingIdentifier(
+  event: NostrEvent,
+  identifier: string
+): boolean {
+  if (!identifier) {
+    return false;
+  }
+
+  if (event.id === identifier) {
+    return true;
+  }
+
+  const dTag = event.tags.find((tag: string[]) => tag[0] === "d")?.[1];
+  if (dTag === identifier) {
+    return true;
+  }
+
+  const decoded = decodeListingNaddr(identifier);
+  if (!decoded || !dTag) {
+    return false;
+  }
+
+  return (
+    decoded.identifier === dTag &&
+    decoded.pubkey === event.pubkey &&
+    decoded.kind === event.kind
+  );
+}


### PR DESCRIPTION
### Description
- Fixes the remaining direct-listing load gap for relay-hinted `naddr` routes on top of the SSR hydration work already present on `main`.
- Adds a shared listing identifier helper that:
  - normalizes catch-all listing route params
  - decodes `naddr` identifiers
  - matches listing events by decoded `identifier`, `pubkey`, and `kind` instead of comparing encoded `naddr` strings
- Updates the listing page hydration reconciliation path so SSR-seeded listings remain visible after `ProductContext` hydrates even when the route uses a relay-hinted `naddr`.
- Updates `DynamicHead` to use the same listing identity matching rules so client-side listing meta resolution stays aligned with the page body behavior.
- Adds focused regression coverage for:
  - relay-hinted and canonical `naddr` matching
  - direct event id and direct `d`-tag matching
  - malformed `naddr` handling
  - SSR-seeded listing persistence after hydration
  - context reconciliation replacing the seeded listing once the matching event is available
  - relay-hinted `naddr` listing meta resolution in `DynamicHead`

### Resolved or fixed issue
Fixes #160

### Screenshots (if applicable)
none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
