### PR TITLE
add audit logging to MCP tool layer 

### DIFF
--- a/mcp/__tests__/audit-log.test.ts
+++ b/mcp/__tests__/audit-log.test.ts
@@ -5,6 +5,15 @@ import {
   AuditEntry,
 } from "@/mcp/audit-log";
 
+// noUncheckedIndexedAccess-safe helper: extract the JSON the spy wrote on call N
+function loggedEntry(
+  spy: { mock: { calls: unknown[][] } },
+  callIndex = 0
+): Record<string, unknown> {
+  const call = spy.mock.calls[callIndex] ?? [];
+  return JSON.parse(call[0] as string) as Record<string, unknown>;
+}
+
 describe("sanitizeParams", () => {
   it("passes through non-sensitive fields unchanged", () => {
     expect(sanitizeParams({ keyword: "shoes", limit: 10 })).toEqual({
@@ -39,13 +48,82 @@ describe("sanitizeParams", () => {
     expect(result.productId).toBe("abc123");
     expect(result.nsec).toBe("[REDACTED]");
   });
+
+  it("redacts sensitive keys nested inside objects", () => {
+    const result = sanitizeParams({
+      order: { nsec: "leak", buyerNote: "hi" },
+    });
+    const order = result.order as Record<string, unknown>;
+    expect(order.nsec).toBe("[REDACTED]");
+    expect(order.buyerNote).toBe("hi");
+  });
+
+  it("redacts sensitive keys at multiple nesting levels", () => {
+    const result = sanitizeParams({
+      outer: { inner: { password: "deep-secret", safe: "ok" } },
+    });
+    const inner = (result.outer as Record<string, unknown>).inner as Record<
+      string,
+      unknown
+    >;
+    expect(inner.password).toBe("[REDACTED]");
+    expect(inner.safe).toBe("ok");
+  });
+
+  it("truncates long string values to 200 chars", () => {
+    const long = "x".repeat(300);
+    const result = sanitizeParams({ fileBase64: long });
+    const val = result.fileBase64 as string;
+    expect(val).toHaveLength("x".repeat(200).length + "...[truncated]".length);
+    expect(val.endsWith("...[truncated]")).toBe(true);
+  });
+
+  it("does not truncate short strings", () => {
+    const result = sanitizeParams({ note: "hello" });
+    expect(result.note).toBe("hello");
+  });
+
+  it("truncates long strings inside nested objects", () => {
+    const long = "a".repeat(300);
+    const result = sanitizeParams({ shipping: { address: long } });
+    const shipping = result.shipping as Record<string, unknown>;
+    expect((shipping.address as string).endsWith("...[truncated]")).toBe(true);
+  });
+
+  it("sanitizes objects inside arrays", () => {
+    const result = sanitizeParams({
+      items: [{ nsec: "should-redact", label: "foo" }],
+    });
+    const items = result.items as Record<string, unknown>[];
+    expect(items[0]?.nsec).toBe("[REDACTED]");
+    expect(items[0]?.label).toBe("foo");
+  });
+
+  it("truncates long strings inside arrays", () => {
+    const long = "b".repeat(300);
+    const result = sanitizeParams({ tags: [long, "short"] });
+    const tags = result.tags as string[];
+    expect(tags[0]?.endsWith("...[truncated]")).toBe(true);
+    expect(tags[1]).toBe("short");
+  });
+
+  it("stops recursing past depth 4 and returns a sentinel", () => {
+    const deep = { a: { b: { c: { d: { e: { f: "too deep" } } } } } };
+    const result = sanitizeParams(deep);
+    // Depth 0→a, 1→b, 2→c, 3→d, 4→_depth_limit sentinel
+    const d = (
+      ((result.a as Record<string, unknown>).b as Record<string, unknown>)
+        .c as Record<string, unknown>
+    ).d as Record<string, unknown>;
+    expect(d).toEqual({ _depth_limit: true });
+  });
 });
 
 describe("logToolCall", () => {
   let consoleSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -57,18 +135,18 @@ describe("logToolCall", () => {
       tool: "search_products",
       params: { keyword: "shoes" },
       durationMs: 42,
-      isError: false,
+      status: "success",
       timestamp: "2026-01-01T00:00:00.000Z",
     };
 
     logToolCall(entry);
 
     expect(consoleSpy).toHaveBeenCalledTimes(1);
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    const logged = loggedEntry(consoleSpy);
     expect(logged.level).toBe("audit");
     expect(logged.tool).toBe("search_products");
     expect(logged.durationMs).toBe(42);
-    expect(logged.isError).toBe(false);
+    expect(logged.status).toBe("success");
   });
 
   it("includes optional apiKeyId and pubkey when provided", () => {
@@ -78,11 +156,11 @@ describe("logToolCall", () => {
       pubkey: "aabbcc",
       params: {},
       durationMs: 10,
-      isError: false,
+      status: "success",
       timestamp: "2026-01-01T00:00:00.000Z",
     });
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    const logged = loggedEntry(consoleSpy);
     expect(logged.apiKeyId).toBe(7);
     expect(logged.pubkey).toBe("aabbcc");
   });
@@ -92,11 +170,11 @@ describe("logToolCall", () => {
       tool: "list_companies",
       params: {},
       durationMs: 5,
-      isError: false,
+      status: "success",
       timestamp: "2026-01-01T00:00:00.000Z",
     });
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    const logged = loggedEntry(consoleSpy);
     expect("apiKeyId" in logged).toBe(false);
     expect("pubkey" in logged).toBe(false);
   });
@@ -106,7 +184,7 @@ describe("wrapWithAudit", () => {
   let consoleSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -134,30 +212,30 @@ describe("wrapWithAudit", () => {
     expect(result).toBe(expected);
   });
 
-  it("logs isError: false for a successful result", async () => {
+  it("logs status: success for a successful result", async () => {
     const wrapped = wrapWithAudit(
       "search_products",
       jest.fn().mockResolvedValue({ content: [] })
     );
     await wrapped({ keyword: "test" }, {});
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
-    expect(logged.isError).toBe(false);
+    const logged = loggedEntry(consoleSpy);
+    expect(logged.status).toBe("success");
     expect(logged.tool).toBe("search_products");
   });
 
-  it("logs isError: true when the result has isError: true", async () => {
+  it("logs status: error when the result has isError: true", async () => {
     const wrapped = wrapWithAudit(
       "get_product_details",
       jest.fn().mockResolvedValue({ content: [], isError: true })
     );
     await wrapped({ productId: "missing" }, {});
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
-    expect(logged.isError).toBe(true);
+    const logged = loggedEntry(consoleSpy);
+    expect(logged.status).toBe("error");
   });
 
-  it("logs isError: true and re-throws when the callback throws", async () => {
+  it("logs status: error and re-throws when the callback throws", async () => {
     const boom = new Error("db exploded");
     const wrapped = wrapWithAudit(
       "create_order",
@@ -166,9 +244,67 @@ describe("wrapWithAudit", () => {
 
     await expect(wrapped({}, {})).rejects.toThrow("db exploded");
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
-    expect(logged.isError).toBe(true);
+    const logged = loggedEntry(consoleSpy);
+    expect(logged.status).toBe("error");
     expect(logged.tool).toBe("create_order");
+  });
+
+  it("logs the original exception message in the error field", async () => {
+    const boom = new Error("connection pool exhausted");
+    const wrapped = wrapWithAudit(
+      "create_order",
+      jest.fn().mockRejectedValue(boom)
+    );
+
+    await expect(wrapped({}, {})).rejects.toThrow();
+
+    const logged = loggedEntry(consoleSpy);
+    expect(logged.error).toBe("connection pool exhausted");
+  });
+
+  it("logs non-Error throws as string in the error field", async () => {
+    const wrapped = wrapWithAudit(
+      "some_tool",
+      jest.fn().mockRejectedValue("plain string error")
+    );
+
+    await expect(wrapped({}, {})).rejects.toBe("plain string error");
+
+    const logged = loggedEntry(consoleSpy);
+    expect(logged.error).toBe("plain string error");
+  });
+
+  it("omits the error field on a successful call", async () => {
+    const wrapped = wrapWithAudit(
+      "list_companies",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({}, {});
+
+    const logged = loggedEntry(consoleSpy);
+    expect("error" in logged).toBe(false);
+  });
+
+  it("logs resultCount when the callback returns one", async () => {
+    const wrapped = wrapWithAudit(
+      "search_products",
+      jest.fn().mockResolvedValue({ content: [], resultCount: 12 })
+    );
+    await wrapped({ keyword: "bitcoin" }, {});
+
+    const logged = loggedEntry(consoleSpy);
+    expect(logged.resultCount).toBe(12);
+  });
+
+  it("omits resultCount when the callback does not return one", async () => {
+    const wrapped = wrapWithAudit(
+      "get_product_details",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({ productId: "abc" }, {});
+
+    const logged = loggedEntry(consoleSpy);
+    expect("resultCount" in logged).toBe(false);
   });
 
   it("records a positive durationMs", async () => {
@@ -178,7 +314,7 @@ describe("wrapWithAudit", () => {
     );
     await wrapped({}, {});
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    const logged = loggedEntry(consoleSpy);
     expect(logged.durationMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -191,7 +327,7 @@ describe("wrapWithAudit", () => {
     );
     await wrapped({}, {});
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    const logged = loggedEntry(consoleSpy);
     expect(logged.apiKeyId).toBe(3);
     expect(logged.pubkey).toBe("deadbeef");
   });
@@ -203,21 +339,52 @@ describe("wrapWithAudit", () => {
     );
     await wrapped({}, {});
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    const logged = loggedEntry(consoleSpy);
     expect("apiKeyId" in logged).toBe(false);
     expect("pubkey" in logged).toBe(false);
   });
 
-  it("redacts sensitive params before logging", async () => {
+  it("redacts top-level sensitive params before logging", async () => {
     const wrapped = wrapWithAudit(
       "some_tool",
       jest.fn().mockResolvedValue({ content: [] })
     );
     await wrapped({ nsec: "nsec1private", productId: "abc" }, {});
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
-    expect(logged.params.nsec).toBe("[REDACTED]");
-    expect(logged.params.productId).toBe("abc");
+    const logged = loggedEntry(consoleSpy);
+    const params = logged.params as Record<string, unknown>;
+    expect(params.nsec).toBe("[REDACTED]");
+    expect(params.productId).toBe("abc");
+  });
+
+  it("redacts sensitive params nested inside objects", async () => {
+    const wrapped = wrapWithAudit(
+      "create_order",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({ order: { nsec: "leaked-key", buyerNote: "rush" } }, {});
+
+    const logged = loggedEntry(consoleSpy);
+    const order = (logged.params as Record<string, unknown>).order as Record<
+      string,
+      unknown
+    >;
+    expect(order.nsec).toBe("[REDACTED]");
+    expect(order.buyerNote).toBe("rush");
+  });
+
+  it("truncates large field values before logging", async () => {
+    const wrapped = wrapWithAudit(
+      "upload_media",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    const blob = "A".repeat(500);
+    await wrapped({ fileBase64: blob }, {});
+
+    const logged = loggedEntry(consoleSpy);
+    const params = logged.params as Record<string, unknown>;
+    expect((params.fileBase64 as string).endsWith("...[truncated]")).toBe(true);
+    expect((params.fileBase64 as string).length).toBeLessThan(500);
   });
 
   it("includes a valid ISO timestamp in the log", async () => {
@@ -227,8 +394,10 @@ describe("wrapWithAudit", () => {
     );
     await wrapped({}, {});
 
-    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
-    expect(() => new Date(logged.timestamp)).not.toThrow();
-    expect(new Date(logged.timestamp).toISOString()).toBe(logged.timestamp);
+    const logged = loggedEntry(consoleSpy);
+    expect(() => new Date(logged.timestamp as string)).not.toThrow();
+    expect(new Date(logged.timestamp as string).toISOString()).toBe(
+      logged.timestamp
+    );
   });
 });

--- a/mcp/__tests__/audit-log.test.ts
+++ b/mcp/__tests__/audit-log.test.ts
@@ -70,10 +70,24 @@ describe("sanitizeParams", () => {
     expect(inner.safe).toBe("ok");
   });
 
-  it("truncates long string values to 200 chars", () => {
+  it("redacts private message, payment, address, and file fields", () => {
+    const result = sanitizeParams({
+      message: "Please leave this by the door",
+      invoice: "lnbc...",
+      fileBase64: "x".repeat(300),
+      shippingAddress: { address: "123 Market St" },
+    });
+
+    expect(result.message).toBe("[REDACTED]");
+    expect(result.invoice).toBe("[REDACTED]");
+    expect(result.fileBase64).toBe("[REDACTED]");
+    expect(result.shippingAddress).toBe("[REDACTED]");
+  });
+
+  it("truncates long non-sensitive string values to 200 chars", () => {
     const long = "x".repeat(300);
-    const result = sanitizeParams({ fileBase64: long });
-    const val = result.fileBase64 as string;
+    const result = sanitizeParams({ description: long });
+    const val = result.description as string;
     expect(val).toHaveLength("x".repeat(200).length + "...[truncated]".length);
     expect(val.endsWith("...[truncated]")).toBe(true);
   });
@@ -83,11 +97,11 @@ describe("sanitizeParams", () => {
     expect(result.note).toBe("hello");
   });
 
-  it("truncates long strings inside nested objects", () => {
+  it("redacts sensitive strings inside nested objects", () => {
     const long = "a".repeat(300);
     const result = sanitizeParams({ shipping: { address: long } });
     const shipping = result.shipping as Record<string, unknown>;
-    expect((shipping.address as string).endsWith("...[truncated]")).toBe(true);
+    expect(shipping.address).toBe("[REDACTED]");
   });
 
   it("sanitizes objects inside arrays", () => {
@@ -373,7 +387,7 @@ describe("wrapWithAudit", () => {
     expect(order.buyerNote).toBe("rush");
   });
 
-  it("truncates large field values before logging", async () => {
+  it("redacts large private field values before logging", async () => {
     const wrapped = wrapWithAudit(
       "upload_media",
       jest.fn().mockResolvedValue({ content: [] })
@@ -383,8 +397,7 @@ describe("wrapWithAudit", () => {
 
     const logged = loggedEntry(consoleSpy);
     const params = logged.params as Record<string, unknown>;
-    expect((params.fileBase64 as string).endsWith("...[truncated]")).toBe(true);
-    expect((params.fileBase64 as string).length).toBeLessThan(500);
+    expect(params.fileBase64).toBe("[REDACTED]");
   });
 
   it("includes a valid ISO timestamp in the log", async () => {

--- a/mcp/__tests__/audit-log.test.ts
+++ b/mcp/__tests__/audit-log.test.ts
@@ -1,0 +1,234 @@
+import {
+  sanitizeParams,
+  logToolCall,
+  wrapWithAudit,
+  AuditEntry,
+} from "@/mcp/audit-log";
+
+describe("sanitizeParams", () => {
+  it("passes through non-sensitive fields unchanged", () => {
+    expect(sanitizeParams({ keyword: "shoes", limit: 10 })).toEqual({
+      keyword: "shoes",
+      limit: 10,
+    });
+  });
+
+  it("redacts known sensitive keys", () => {
+    const result = sanitizeParams({
+      nsec: "nsec1secret",
+      cashuToken: "cashuA...",
+      password: "hunter2",
+      secret: "shh",
+      token: "tok_xyz",
+      apiKey: "sk_live_...",
+    });
+    for (const key of [
+      "nsec",
+      "cashuToken",
+      "password",
+      "secret",
+      "token",
+      "apiKey",
+    ]) {
+      expect(result[key]).toBe("[REDACTED]");
+    }
+  });
+
+  it("redacts only sensitive keys, leaving the rest intact", () => {
+    const result = sanitizeParams({ productId: "abc123", nsec: "nsec1secret" });
+    expect(result.productId).toBe("abc123");
+    expect(result.nsec).toBe("[REDACTED]");
+  });
+});
+
+describe("logToolCall", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("writes a single JSON line with level=audit", () => {
+    const entry: AuditEntry = {
+      tool: "search_products",
+      params: { keyword: "shoes" },
+      durationMs: 42,
+      isError: false,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    };
+
+    logToolCall(entry);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.level).toBe("audit");
+    expect(logged.tool).toBe("search_products");
+    expect(logged.durationMs).toBe(42);
+    expect(logged.isError).toBe(false);
+  });
+
+  it("includes optional apiKeyId and pubkey when provided", () => {
+    logToolCall({
+      tool: "get_product_details",
+      apiKeyId: 7,
+      pubkey: "aabbcc",
+      params: {},
+      durationMs: 10,
+      isError: false,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.apiKeyId).toBe(7);
+    expect(logged.pubkey).toBe("aabbcc");
+  });
+
+  it("omits apiKeyId and pubkey when not in entry", () => {
+    logToolCall({
+      tool: "list_companies",
+      params: {},
+      durationMs: 5,
+      isError: false,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect("apiKeyId" in logged).toBe(false);
+    expect("pubkey" in logged).toBe(false);
+  });
+});
+
+describe("wrapWithAudit", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("passes args and extra through to the original callback", async () => {
+    const cb = jest.fn().mockResolvedValue({ content: [] });
+    const wrapped = wrapWithAudit("my_tool", cb);
+
+    await wrapped({ foo: "bar" }, { session: "xyz" });
+
+    expect(cb).toHaveBeenCalledWith({ foo: "bar" }, { session: "xyz" });
+  });
+
+  it("returns the result from the original callback", async () => {
+    const expected = { content: [{ type: "text", text: "ok" }] };
+    const wrapped = wrapWithAudit(
+      "my_tool",
+      jest.fn().mockResolvedValue(expected)
+    );
+
+    const result = await wrapped({}, {});
+
+    expect(result).toBe(expected);
+  });
+
+  it("logs isError: false for a successful result", async () => {
+    const wrapped = wrapWithAudit(
+      "search_products",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({ keyword: "test" }, {});
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.isError).toBe(false);
+    expect(logged.tool).toBe("search_products");
+  });
+
+  it("logs isError: true when the result has isError: true", async () => {
+    const wrapped = wrapWithAudit(
+      "get_product_details",
+      jest.fn().mockResolvedValue({ content: [], isError: true })
+    );
+    await wrapped({ productId: "missing" }, {});
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.isError).toBe(true);
+  });
+
+  it("logs isError: true and re-throws when the callback throws", async () => {
+    const boom = new Error("db exploded");
+    const wrapped = wrapWithAudit(
+      "create_order",
+      jest.fn().mockRejectedValue(boom)
+    );
+
+    await expect(wrapped({}, {})).rejects.toThrow("db exploded");
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.isError).toBe(true);
+    expect(logged.tool).toBe("create_order");
+  });
+
+  it("records a positive durationMs", async () => {
+    const wrapped = wrapWithAudit(
+      "list_companies",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({}, {});
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes context fields (apiKeyId, pubkey) in the log", async () => {
+    const context = { apiKeyId: 3, pubkey: "deadbeef" };
+    const wrapped = wrapWithAudit(
+      "set_user_profile",
+      jest.fn().mockResolvedValue({ content: [] }),
+      context
+    );
+    await wrapped({}, {});
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.apiKeyId).toBe(3);
+    expect(logged.pubkey).toBe("deadbeef");
+  });
+
+  it("omits context fields when no context is provided", async () => {
+    const wrapped = wrapWithAudit(
+      "list_companies",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({}, {});
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect("apiKeyId" in logged).toBe(false);
+    expect("pubkey" in logged).toBe(false);
+  });
+
+  it("redacts sensitive params before logging", async () => {
+    const wrapped = wrapWithAudit(
+      "some_tool",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({ nsec: "nsec1private", productId: "abc" }, {});
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.params.nsec).toBe("[REDACTED]");
+    expect(logged.params.productId).toBe("abc");
+  });
+
+  it("includes a valid ISO timestamp in the log", async () => {
+    const wrapped = wrapWithAudit(
+      "search_products",
+      jest.fn().mockResolvedValue({ content: [] })
+    );
+    await wrapped({}, {});
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(() => new Date(logged.timestamp)).not.toThrow();
+    expect(new Date(logged.timestamp).toISOString()).toBe(logged.timestamp);
+  });
+});

--- a/mcp/audit-log.ts
+++ b/mcp/audit-log.ts
@@ -30,14 +30,29 @@ export type ToolCb = (
 const REDACTED = "[REDACTED]";
 const MAX_STRING_LENGTH = 200;
 
-const SENSITIVE_KEYS = new Set([
-  "nsec",
-  "password",
-  "secret",
-  "cashuToken",
-  "token",
-  "apiKey",
-]);
+const SENSITIVE_KEY_PATTERNS = [
+  /nsec/i,
+  /password/i,
+  /secret/i,
+  /token/i,
+  /api[-_]?key/i,
+  /authorization/i,
+  /private/i,
+  /seed/i,
+  /mnemonic/i,
+  /message/i,
+  /^content$/i,
+  /address/i,
+  /invoice/i,
+  /bolt11/i,
+  /^file/i,
+  /base64/i,
+  /tracking/i,
+];
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));
+}
 
 function truncateString(s: string): string {
   return s.length > MAX_STRING_LENGTH
@@ -52,7 +67,7 @@ export function sanitizeParams(
   if (depth >= 4) return { _depth_limit: true };
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(params)) {
-    if (SENSITIVE_KEYS.has(k)) {
+    if (isSensitiveKey(k)) {
       out[k] = REDACTED;
     } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
       out[k] = sanitizeParams(v as Record<string, unknown>, depth + 1);

--- a/mcp/audit-log.ts
+++ b/mcp/audit-log.ts
@@ -1,0 +1,67 @@
+export interface ToolContext {
+  apiKeyId?: number | null;
+  pubkey?: string;
+}
+
+export interface AuditEntry {
+  tool: string;
+  apiKeyId?: number | null;
+  pubkey?: string;
+  params: Record<string, unknown>;
+  durationMs: number;
+  isError: boolean;
+  timestamp: string;
+}
+
+const REDACTED = "[REDACTED]";
+const SENSITIVE_KEYS = new Set([
+  "nsec",
+  "password",
+  "secret",
+  "cashuToken",
+  "token",
+  "apiKey",
+]);
+
+export function sanitizeParams(
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(params)) {
+    out[k] = SENSITIVE_KEYS.has(k) ? REDACTED : v;
+  }
+  return out;
+}
+
+export function logToolCall(entry: AuditEntry): void {
+  console.log(JSON.stringify({ level: "audit", ...entry }));
+}
+
+export function wrapWithAudit(
+  toolName: string,
+  cb: (args: any, extra: any) => any,
+  context?: ToolContext
+): (args: any, extra: any) => any {
+  return async (args: any, extra: any) => {
+    const start = Date.now();
+    let isError = false;
+    try {
+      const result = await cb(args, extra);
+      isError = result?.isError === true;
+      return result;
+    } catch (err) {
+      isError = true;
+      throw err;
+    } finally {
+      logToolCall({
+        tool: toolName,
+        ...(context?.apiKeyId !== undefined && { apiKeyId: context.apiKeyId }),
+        ...(context?.pubkey !== undefined && { pubkey: context.pubkey }),
+        params: sanitizeParams(args ?? {}),
+        durationMs: Date.now() - start,
+        isError,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  };
+}

--- a/mcp/audit-log.ts
+++ b/mcp/audit-log.ts
@@ -9,11 +9,27 @@ export interface AuditEntry {
   pubkey?: string;
   params: Record<string, unknown>;
   durationMs: number;
-  isError: boolean;
+  status: "success" | "error";
+  error?: string | null;
+  resultCount?: number;
   timestamp: string;
 }
 
+type MaybePromise<T> = T | Promise<T>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ToolCb = (
+  args: any,
+  extra: any
+) => MaybePromise<{
+  content: unknown[];
+  isError?: boolean;
+  resultCount?: number;
+}>;
+
 const REDACTED = "[REDACTED]";
+const MAX_STRING_LENGTH = 200;
+
 const SENSITIVE_KEYS = new Set([
   "nsec",
   "password",
@@ -23,34 +39,63 @@ const SENSITIVE_KEYS = new Set([
   "apiKey",
 ]);
 
+function truncateString(s: string): string {
+  return s.length > MAX_STRING_LENGTH
+    ? `${s.slice(0, MAX_STRING_LENGTH)}...[truncated]`
+    : s;
+}
+
 export function sanitizeParams(
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  depth = 0
 ): Record<string, unknown> {
+  if (depth >= 4) return { _depth_limit: true };
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(params)) {
-    out[k] = SENSITIVE_KEYS.has(k) ? REDACTED : v;
+    if (SENSITIVE_KEYS.has(k)) {
+      out[k] = REDACTED;
+    } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      out[k] = sanitizeParams(v as Record<string, unknown>, depth + 1);
+    } else if (Array.isArray(v)) {
+      out[k] = v.map((item) =>
+        item !== null && typeof item === "object" && !Array.isArray(item)
+          ? sanitizeParams(item as Record<string, unknown>, depth + 1)
+          : typeof item === "string"
+            ? truncateString(item)
+            : item
+      );
+    } else if (typeof v === "string") {
+      out[k] = truncateString(v);
+    } else {
+      out[k] = v;
+    }
   }
   return out;
 }
 
 export function logToolCall(entry: AuditEntry): void {
-  console.log(JSON.stringify({ level: "audit", ...entry }));
+  console.error(JSON.stringify({ level: "audit", ...entry }));
 }
 
 export function wrapWithAudit(
   toolName: string,
-  cb: (args: any, extra: any) => any,
+  cb: ToolCb,
   context?: ToolContext
-): (args: any, extra: any) => any {
+): ToolCb {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return async (args: any, extra: any) => {
     const start = Date.now();
-    let isError = false;
+    let status: "success" | "error" = "success";
+    let errorMessage: string | null = null;
+    let resultCount: number | undefined;
     try {
       const result = await cb(args, extra);
-      isError = result?.isError === true;
+      if (result?.isError === true) status = "error";
+      if (result?.resultCount !== undefined) resultCount = result.resultCount;
       return result;
     } catch (err) {
-      isError = true;
+      status = "error";
+      errorMessage = err instanceof Error ? err.message : String(err);
       throw err;
     } finally {
       logToolCall({
@@ -59,7 +104,9 @@ export function wrapWithAudit(
         ...(context?.pubkey !== undefined && { pubkey: context.pubkey }),
         params: sanitizeParams(args ?? {}),
         durationMs: Date.now() - start,
-        isError,
+        status,
+        ...(errorMessage !== null && { error: errorMessage }),
+        ...(resultCount !== undefined && { resultCount }),
         timestamp: new Date().toISOString(),
       });
     }

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerReadTools } from "./tools/read-tools";
 import { registerResources } from "./resources";
+import { ToolContext } from "./audit-log";
 
-export function createMcpServer(): McpServer {
+export function createMcpServer(context?: ToolContext): McpServer {
   const server = new McpServer(
     {
       name: "shopstr",
@@ -16,7 +17,7 @@ export function createMcpServer(): McpServer {
     }
   );
 
-  registerReadTools(server);
+  registerReadTools(server, context);
   registerResources(server);
 
   return server;

--- a/mcp/tools/read-tools.ts
+++ b/mcp/tools/read-tools.ts
@@ -13,6 +13,7 @@ import {
 } from "@/utils/parsers/product-tag-helpers";
 import { NostrEvent } from "@/utils/types/types";
 import { registerTool } from "./register-tool";
+import { ToolContext } from "../audit-log";
 
 function getTagValue(tags: string[][], key: string): string | undefined {
   const tag = tags.find((t) => t[0] === key);
@@ -192,9 +193,15 @@ function parseReviewEvent(event: NostrEvent) {
   };
 }
 
-export function registerReadTools(server: McpServer) {
-  registerTool(
-    server,
+export function registerReadTools(server: McpServer, context?: ToolContext) {
+  const reg = (
+    name: string,
+    description: string,
+    inputSchema: any,
+    cb: (args: any, extra: any) => any
+  ) => registerTool(server, name, description, inputSchema, cb, context);
+
+  reg(
     "search_products",
     "Search and filter products by category, location, price range, or keyword",
     {
@@ -303,8 +310,7 @@ export function registerReadTools(server: McpServer) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "get_product_details",
     "Get full details for a specific product by its event ID",
     {
@@ -360,8 +366,7 @@ export function registerReadTools(server: McpServer) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "list_companies",
     "List all seller/shop profiles",
     {
@@ -411,8 +416,7 @@ export function registerReadTools(server: McpServer) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "get_company_details",
     "Get a specific company's shop profile, their products, and reviews",
     {
@@ -533,8 +537,7 @@ export function registerReadTools(server: McpServer) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "get_reviews",
     "Get reviews for a product or seller",
     {
@@ -610,8 +613,7 @@ export function registerReadTools(server: McpServer) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "check_discount_code",
     "Validate a discount code for a specific seller",
     {
@@ -644,8 +646,7 @@ export function registerReadTools(server: McpServer) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "get_storefront",
     "Look up a seller's storefront by shop slug or pubkey. Returns storefront configuration, products, and shop profile for rendering a seller's standalone shop page.",
     {

--- a/mcp/tools/register-tool.ts
+++ b/mcp/tools/register-tool.ts
@@ -1,20 +1,23 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ToolContext, wrapWithAudit } from "../audit-log";
+import { ToolCb, ToolContext, wrapWithAudit } from "../audit-log";
 
 export function registerTool(
   server: McpServer,
   name: string,
   description: string,
-  inputSchema: any,
-  cb: (args: any, extra: any) => any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema: Record<string, any>,
+  cb: ToolCb,
   context?: ToolContext
 ) {
   return server.registerTool(
     name,
     {
       description,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       inputSchema: inputSchema as any,
     },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     wrapWithAudit(name, cb, context) as any
   );
 }

--- a/mcp/tools/register-tool.ts
+++ b/mcp/tools/register-tool.ts
@@ -1,11 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolContext, wrapWithAudit } from "../audit-log";
 
 export function registerTool(
   server: McpServer,
   name: string,
   description: string,
   inputSchema: any,
-  cb: (args: any, extra: any) => any
+  cb: (args: any, extra: any) => any,
+  context?: ToolContext
 ) {
   return server.registerTool(
     name,
@@ -13,6 +15,6 @@ export function registerTool(
       description,
       inputSchema: inputSchema as any,
     },
-    cb as any
+    wrapWithAudit(name, cb, context) as any
   );
 }

--- a/mcp/tools/write-tools.ts
+++ b/mcp/tools/write-tools.ts
@@ -106,9 +106,15 @@ async function getSigner(apiKey: ApiKeyRecord): Promise<McpNostrSigner | null> {
 
 export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
   const baseUrl = `http://localhost:${process.env.PORT || 5000}`;
+  const context = { apiKeyId: apiKey.id, pubkey: apiKey.pubkey };
+  const reg = (
+    name: string,
+    description: string,
+    inputSchema: any,
+    cb: (args: any, extra: any) => any
+  ) => registerTool(server, name, description, inputSchema, cb, context);
 
-  registerTool(
-    server,
+  reg(
     "set_user_profile",
     "Create or update your Nostr user profile (kind 0). Sets metadata like name, about, picture, lightning address, etc.",
     {
@@ -183,8 +189,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "set_shop_profile",
     "Create or update your shop profile (kind 30019). Sets shop metadata like name, about, picture, banner, settings, and storefront configuration.",
     {
@@ -514,8 +519,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "register_shop_slug",
     "Register, update, or delete your shop's URL slug for the storefront. The slug becomes part of your shop URL (e.g. milk.market/shop/your-slug). Slug must be lowercase alphanumeric with hyphens, 3-50 characters. Reserved words (shop, admin, api, etc.) are not allowed. To delete, set action to 'delete'.",
     {
@@ -639,8 +643,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "create_product_listing",
     "Publish a new product listing (kind 30402) to the marketplace. Creates a classified listing with title, description, price, images, categories, shipping options, and more.",
     {
@@ -919,8 +922,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "update_product_listing",
     "Update an existing product listing by publishing a new event with the same d-tag. All fields are optional — only provided fields will be included.",
     {
@@ -1129,8 +1131,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "delete_listing",
     "Delete a product listing or any Nostr event by publishing a deletion event (kind 5).",
     {
@@ -1170,8 +1171,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "publish_review",
     "Publish a review (kind 31555) for a product or seller. Includes content text and ratings.",
     {
@@ -1265,8 +1265,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "create_community_post",
     "Create a post in a Nostr community (kind 1111). Supports top-level posts and replies.",
     {
@@ -1343,8 +1342,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "send_direct_message",
     "Send an encrypted direct message using NIP-17 gift wrap (kind 1059/13/14). Supports plain messages, listing inquiries, and order-related messages.",
     {
@@ -1558,8 +1556,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "update_order_address",
     "Update the shipping address for an existing order. Sends an encrypted address change request to the seller via NIP-17 gift-wrapped DM and updates the order record.",
     {
@@ -1709,8 +1706,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "send_shipping_update",
     "Send a shipping update to a buyer via encrypted NIP-17 gift-wrapped DM. Includes tracking number, carrier, and estimated delivery time. Also updates the order status to 'shipped' in the database.",
     {
@@ -1910,8 +1906,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "update_order_status",
     "Update the status of an order and optionally notify the buyer via encrypted DM. Sellers can confirm, ship, or complete orders. Buyers can cancel orders.",
     {
@@ -2110,8 +2105,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "list_messages",
     "Fetch and decrypt your incoming messages (NIP-17 gift-wrapped DMs). Returns decrypted message content, sender, subject, and read status. Use to check inquiries, order messages, address changes, and other DMs.",
     {
@@ -2234,8 +2228,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "mark_messages_read",
     "Mark specific messages as read by their event IDs.",
     {
@@ -2278,8 +2271,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "set_relay_list",
     "Publish your relay list (kind 10002, NIP-65). Configures which relays you read from and write to.",
     {
@@ -2341,8 +2333,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "set_blossom_servers",
     "Publish your Blossom media server list (kind 10063). Configures which servers to use for media uploads.",
     {
@@ -2388,8 +2379,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "upload_media",
     "Upload media to a Blossom server. Creates a signed authorization event (kind 24242) and uploads the file. Returns the URL of the uploaded media.",
     {
@@ -2488,8 +2478,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "create_discount_code",
     "Create a discount code for your shop. Codes are percentage-based and can have optional expiration dates.",
     {
@@ -2557,8 +2546,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "delete_discount_code",
     "Delete one of your discount codes.",
     {
@@ -2607,8 +2595,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "list_discount_codes",
     "List your shop's discount codes.",
     {},
@@ -2651,8 +2638,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "get_cashu_balance",
     "Check your Cashu wallet balance by querying stored proof events.",
     {
@@ -2714,8 +2700,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "receive_cashu_tokens",
     "Receive Cashu tokens and store them as a proof event (kind 7375). Publishes the encrypted proof event to your Nostr relays.",
     {
@@ -2782,8 +2767,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "set_cashu_mints",
     "Configure your Cashu wallet mints by publishing a wallet configuration event (kind 17375).",
     {
@@ -2843,8 +2827,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "send_cashu_payment",
     "Send a Cashu payment by melting tokens to pay a Lightning invoice. Uses proofs from your stored Cashu wallet.",
     {
@@ -2964,8 +2947,7 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
     }
   );
 
-  registerTool(
-    server,
+  reg(
     "manage_custom_domain",
     "Verify and register a custom domain for your Milk Market storefront. Checks that the domain's CNAME or A record points to milk.market, then records the mapping in the database.",
     {

--- a/pages/api/mcp/index.ts
+++ b/pages/api/mcp/index.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { randomUUID } from "crypto";
 import { z } from "zod/v4";
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createMcpServer } from "@/mcp/server";
 import {
@@ -12,7 +14,7 @@ import {
 import { recordRequest } from "@/utils/mcp/metrics";
 import { registerWriteTools } from "@/mcp/tools/write-tools";
 import { applyRateLimit } from "@/utils/rate-limit";
-import { wrapWithAudit } from "@/mcp/audit-log";
+import { wrapWithAudit, type ToolCb } from "@/mcp/audit-log";
 
 // MCP protocol entry — high per-IP cap for legitimate session traffic, with
 // a tighter per-key cap so a single compromised credential cannot exhaust
@@ -47,13 +49,19 @@ function registerPurchaseTools(
 ) {
   const baseUrl = `http://localhost:${process.env.PORT || 5000}`;
   const auditContext = { apiKeyId: apiKey.id, pubkey: apiKey.pubkey };
-  const reg = (name: string, description: string, schema: any, cb: any) =>
-    server.tool(
+  function reg<Args extends ZodRawShapeCompat>(
+    name: string,
+    description: string,
+    schema: Args,
+    cb: ToolCallback<Args>
+  ) {
+    return server.tool(
       name,
       description,
       schema,
-      wrapWithAudit(name, cb, auditContext) as any
+      wrapWithAudit(name, cb as ToolCb, auditContext) as ToolCallback<Args>
     );
+  }
 
   function permissionError() {
     return {

--- a/pages/api/mcp/index.ts
+++ b/pages/api/mcp/index.ts
@@ -12,6 +12,7 @@ import {
 import { recordRequest } from "@/utils/mcp/metrics";
 import { registerWriteTools } from "@/mcp/tools/write-tools";
 import { applyRateLimit } from "@/utils/rate-limit";
+import { wrapWithAudit } from "@/mcp/audit-log";
 
 // MCP protocol entry — high per-IP cap for legitimate session traffic, with
 // a tighter per-key cap so a single compromised credential cannot exhaust
@@ -45,6 +46,14 @@ function registerPurchaseTools(
   token: string
 ) {
   const baseUrl = `http://localhost:${process.env.PORT || 5000}`;
+  const auditContext = { apiKeyId: apiKey.id, pubkey: apiKey.pubkey };
+  const reg = (name: string, description: string, schema: any, cb: any) =>
+    server.tool(
+      name,
+      description,
+      schema,
+      wrapWithAudit(name, cb, auditContext) as any
+    );
 
   function permissionError() {
     return {
@@ -61,7 +70,7 @@ function registerPurchaseTools(
     };
   }
 
-  server.tool(
+  reg(
     "create_order",
     "Place an order for a product. Supports Bitcoin payment methods: lightning (Bitcoin Lightning invoice) or cashu (ecash tokens). Supports selecting product specifications (size, volume, weight, bulk bundle) and providing a shipping address. Requires read_write API key permission.",
     {
@@ -195,7 +204,7 @@ function registerPurchaseTools(
     }
   );
 
-  server.tool(
+  reg(
     "get_order_status",
     "Check the status of an existing order. Requires read_write API key permission.",
     {
@@ -248,7 +257,7 @@ function registerPurchaseTools(
     }
   );
 
-  server.tool(
+  reg(
     "list_orders",
     "List your orders. Requires read_write API key permission.",
     {
@@ -310,7 +319,7 @@ function registerPurchaseTools(
     }
   );
 
-  server.tool(
+  reg(
     "verify_payment",
     "Verify the payment status of a Lightning invoice for an order. Use after paying a Lightning invoice to confirm the order. Requires read_write API key permission.",
     {
@@ -366,7 +375,7 @@ function registerPurchaseTools(
     }
   );
 
-  server.tool(
+  reg(
     "get_payment_methods",
     "Get available payment methods for a specific seller. Shows which Bitcoin payment options (lightning, cashu) the seller accepts, along with any payment method discounts.",
     {
@@ -470,7 +479,7 @@ function registerPurchaseTools(
       }
     }
   );
-  server.tool(
+  reg(
     "get_notifications",
     "Check for new activity: unread message count, recent orders as buyer, and recent orders as seller. Use this to detect new inquiries, order updates, and address changes that need attention.",
     {
@@ -567,7 +576,7 @@ function registerPurchaseTools(
     }
   );
 
-  server.tool(
+  reg(
     "list_seller_orders",
     "List orders where you are the seller. Shows incoming purchases from buyers with payment status, order status, quantities, and shipping addresses.",
     {
@@ -728,7 +737,10 @@ export default async function handler(
         },
       });
 
-      const server = createMcpServer();
+      const server = createMcpServer({
+        apiKeyId: apiKey.id,
+        pubkey: apiKey.pubkey,
+      });
       registerPurchaseTools(server, apiKey, token);
       if (apiKey.permissions === "full_access") {
         registerWriteTools(server, apiKey);


### PR DESCRIPTION
## Problem                                                           
                                                                       
  The MCP server had no logging. When an agent called any tool there   
  was no                                                               
  record of what was called, with what arguments, by whom, or whether
  it                                                                 
  succeeded. This made the server impossible to monitor, debug, or     
  audit.                                                          
                                                                       
  ## What this PR does
                      
  Adds a wrapWithAudit wrapper that fires on every tool call
  automatically.                                                       
  Every invocation now logs: tool name, API key ID, caller pubkey,
  input                                                                
  params (with sensitive fields redacted), duration, error status, and 
  timestamp.                                                          
                                                                       
  Sensitive fields like nsec, cashuToken, and password are replaced
  with                                                                 
  [REDACTED] so private keys never appear in logs.
                                                                       
  ## Files changed
                  
  - mcp/audit-log.ts — new core logging module
  - mcp/tools/register-tool.ts — wraps every tool callback with audit  
  logging                                                            
  - mcp/tools/read-tools.ts — threads API key context through 7 read   
  tools                                                             
  - mcp/tools/write-tools.ts — threads API key context through 25 write
   tools                                                               
  - pages/api/mcp/index.ts — threads API key context through 7 purchase
   tools                                                               
  - mcp/server.ts — passes context down to registerReadTools           
  - mcp/__tests__/audit-log.test.ts — 16 new tests          
                                                                       
  ## Testing
                                                                       
  - 16 new audit-log tests all pass
  - 55 MCP-related tests all pass                                      
  - Full suite: zero new failures introduced
  - ESLint and Prettier checks pass         
  - issues : #455
