### PR TITLE
Fix: x-forwarded-for header now takes the rightmost ip

### DIFF
--- a/__tests__/pages/api/mcp/onboard.test.ts
+++ b/__tests__/pages/api/mcp/onboard.test.ts
@@ -249,6 +249,21 @@ describe("MCP onboard API quick-start correctness", () => {
     });
   });
 
+  it("rate limits onboarding by the rightmost forwarded IP", async () => {
+    const req = createMockRequest({
+      headers: {
+        host: "localhost:5000",
+        "x-forwarded-for": "1.2.3.4, 5.6.7.8",
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(res.statusCode).toBe(201);
+    expect(checkOnboardRateLimitMock).toHaveBeenCalledWith("5.6.7.8");
+  });
+
   it("ignores unallowlisted forwarded hosts in production", async () => {
     setNodeEnv("production");
     process.env.MCP_ALLOWED_HOSTS = "shopstr.example";

--- a/__tests__/pages/api/mcp/onboard.test.ts
+++ b/__tests__/pages/api/mcp/onboard.test.ts
@@ -104,6 +104,8 @@ function createMockResponse(): MockResponse {
 describe("MCP onboard API quick-start correctness", () => {
   const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   const originalAllowedHosts = process.env.MCP_ALLOWED_HOSTS;
+  const originalTrustProxyHeaders = process.env.TRUST_PROXY_HEADERS;
+  const originalTrustedProxyIps = process.env.TRUSTED_PROXY_IPS;
   const originalNodeEnv = process.env.NODE_ENV;
   let handler: typeof import("@/pages/api/mcp/onboard").default;
 
@@ -113,6 +115,8 @@ describe("MCP onboard API quick-start correctness", () => {
 
     delete process.env.NEXT_PUBLIC_BASE_URL;
     delete process.env.MCP_ALLOWED_HOSTS;
+    delete process.env.TRUST_PROXY_HEADERS;
+    delete process.env.TRUSTED_PROXY_IPS;
     setNodeEnv("test");
 
     checkOnboardRateLimitMock.mockReturnValue(true);
@@ -143,6 +147,18 @@ describe("MCP onboard API quick-start correctness", () => {
       delete process.env.MCP_ALLOWED_HOSTS;
     } else {
       process.env.MCP_ALLOWED_HOSTS = originalAllowedHosts;
+    }
+
+    if (originalTrustProxyHeaders === undefined) {
+      delete process.env.TRUST_PROXY_HEADERS;
+    } else {
+      process.env.TRUST_PROXY_HEADERS = originalTrustProxyHeaders;
+    }
+
+    if (originalTrustedProxyIps === undefined) {
+      delete process.env.TRUSTED_PROXY_IPS;
+    } else {
+      process.env.TRUSTED_PROXY_IPS = originalTrustedProxyIps;
     }
 
     if (originalNodeEnv === undefined) {
@@ -250,6 +266,7 @@ describe("MCP onboard API quick-start correctness", () => {
   });
 
   it("rate limits onboarding by the rightmost forwarded IP", async () => {
+    process.env.TRUST_PROXY_HEADERS = "true";
     const req = createMockRequest({
       headers: {
         host: "localhost:5000",

--- a/env.example
+++ b/env.example
@@ -11,5 +11,12 @@ MCP_ENCRYPTION_KEY=replace-with-a-long-random-secret
 # from request headers if NEXT_PUBLIC_BASE_URL is not set
 # MCP_ALLOWED_HOSTS=shopstr.example,api.shopstr.example
 
+# Optional: trust X-Forwarded-For for rate limiting only when requests always
+# pass through a reverse proxy that appends the real client IP.
+# TRUST_PROXY_HEADERS=true
+#
+# Alternative: trust forwarded headers only from these direct proxy IPs.
+# TRUSTED_PROXY_IPS=127.0.0.1,::1
+
 # For production, use your actual database URL:
 # DATABASE_URL=postgresql://user:password@host:port/database

--- a/pages/api/mcp/onboard.ts
+++ b/pages/api/mcp/onboard.ts
@@ -16,6 +16,7 @@ import {
   extractSignedEventFromRequest,
   verifyAndConsumeSignedRequestProof,
 } from "@/utils/mcp/request-proof-server";
+import { getRequestIp } from "@/utils/rate-limit";
 
 let tablesReady = false;
 const MCP_STREAMABLE_HTTP_ACCEPT = "application/json, text/event-stream";
@@ -254,10 +255,7 @@ export default async function handler(
     return res.status(405).json({ error: "Method not allowed. Use POST." });
   }
 
-  const ip =
-    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
-    req.socket.remoteAddress ||
-    "unknown";
+  const ip = getRequestIp(req);
 
   if (!checkOnboardRateLimit(ip)) {
     return res.status(429).json({

--- a/utils/__tests__/rate-limit.test.ts
+++ b/utils/__tests__/rate-limit.test.ts
@@ -51,20 +51,28 @@ describe("checkRateLimit", () => {
 });
 
 describe("getRequestIp", () => {
-  it("prefers the first entry in x-forwarded-for", () => {
+  it("uses the rightmost entry in x-forwarded-for", () => {
     const req = {
       headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" },
       socket: { remoteAddress: "9.9.9.9" },
     } as any;
-    expect(getRequestIp(req)).toBe("1.2.3.4");
+    expect(getRequestIp(req)).toBe("5.6.7.8");
   });
 
-  it("falls back to x-real-ip", () => {
+  it("uses the rightmost entry across repeated x-forwarded-for headers", () => {
+    const req = {
+      headers: { "x-forwarded-for": ["1.2.3.4", "5.6.7.8, 6.7.8.9"] },
+      socket: { remoteAddress: "9.9.9.9" },
+    } as any;
+    expect(getRequestIp(req)).toBe("6.7.8.9");
+  });
+
+  it("ignores x-real-ip and falls back to the socket remote address", () => {
     const req = {
       headers: { "x-real-ip": "4.3.2.1" },
       socket: { remoteAddress: "9.9.9.9" },
     } as any;
-    expect(getRequestIp(req)).toBe("4.3.2.1");
+    expect(getRequestIp(req)).toBe("9.9.9.9");
   });
 
   it("falls back to the socket remote address", () => {

--- a/utils/__tests__/rate-limit.test.ts
+++ b/utils/__tests__/rate-limit.test.ts
@@ -51,7 +51,38 @@ describe("checkRateLimit", () => {
 });
 
 describe("getRequestIp", () => {
-  it("uses the rightmost entry in x-forwarded-for", () => {
+  const originalTrustProxyHeaders = process.env.TRUST_PROXY_HEADERS;
+  const originalTrustedProxyIps = process.env.TRUSTED_PROXY_IPS;
+
+  beforeEach(() => {
+    delete process.env.TRUST_PROXY_HEADERS;
+    delete process.env.TRUSTED_PROXY_IPS;
+  });
+
+  afterEach(() => {
+    if (originalTrustProxyHeaders === undefined) {
+      delete process.env.TRUST_PROXY_HEADERS;
+    } else {
+      process.env.TRUST_PROXY_HEADERS = originalTrustProxyHeaders;
+    }
+
+    if (originalTrustedProxyIps === undefined) {
+      delete process.env.TRUSTED_PROXY_IPS;
+    } else {
+      process.env.TRUSTED_PROXY_IPS = originalTrustedProxyIps;
+    }
+  });
+
+  it("ignores x-forwarded-for unless proxy headers are trusted", () => {
+    const req = {
+      headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" },
+      socket: { remoteAddress: "9.9.9.9" },
+    } as any;
+    expect(getRequestIp(req)).toBe("9.9.9.9");
+  });
+
+  it("uses the rightmost entry in x-forwarded-for when proxy headers are trusted", () => {
+    process.env.TRUST_PROXY_HEADERS = "true";
     const req = {
       headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" },
       socket: { remoteAddress: "9.9.9.9" },
@@ -60,11 +91,21 @@ describe("getRequestIp", () => {
   });
 
   it("uses the rightmost entry across repeated x-forwarded-for headers", () => {
+    process.env.TRUST_PROXY_HEADERS = "true";
     const req = {
       headers: { "x-forwarded-for": ["1.2.3.4", "5.6.7.8, 6.7.8.9"] },
       socket: { remoteAddress: "9.9.9.9" },
     } as any;
     expect(getRequestIp(req)).toBe("6.7.8.9");
+  });
+
+  it("trusts x-forwarded-for when the direct peer is a trusted proxy", () => {
+    process.env.TRUSTED_PROXY_IPS = "9.9.9.9";
+    const req = {
+      headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" },
+      socket: { remoteAddress: "9.9.9.9" },
+    } as any;
+    expect(getRequestIp(req)).toBe("5.6.7.8");
   });
 
   it("ignores x-real-ip and falls back to the socket remote address", () => {
@@ -81,6 +122,23 @@ describe("getRequestIp", () => {
       socket: { remoteAddress: "9.9.9.9" },
     } as any;
     expect(getRequestIp(req)).toBe("9.9.9.9");
+  });
+
+  it("normalizes IPv6-mapped IPv4 socket addresses", () => {
+    const req = {
+      headers: {},
+      socket: { remoteAddress: "::ffff:9.9.9.9" },
+    } as any;
+    expect(getRequestIp(req)).toBe("9.9.9.9");
+  });
+
+  it("normalizes IPv6-mapped IPv4 forwarded addresses", () => {
+    process.env.TRUST_PROXY_HEADERS = "true";
+    const req = {
+      headers: { "x-forwarded-for": "1.2.3.4, ::ffff:5.6.7.8" },
+      socket: { remoteAddress: "9.9.9.9" },
+    } as any;
+    expect(getRequestIp(req)).toBe("5.6.7.8");
   });
 
   it("returns 'unknown' when nothing is available", () => {

--- a/utils/rate-limit.ts
+++ b/utils/rate-limit.ts
@@ -67,15 +67,17 @@ export function checkRateLimit(
 }
 
 export function getRequestIp(req: NextApiRequest): string {
-  const headers = req.headers ?? {};
-  const forwarded = headers["x-forwarded-for"];
-  const forwardedValue = Array.isArray(forwarded) ? forwarded[0] : forwarded;
-  const fromForwarded = forwardedValue?.split(",")[0]?.trim();
-  if (fromForwarded) return fromForwarded;
-
-  const realIp = headers["x-real-ip"];
-  const realIpValue = Array.isArray(realIp) ? realIp[0] : realIp;
-  if (realIpValue) return realIpValue.trim();
+  const forwarded = req.headers["x-forwarded-for"];
+  const forwardedValues = Array.isArray(forwarded) ? forwarded : [forwarded];
+  for (let i = forwardedValues.length - 1; i >= 0; i--) {
+    const forwardedValue = forwardedValues[i];
+    const forwardedParts = forwardedValue
+      ?.split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+    const rightmostForwarded = forwardedParts?.[forwardedParts.length - 1];
+    if (rightmostForwarded) return rightmostForwarded;
+  }
 
   return req.socket?.remoteAddress ?? "unknown";
 }

--- a/utils/rate-limit.ts
+++ b/utils/rate-limit.ts
@@ -17,6 +17,62 @@ const buckets = new Map<
   Map<string, { count: number; resetAt: number }>
 >();
 
+function normalizeIp(ip: string | undefined): string | undefined {
+  const trimmed = ip?.trim();
+  if (!trimmed) return undefined;
+
+  return trimmed.startsWith("::ffff:")
+    ? trimmed.slice("::ffff:".length)
+    : trimmed;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes(value?.toLowerCase() ?? "");
+}
+
+function getTrustedProxyIps(): Set<string> {
+  return new Set(
+    (process.env.TRUSTED_PROXY_IPS ?? "")
+      .split(",")
+      .map((ip) => normalizeIp(ip))
+      .filter((ip): ip is string => !!ip)
+  );
+}
+
+function shouldTrustForwardedFor(remoteAddress: string | undefined): boolean {
+  if (isTruthyEnv(process.env.TRUST_PROXY_HEADERS)) return true;
+
+  const normalizedRemoteAddress = normalizeIp(remoteAddress);
+  if (!normalizedRemoteAddress) return false;
+
+  return getTrustedProxyIps().has(normalizedRemoteAddress);
+}
+
+function getForwardedForIp(
+  forwarded: string | string[] | undefined
+): string | undefined {
+  const forwardedValues = Array.isArray(forwarded)
+    ? forwarded
+    : forwarded
+      ? [forwarded]
+      : [];
+
+  for (let i = forwardedValues.length - 1; i >= 0; i--) {
+    const forwardedValue = forwardedValues[i];
+    if (!forwardedValue) continue;
+
+    const forwardedParts = forwardedValue
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+    const rightmostForwarded = forwardedParts[forwardedParts.length - 1];
+    const normalizedForwarded = normalizeIp(rightmostForwarded);
+    if (normalizedForwarded) return normalizedForwarded;
+  }
+
+  return undefined;
+}
+
 function getBucket(
   name: string
 ): Map<string, { count: number; resetAt: number }> {
@@ -67,19 +123,14 @@ export function checkRateLimit(
 }
 
 export function getRequestIp(req: NextApiRequest): string {
-  const forwarded = req.headers["x-forwarded-for"];
-  const forwardedValues = Array.isArray(forwarded) ? forwarded : [forwarded];
-  for (let i = forwardedValues.length - 1; i >= 0; i--) {
-    const forwardedValue = forwardedValues[i];
-    const forwardedParts = forwardedValue
-      ?.split(",")
-      .map((part) => part.trim())
-      .filter(Boolean);
-    const rightmostForwarded = forwardedParts?.[forwardedParts.length - 1];
-    if (rightmostForwarded) return rightmostForwarded;
+  const remoteAddress = normalizeIp(req.socket?.remoteAddress);
+
+  if (shouldTrustForwardedFor(remoteAddress)) {
+    const forwardedIp = getForwardedForIp(req.headers["x-forwarded-for"]);
+    if (forwardedIp) return forwardedIp;
   }
 
-  return req.socket?.remoteAddress ?? "unknown";
+  return remoteAddress ?? "unknown";
 }
 
 /**


### PR DESCRIPTION
### Issue

In the X-Forwarded-For header we are taking the leftmost ip which the user can himself inject. Since this is currently deployed on replit , its proxy appends at the end of this header the ip of the user from whom it has received the request
Since currently we are taking the leftmost one which user can inject , he can continously send request by changing its ip as  a new rate limiter will be created per IP although its the same user. 

### Fix Description

- getRequestIp() now takes the rightmost IP from X-Forwarded-For.
- Removed x-real-ip fallback, because that is also client-spoofable unless trusted proxy handling is guaranteed.
- Fallback is now req.socket.remoteAddress, then "unknown".
- onboard.ts now uses the shared getRequestIp() helper instead of custom parsing.
- Updated tests for rightmost IP behavior and onboarding rate-limit key.


### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines