### PR TITLE
add relay allowlist to McpRelayManager

### DIFF
--- a/utils/mcp/__tests__/relay-allowlist.test.ts
+++ b/utils/mcp/__tests__/relay-allowlist.test.ts
@@ -1,0 +1,127 @@
+jest.mock("nostr-tools", () => ({
+  SimplePool: jest.fn().mockImplementation(() => ({
+    publish: jest.fn().mockReturnValue([Promise.resolve()]),
+    close: jest.fn(),
+  })),
+  finalizeEvent: jest.fn(),
+  getPublicKey: jest.fn(),
+  nip19: { decode: jest.fn() },
+  nip44: {
+    getConversationKey: jest.fn(),
+    encrypt: jest.fn(),
+    decrypt: jest.fn(),
+  },
+}));
+
+jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
+  getDefaultRelays: jest.fn(() => [
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+    "wss://purplepag.es",
+    "wss://relay.primal.net",
+    "wss://relay.nostr.band",
+  ]),
+  withBlastr: jest.fn((relays: string[]) => [
+    ...relays,
+    "wss://sendit.nosflare.com",
+  ]),
+}));
+
+jest.mock("@/utils/db/db-service", () => ({ cacheEvent: jest.fn() }));
+
+import { McpRelayManager, MCP_RELAY_ALLOWLIST } from "../nostr-signing";
+
+describe("MCP_RELAY_ALLOWLIST", () => {
+  it("contains the 6 known Shopstr relays", () => {
+    expect(MCP_RELAY_ALLOWLIST.has("wss://relay.damus.io")).toBe(true);
+    expect(MCP_RELAY_ALLOWLIST.has("wss://nos.lol")).toBe(true);
+    expect(MCP_RELAY_ALLOWLIST.has("wss://purplepag.es")).toBe(true);
+    expect(MCP_RELAY_ALLOWLIST.has("wss://relay.primal.net")).toBe(true);
+    expect(MCP_RELAY_ALLOWLIST.has("wss://relay.nostr.band")).toBe(true);
+    expect(MCP_RELAY_ALLOWLIST.has("wss://sendit.nosflare.com")).toBe(true);
+  });
+
+  it("has exactly 6 entries", () => {
+    expect(MCP_RELAY_ALLOWLIST.size).toBe(6);
+  });
+});
+
+describe("McpRelayManager — allowlist enforcement", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("accepts all known allowlisted relays", () => {
+    const mgr = new McpRelayManager(["wss://relay.damus.io", "wss://nos.lol"]);
+    expect(mgr.getRelayUrls()).toEqual([
+      "wss://relay.damus.io",
+      "wss://nos.lol",
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks an unknown relay and logs a warning", () => {
+    expect(
+      () => new McpRelayManager(["wss://attacker-controlled.example.com"])
+    ).toThrow("MCP relay allowlist produced no valid relays");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "MCP relay blocked (not in allowlist): wss://attacker-controlled.example.com"
+    );
+  });
+
+  it("filters out unknown relays while keeping allowed ones", () => {
+    const mgr = new McpRelayManager([
+      "wss://relay.damus.io",
+      "wss://attacker-controlled.example.com",
+      "wss://nos.lol",
+    ]);
+    expect(mgr.getRelayUrls()).toEqual([
+      "wss://relay.damus.io",
+      "wss://nos.lol",
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "MCP relay blocked (not in allowlist): wss://attacker-controlled.example.com"
+    );
+  });
+
+  it("throws when all supplied relays are blocked", () => {
+    expect(
+      () =>
+        new McpRelayManager([
+          "wss://evil.example.com",
+          "wss://another-bad.relay.io",
+        ])
+    ).toThrow("MCP relay allowlist produced no valid relays");
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses default relays when none are supplied and all pass the allowlist", () => {
+    const mgr = new McpRelayManager();
+    const urls = mgr.getRelayUrls();
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      expect(MCP_RELAY_ALLOWLIST.has(url)).toBe(true);
+    }
+  });
+
+  it("warns once per blocked relay", () => {
+    expect(
+      () => new McpRelayManager(["wss://bad1.com", "wss://bad2.com"])
+    ).toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "MCP relay blocked (not in allowlist): wss://bad1.com"
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "MCP relay blocked (not in allowlist): wss://bad2.com"
+    );
+  });
+});

--- a/utils/mcp/nostr-signing.ts
+++ b/utils/mcp/nostr-signing.ts
@@ -22,6 +22,27 @@ import {
 
 const ALGORITHM = "aes-256-gcm";
 
+export const MCP_RELAY_ALLOWLIST = new Set([
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://purplepag.es",
+  "wss://relay.primal.net",
+  "wss://relay.nostr.band",
+  "wss://sendit.nosflare.com",
+]);
+
+function filterAllowedRelays(urls: string[]): string[] {
+  const allowed: string[] = [];
+  for (const url of urls) {
+    if (MCP_RELAY_ALLOWLIST.has(url)) {
+      allowed.push(url);
+    } else {
+      console.warn(`MCP relay blocked (not in allowlist): ${url}`);
+    }
+  }
+  return allowed;
+}
+
 function getEncryptionKey(): Uint8Array {
   const envKey = process.env.MCP_ENCRYPTION_KEY;
   if (!envKey) {
@@ -112,7 +133,11 @@ export class McpRelayManager {
 
   constructor(relayUrls?: string[]) {
     this.pool = new SimplePool();
-    this.relayUrls = relayUrls || withBlastr(getDefaultRelays());
+    const raw = relayUrls || withBlastr(getDefaultRelays());
+    this.relayUrls = filterAllowedRelays(raw);
+    if (this.relayUrls.length === 0) {
+      throw new Error("MCP relay allowlist produced no valid relays");
+    }
   }
 
   getRelayUrls(): string[] {


### PR DESCRIPTION
## What does this PR do?

Fixes a security vulnerability where `McpRelayManager` accepted any relay URL
without validation, allowing signed Nostr events (product listings, profile
updates, orders, messages) to be silently published to unauthorized relays.

Now `McpRelayManager` only publishes to a hardcoded allowlist of 6 known
Shopstr relays. Any URL outside the list is dropped with a warning. If no
valid relays remain after filtering, the constructor throws so the failure
is explicit rather than silent.

## Files Changed

**Modified**
- `utils/mcp/nostr-signing.ts` — added `MCP_RELAY_ALLOWLIST`, `filterAllowedRelays()`, and allowlist enforcement in `McpRelayManager` constructor

**Added**
- `utils/mcp/__tests__/relay-allowlist.test.ts` — test suite for allowlist enforcement

Issue : #471 