### PR TITLE
Fix dropdown country positioning and add search bar

### DIFF
--- a/components/home/marketplace.tsx
+++ b/components/home/marketplace.tsx
@@ -92,6 +92,7 @@ function MarketplacePage({
   const [selectedCategories, setSelectedCategories] = useState(
     new Set<string>([])
   );
+  const [categorySearch, setCategorySearch] = useState("");
   const [selectedLocation, setSelectedLocation] = useState("");
   const [selectedSearch, setSelectedSearch] = useState("");
   const debouncedSearch = useDebounce(selectedSearch, 300);
@@ -532,9 +533,27 @@ function MarketplacePage({
                   }
                 }}
                 selectionMode="multiple"
+                listboxProps={{
+                  topContent: (
+                    <Input
+                      className="mb-1 px-1 py-1"
+                      value={categorySearch}
+                      onValueChange={setCategorySearch}
+                      placeholder="Search category..."
+                      type="text"
+                      startContent={
+                        <MagnifyingGlassIcon className="text-default-400 h-4 w-4" />
+                      }
+                      onKeyDown={(e) => e.stopPropagation()}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  ),
+                }}
               >
                 <SelectSection className="text-light-text dark:text-dark-text">
-                  {CATEGORIES.map((category) => (
+                  {CATEGORIES.filter((c) =>
+                    c.toLowerCase().includes(categorySearch.toLowerCase())
+                  ).map((category) => (
                     <SelectItem key={category}>{category}</SelectItem>
                   ))}
                 </SelectSection>

--- a/components/home/marketplace.tsx
+++ b/components/home/marketplace.tsx
@@ -536,13 +536,17 @@ function MarketplacePage({
                 listboxProps={{
                   topContent: (
                     <Input
+                      aria-label="Search categories"
                       className="mb-1 px-1 py-1"
                       value={categorySearch}
                       onValueChange={setCategorySearch}
                       placeholder="Search category..."
                       type="text"
                       startContent={
-                        <MagnifyingGlassIcon className="text-default-400 h-4 w-4" />
+                        <MagnifyingGlassIcon
+                          aria-hidden="true"
+                          className="text-default-400 h-4 w-4"
+                        />
                       }
                       onKeyDown={(e) => e.stopPropagation()}
                       onClick={(e) => e.stopPropagation()}

--- a/components/utility-components/dropdowns/country-dropdown.tsx
+++ b/components/utility-components/dropdowns/country-dropdown.tsx
@@ -5,7 +5,7 @@ import locations from "../../../public/locationSelection.json";
 const CountryDropdown = ({ _value, ...props }: { [x: string]: any }) => {
   const countryOptions = useMemo(() => {
     const headingClasses =
-      "flex w-full sticky top-1 z-20 py-1.5 px-2 dark:bg-dark-bg bg-light-bg shadow-small rounded-small";
+      "flex w-full py-1.5 px-2 dark:bg-dark-bg bg-light-bg shadow-small rounded-small";
 
     const countryOptions = (
       <SelectSection

--- a/components/utility-components/dropdowns/location-dropdown.tsx
+++ b/components/utility-components/dropdowns/location-dropdown.tsx
@@ -36,12 +36,14 @@ const LocationDropdown = ({ value, ...props }: { [x: string]: any }) => {
     const headingClasses =
       "flex w-full py-1.5 px-2 dark:bg-dark-bg bg-light-bg shadow-small rounded-small";
 
+    const q = searchValue.trim().toLowerCase();
+
     const filteredCountries = locations.countries.filter((country) =>
-      country.country.toLowerCase().includes(searchValue.toLowerCase())
+      country.country.toLowerCase().includes(q)
     );
 
     const filteredStates = locations.states.filter((state) =>
-      state.state.toLowerCase().includes(searchValue.toLowerCase())
+      state.state.toLowerCase().includes(q)
     );
 
     const regionalOptionsList = [
@@ -52,7 +54,7 @@ const LocationDropdown = ({ value, ...props }: { [x: string]: any }) => {
     ];
 
     const filteredRegional = regionalOptionsList.filter((regional) =>
-      regional.toLowerCase().includes(searchValue.toLowerCase())
+      regional.toLowerCase().includes(q)
     );
 
     const mappedCountryOptions =
@@ -143,17 +145,21 @@ const LocationDropdown = ({ value, ...props }: { [x: string]: any }) => {
     <Select
       startContent={locationAvatar(value)}
       {...props}
-      className={`text-light-text dark:text-dark-text ${props.className || "mt-2"}`}
+      className={`text-light-text dark:text-dark-text mt-2 ${props.className ?? ""}`}
       listboxProps={{
         topContent: (
           <Input
+            aria-label="Search location"
             className="mb-1 px-1 py-1"
             value={searchValue}
             onValueChange={setSearchValue}
             placeholder="Search location..."
             type="text"
             startContent={
-              <MagnifyingGlassIcon className="text-default-400 h-4 w-4" />
+              <MagnifyingGlassIcon
+                aria-hidden="true"
+                className="text-default-400 h-4 w-4"
+              />
             }
             onKeyDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}

--- a/components/utility-components/dropdowns/location-dropdown.tsx
+++ b/components/utility-components/dropdowns/location-dropdown.tsx
@@ -25,7 +25,7 @@ export const locationAvatar = (location: string) => {
 const LocationDropdown = ({ value, ...props }: { [x: string]: any }) => {
   const locationOptions = useMemo(() => {
     const headingClasses =
-      "flex w-full sticky top-1 z-20 py-1.5 px-2 dark:bg-dark-bg bg-light-bg shadow-small rounded-small";
+      "flex w-full py-1.5 px-2 dark:bg-dark-bg bg-light-bg shadow-small rounded-small";
 
     const countryOptions = (
       <SelectSection

--- a/components/utility-components/dropdowns/location-dropdown.tsx
+++ b/components/utility-components/dropdowns/location-dropdown.tsx
@@ -1,5 +1,12 @@
-import { useMemo } from "react";
-import { Select, SelectItem, SelectSection, Avatar } from "@heroui/react";
+import { useState, useMemo } from "react";
+import {
+  Select,
+  SelectItem,
+  SelectSection,
+  Avatar,
+  Input,
+} from "@heroui/react";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import locations from "../../../public/locationSelection.json";
 
 export const locationAvatar = (location: string) => {
@@ -23,92 +30,136 @@ export const locationAvatar = (location: string) => {
 };
 
 const LocationDropdown = ({ value, ...props }: { [x: string]: any }) => {
+  const [searchValue, setSearchValue] = useState("");
+
   const locationOptions = useMemo(() => {
     const headingClasses =
       "flex w-full py-1.5 px-2 dark:bg-dark-bg bg-light-bg shadow-small rounded-small";
 
-    const countryOptions = (
-      <SelectSection
-        key={"countryOptions"}
-        title="Countries"
-        classNames={{
-          heading: headingClasses,
-        }}
-        className="text-light-text dark:text-dark-text"
-      >
-        {locations.countries.map((country) => {
-          return (
-            <SelectItem
-              key={country.country}
-              classNames={{
-                wrapper: "dark:bg-dark-bg bg-dark-bg",
-              }}
-              // startContent={
-              //   <Avatar
-              //     alt={country.country}
-              //     className="h-6 w-6"
-              //     src={`https://flagcdn.com/16x12/${country.iso3166}.png`}
-              //   />
-              // }
-            >
-              {country.country}
-            </SelectItem>
-          );
-        })}
-      </SelectSection>
+    const filteredCountries = locations.countries.filter((country) =>
+      country.country.toLowerCase().includes(searchValue.toLowerCase())
     );
 
-    const stateOptions = (
-      <SelectSection
-        key={"stateOptions"}
-        title="U.S. States"
-        classNames={{
-          heading: headingClasses,
-        }}
-        className="text-light-text dark:text-dark-text"
-      >
-        {locations.states.map((state) => {
-          return (
-            <SelectItem
-              key={state.state}
-              // startContent={
-              //   <Avatar
-              //     alt={state.state}
-              //     className="h-6 w-6"
-              //     src={`https://flagcdn.com/16x12/${state.iso3166}.png`}
-              //   />
-              // }
-            >
-              {state.state}
-            </SelectItem>
-          );
-        })}
-      </SelectSection>
+    const filteredStates = locations.states.filter((state) =>
+      state.state.toLowerCase().includes(searchValue.toLowerCase())
     );
 
-    const regionalOptions = (
-      <SelectSection
-        key={"regionalOptions"}
-        title="Regional"
-        classNames={{
-          heading: headingClasses,
-        }}
-        className="text-light-text dark:text-dark-text"
-      >
-        <SelectItem key={"Worldwide"}>Worldwide</SelectItem>
-        <SelectItem key={"US & Canada"}>US &amp; Canada</SelectItem>
-        <SelectItem key={"Europe"}>Europe</SelectItem>
-        <SelectItem key={"Online"}>Online</SelectItem>
-      </SelectSection>
+    const regionalOptionsList = [
+      "Worldwide",
+      "US & Canada",
+      "Europe",
+      "Online",
+    ];
+
+    const filteredRegional = regionalOptionsList.filter((regional) =>
+      regional.toLowerCase().includes(searchValue.toLowerCase())
     );
-    return [regionalOptions, countryOptions, stateOptions];
-  }, []);
+
+    const mappedCountryOptions =
+      filteredCountries.length > 0 ? (
+        <SelectSection
+          key={"countryOptions"}
+          title="Countries"
+          classNames={{
+            heading: headingClasses,
+          }}
+          className="text-light-text dark:text-dark-text"
+        >
+          {filteredCountries.map((country) => {
+            return (
+              <SelectItem
+                key={country.country}
+                classNames={{
+                  wrapper: "dark:bg-dark-bg bg-dark-bg",
+                }}
+                // startContent={
+                //   <Avatar
+                //     alt={country.country}
+                //     className="h-6 w-6"
+                //     src={`https://flagcdn.com/16x12/${country.iso3166}.png`}
+                //   />
+                // }
+              >
+                {country.country}
+              </SelectItem>
+            );
+          })}
+        </SelectSection>
+      ) : null;
+
+    const mappedStateOptions =
+      filteredStates.length > 0 ? (
+        <SelectSection
+          key={"stateOptions"}
+          title="U.S. States"
+          classNames={{
+            heading: headingClasses,
+          }}
+          className="text-light-text dark:text-dark-text"
+        >
+          {filteredStates.map((state) => {
+            return (
+              <SelectItem
+                key={state.state}
+                // startContent={
+                //   <Avatar
+                //     alt={state.state}
+                //     className="h-6 w-6"
+                //     src={`https://flagcdn.com/16x12/${state.iso3166}.png`}
+                //   />
+                // }
+              >
+                {state.state}
+              </SelectItem>
+            );
+          })}
+        </SelectSection>
+      ) : null;
+
+    const mappedRegionalOptions =
+      filteredRegional.length > 0 ? (
+        <SelectSection
+          key={"regionalOptions"}
+          title="Regional"
+          classNames={{
+            heading: headingClasses,
+          }}
+          className="text-light-text dark:text-dark-text"
+        >
+          {filteredRegional.map((regional) => (
+            <SelectItem key={regional}>{regional}</SelectItem>
+          ))}
+        </SelectSection>
+      ) : null;
+
+    return [
+      mappedRegionalOptions,
+      mappedCountryOptions,
+      mappedStateOptions,
+    ].filter(Boolean) as JSX.Element[];
+  }, [searchValue]);
 
   return (
     <Select
       startContent={locationAvatar(value)}
       {...props}
-      className="text-light-text dark:text-dark-text mt-2"
+      className={`text-light-text dark:text-dark-text ${props.className || "mt-2"}`}
+      listboxProps={{
+        topContent: (
+          <Input
+            className="mb-1 px-1 py-1"
+            value={searchValue}
+            onValueChange={setSearchValue}
+            placeholder="Search location..."
+            type="text"
+            startContent={
+              <MagnifyingGlassIcon className="text-default-400 h-4 w-4" />
+            }
+            onKeyDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ),
+      }}
     >
       {locationOptions}
     </Select>


### PR DESCRIPTION
### Description

- Fix country dropdown positioning: removed the sticky top class from the headings so countries no longer appear in between entries and maintain correct ordering.
- Added a search bar inside the dropdown/listbox to filter countries, states, and regional options so users can quickly find locations.
- Kept behavior simple: avoided making the countries list permanently sticky at the top because the `region` component doesn't start at the top and making it sticky would increase complexity.

### Screenshots 
Before:

[DropdownError.webm](https://github.com/user-attachments/assets/c1e521e5-5a4a-49c9-b8ad-8e0bed52ff96)

After:

[FixDropdown.webm](https://github.com/user-attachments/assets/98263f56-c1ca-4b8a-acff-d737ec532168)


### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
