### PR TITLE
 fix: pin MCP sessions to originating API key and add TTL eviction

### DIFF
--- a/pages/api/mcp/index.ts
+++ b/pages/api/mcp/index.ts
@@ -28,10 +28,37 @@ async function ensureTables() {
   }
 }
 
-const sessions = new Map<
-  string,
-  { transport: StreamableHTTPServerTransport; apiKey: ApiKeyRecord }
->();
+const SESSION_TTL_MS = 30 * 60 * 1000;
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+interface McpSession {
+  transport: StreamableHTTPServerTransport;
+  apiKey: ApiKeyRecord;
+  createdAt: number;
+  lastActivityAt: number;
+}
+
+const sessions = new Map<string, McpSession>();
+
+function rejectSessionMismatch(res: NextApiResponse) {
+  return res.status(403).json({
+    jsonrpc: "2.0",
+    error: { code: -32000, message: "Session belongs to a different API key" },
+    id: null,
+  });
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [sid, session] of sessions) {
+    if (now - session.lastActivityAt > SESSION_TTL_MS) {
+      try {
+        session.transport.close?.();
+      } catch {}
+      sessions.delete(sid);
+    }
+  }
+}, SWEEP_INTERVAL_MS);
 
 export const config = {
   api: {
@@ -712,6 +739,8 @@ export default async function handler(
 
     if (sessionId && sessions.has(sessionId)) {
       const session = sessions.get(sessionId)!;
+      if (apiKey.id !== session.apiKey.id) return rejectSessionMismatch(res);
+      session.lastActivityAt = Date.now();
       await session.transport.handleRequest(req as any, res as any, req.body);
       return;
     }
@@ -724,7 +753,13 @@ export default async function handler(
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (sid) => {
-          sessions.set(sid, { transport, apiKey });
+          const now = Date.now();
+          sessions.set(sid, {
+            transport,
+            apiKey,
+            createdAt: now,
+            lastActivityAt: now,
+          });
         },
       });
 
@@ -753,6 +788,8 @@ export default async function handler(
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
     if (sessionId && sessions.has(sessionId)) {
       const session = sessions.get(sessionId)!;
+      if (apiKey.id !== session.apiKey.id) return rejectSessionMismatch(res);
+      session.lastActivityAt = Date.now();
       await session.transport.handleRequest(req as any, res as any);
       return;
     }
@@ -770,6 +807,7 @@ export default async function handler(
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
     if (sessionId && sessions.has(sessionId)) {
       const session = sessions.get(sessionId)!;
+      if (apiKey.id !== session.apiKey.id) return rejectSessionMismatch(res);
       await session.transport.handleRequest(req as any, res as any);
       sessions.delete(sessionId);
       return;

--- a/pages/api/mcp/index.ts
+++ b/pages/api/mcp/index.ts
@@ -48,6 +48,17 @@ function rejectSessionMismatch(res: NextApiResponse) {
   });
 }
 
+function evictIfExpired(sessionId: string, session: McpSession): boolean {
+  if (Date.now() - session.lastActivityAt > SESSION_TTL_MS) {
+    try {
+      session.transport.close?.();
+    } catch {}
+    sessions.delete(sessionId);
+    return true;
+  }
+  return false;
+}
+
 setInterval(() => {
   const now = Date.now();
   for (const [sid, session] of sessions) {
@@ -739,6 +750,13 @@ export default async function handler(
 
     if (sessionId && sessions.has(sessionId)) {
       const session = sessions.get(sessionId)!;
+      if (evictIfExpired(sessionId, session)) {
+        return res.status(404).json({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Session expired" },
+          id: null,
+        });
+      }
       if (apiKey.id !== session.apiKey.id) return rejectSessionMismatch(res);
       session.lastActivityAt = Date.now();
       await session.transport.handleRequest(req as any, res as any, req.body);
@@ -788,6 +806,13 @@ export default async function handler(
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
     if (sessionId && sessions.has(sessionId)) {
       const session = sessions.get(sessionId)!;
+      if (evictIfExpired(sessionId, session)) {
+        return res.status(404).json({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Session expired" },
+          id: null,
+        });
+      }
       if (apiKey.id !== session.apiKey.id) return rejectSessionMismatch(res);
       session.lastActivityAt = Date.now();
       await session.transport.handleRequest(req as any, res as any);
@@ -807,6 +832,13 @@ export default async function handler(
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
     if (sessionId && sessions.has(sessionId)) {
       const session = sessions.get(sessionId)!;
+      if (evictIfExpired(sessionId, session)) {
+        return res.status(404).json({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Session expired" },
+          id: null,
+        });
+      }
       if (apiKey.id !== session.apiKey.id) return rejectSessionMismatch(res);
       await session.transport.handleRequest(req as any, res as any);
       sessions.delete(sessionId);


### PR DESCRIPTION
## Description

- **Session hijack prevention:** After `initialize`, subsequent POST/GET/DELETE requests that resume a session via `Mcp-Session-Id` now verify that the Bearer token resolves to the same `apiKey.id` that created the session. If there is a mismatch, the request is rejected with a `403` and JSON-RPC error `"Session belongs to a different API key"`. Previously, any valid API key could attach to any existing session, allowing a leaked session ID to be hijacked by a different credential — the tool closures would still operate under the original user's identity and permissions.
- **Session TTL with automatic eviction:** Sessions now track `createdAt` and `lastActivityAt` timestamps. A background sweep runs every 5 minutes and removes sessions that have been inactive for more than 30 minutes, calling `transport.close()` before deletion. This prevents unbounded memory growth from clients that crash or disconnect without sending DELETE.
- **Activity tracking:** Each successful session resume (POST and GET) updates `lastActivityAt`, so active sessions are kept alive while idle ones are cleaned up.

All changes are in `pages/api/mcp/index.ts`.

## Resolved or fixed issue

none

## Screenshots (if applicable)

N/A — backend-only security fix, no UI changes.

## Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines