### PR TITLE
fix: add missing app routes to RESERVED_SLUGS

### DIFF
--- a/pages/api/storefront/register-slug.ts
+++ b/pages/api/storefront/register-slug.ts
@@ -35,6 +35,13 @@ const RESERVED_SLUGS = [
   "blog",
   "docs",
   "status",
+  "my-listings",
+  "about",
+  "contact",
+  "faq",
+  "privacy",
+  "terms",
+  "order-summary",
 ];
 
 export default async function handler(


### PR DESCRIPTION
### Description

- The `RESERVED_SLUGS` list in `pages/api/storefront/register-slug.ts` was missing 7 top-level Next.js page routes, meaning users could register them as their shop slug (e.g. `/shop/my-listings` would resolve but could conflict with `/my-listings` if routing ever changes).
- Added the following slugs to `RESERVED_SLUGS`: `my-listings`, `about`, `contact`, `faq`, `privacy`, `terms`, `order-summary`.
- No logic changes — the existing `RESERVED_SLUGS.includes(sanitized)` check already handles the blocking; only the array needed updating.

### Resolved or fixed issue

none

### Screenshots (if applicable)

N/A — no UI changes.

### Affirmation

- [ ] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines