### PR TITLE
fix: consume storefront order summary after successful load

### DIFF
--- a/components/storefront/__tests__/storefront-order-confirmation.test.tsx
+++ b/components/storefront/__tests__/storefront-order-confirmation.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import StorefrontOrderConfirmation from "../storefront-order-confirmation";
+import { ProductContext } from "@/utils/context/context";
+import { SignerContext } from "@/components/utility-components/nostr-context-provider";
+
+const mockPush = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(() => ({
+    push: mockPush,
+  })),
+}));
+
+describe("StorefrontOrderConfirmation", () => {
+  const productContextValue = {
+    productEvents: [],
+    isLoading: false,
+    addNewlyCreatedProductEvent: jest.fn(),
+    removeDeletedProductEvent: jest.fn(),
+  };
+
+  const signerContextValue = {
+    signer: undefined,
+    isLoggedIn: false,
+    isAuthStateResolved: true,
+    pubkey: "",
+    npub: "",
+    newSigner: {},
+  };
+
+  const baseProps = {
+    colors: {
+      primary: "#111111",
+      secondary: "#222222",
+      accent: "#333333",
+      background: "#ffffff",
+      text: "#000000",
+    },
+    shopName: "Test Shop",
+    shopSlug: "test-shop",
+    shopPubkey: "seller-pubkey",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  test("consumes orderSummary once and does not redirect under StrictMode", async () => {
+    sessionStorage.setItem(
+      "orderSummary",
+      JSON.stringify({
+        productTitle: "Coffee Beans",
+        productImage: "https://example.com/coffee.png",
+        amount: "2500",
+        currency: "sats",
+        paymentMethod: "lightning",
+        orderId: "order_12345678",
+      })
+    );
+
+    render(
+      <React.StrictMode>
+        <SignerContext.Provider value={signerContextValue as any}>
+          <ProductContext.Provider value={productContextValue}>
+            <StorefrontOrderConfirmation {...baseProps} />
+          </ProductContext.Provider>
+        </SignerContext.Provider>
+      </React.StrictMode>
+    );
+
+    expect(await screen.findByText("Order Confirmed!")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem("orderSummary")).toBeNull();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  test("redirects back to the shop when orderSummary is invalid", async () => {
+    sessionStorage.setItem("orderSummary", "{invalid-json");
+
+    render(
+      <SignerContext.Provider value={signerContextValue as any}>
+        <ProductContext.Provider value={productContextValue}>
+          <StorefrontOrderConfirmation {...baseProps} />
+        </ProductContext.Provider>
+      </SignerContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/shop/test-shop");
+    });
+  });
+});

--- a/components/storefront/storefront-order-confirmation.tsx
+++ b/components/storefront/storefront-order-confirmation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext, useMemo } from "react";
+import { useEffect, useState, useContext, useMemo, useRef } from "react";
 import { useRouter } from "next/router";
 import {
   CheckCircleIcon,
@@ -67,12 +67,16 @@ export default function StorefrontOrderConfirmation({
   const { isLoggedIn } = useContext(SignerContext);
   const productContext = useContext(ProductContext);
   const [orderData, setOrderData] = useState<OrderSummaryData | null>(null);
+  const hasConsumedOrderRef = useRef(false);
 
   useEffect(() => {
+    if (hasConsumedOrderRef.current) return;
     const stored = sessionStorage.getItem("orderSummary");
     if (stored) {
+      hasConsumedOrderRef.current = true;
       try {
         setOrderData(JSON.parse(stored));
+        sessionStorage.removeItem("orderSummary");
       } catch {
         router.push(`/shop/${shopSlug}`);
       }


### PR DESCRIPTION
## Summary

Consume the storefront `orderSummary` session payload after it is successfully loaded, and guard the effect so it only consumes once.

## Problem

The storefront order confirmation page was reading `sessionStorage["orderSummary"]` but not removing it after a successful parse.

That left two issues:
- stale checkout data could persist across later storefront visits or reloads
- a naive cleanup could cause an incorrect redirect under React strict mode if the effect runs twice

The generic `/order-summary` flow already uses a guarded consume-once pattern, but the storefront confirmation page did not.

## Solution

- add a `useRef` guard so the effect only consumes the stored payload once
- remove `sessionStorage["orderSummary"]` after a successful parse
- keep the existing fallback redirect when the stored payload is missing or invalid
- add a regression test for strict-mode-safe consumption and invalid stored data

## Testing

- `npm test -- storefront-order-confirmation.test.tsx --runInBand`
