### PR TITLE
feat: add unit tests for db-service helpers and export helper functions

### DIFF
--- a/utils/db/__tests__/db-service.test.ts
+++ b/utils/db/__tests__/db-service.test.ts
@@ -4,9 +4,6 @@ import {
   isReviewEvent,
   buildReviewDTagFilter,
   profileNameToSlug,
-  cacheEvents,
-  cacheEvent,
-  getDbPool,
 } from "../db-service";
 
 describe("db-service helpers", () => {
@@ -57,26 +54,73 @@ describe("db-service helpers", () => {
   });
 
   test("cacheEvents short-circuits on empty input (no DB calls)", async () => {
-    const spy = jest.spyOn({ getDbPool }, "getDbPool");
-    // call with empty array
-    await cacheEvents([]);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+    await jest.isolateModulesAsync(async () => {
+      const prev = process.env.DATABASE_URL;
+      process.env.DATABASE_URL = "postgres://test@localhost/testdb";
+      try {
+        let connectCalled = false;
+        const pool = {
+          connect: jest.fn(async () => {
+            connectCalled = true;
+            return { query: jest.fn(), release: jest.fn() };
+          }),
+          on: jest.fn(),
+        } as any;
+
+        jest.doMock("pg", () => ({
+          Pool: class {
+            constructor() {
+              return pool;
+            }
+          },
+        }));
+
+        const mod = await import("../db-service");
+        await mod.cacheEvents([]);
+        expect(connectCalled).toBe(false);
+      } finally {
+        process.env.DATABASE_URL = prev;
+      }
+    });
   });
 
   test("cacheEvent returns early for unknown kind (no DB calls)", async () => {
-    const spy = jest.spyOn({ getDbPool }, "getDbPool");
-    await cacheEvent({
-      id: "e1",
-      pubkey: "p1",
-      created_at: Date.now(),
-      kind: 999999,
-      tags: [],
-      content: "x",
-      sig: "s",
-    } as any);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+    await jest.isolateModulesAsync(async () => {
+      const prev = process.env.DATABASE_URL;
+      process.env.DATABASE_URL = "postgres://test@localhost/testdb";
+      try {
+        let connectCalled = false;
+        const pool = {
+          connect: jest.fn(async () => {
+            connectCalled = true;
+            return { query: jest.fn(), release: jest.fn() };
+          }),
+          on: jest.fn(),
+        } as any;
+
+        jest.doMock("pg", () => ({
+          Pool: class {
+            constructor() {
+              return pool;
+            }
+          },
+        }));
+
+        const mod = await import("../db-service");
+        await mod.cacheEvent({
+          id: "e1",
+          pubkey: "p1",
+          created_at: Date.now(),
+          kind: 999999,
+          tags: [],
+          content: "x",
+          sig: "s",
+        } as any);
+        expect(connectCalled).toBe(false);
+      } finally {
+        process.env.DATABASE_URL = prev;
+      }
+    });
   });
 
   test("cacheEvents groups events and runs transaction (calls BEGIN)", async () => {
@@ -98,50 +142,56 @@ describe("db-service helpers", () => {
     } as any;
 
     await jest.isolateModulesAsync(async () => {
-      jest.doMock("pg", () => ({
-        Pool: class {
-          constructor() {
-            return pool;
-          }
-        },
-      }));
-      const mod = await import("../db-service");
+      const prev = process.env.DATABASE_URL;
+      process.env.DATABASE_URL = "postgres://test@localhost/testdb";
+      try {
+        jest.doMock("pg", () => ({
+          Pool: class {
+            constructor() {
+              return pool;
+            }
+          },
+        }));
+        const mod = await import("../db-service");
 
-      const events = [
-        {
-          id: "a1",
-          pubkey: "u1",
-          created_at: 1,
-          kind: 17375,
-          tags: [],
-          content: "",
-          sig: "",
-        },
-        {
-          id: "r1",
-          pubkey: "u1",
-          created_at: 2,
-          kind: 31555,
-          tags: [["d", "prod1"]],
-          content: "",
-          sig: "",
-        },
-        {
-          id: "p1",
-          pubkey: "u2",
-          created_at: 3,
-          kind: 30402,
-          tags: [],
-          content: "",
-          sig: "",
-        },
-      ];
+        const events = [
+          {
+            id: "a1",
+            pubkey: "u1",
+            created_at: 1,
+            kind: 17375,
+            tags: [],
+            content: "",
+            sig: "",
+          },
+          {
+            id: "r1",
+            pubkey: "u1",
+            created_at: 2,
+            kind: 31555,
+            tags: [["d", "prod1"]],
+            content: "",
+            sig: "",
+          },
+          {
+            id: "p1",
+            pubkey: "u2",
+            created_at: 3,
+            kind: 30402,
+            tags: [],
+            content: "",
+            sig: "",
+          },
+        ];
 
-      await mod.cacheEvents(events as any[]);
+        await mod.cacheEvents(events as any[]);
 
-      // Expect that a transaction was started
-      expect(queries.some((q) => /BEGIN/i.test(q))).toBe(true);
-      expect(queries.some((q) => /COMMIT/i.test(q))).toBe(true);
+        // Expect that a transaction was started
+        expect(queries.some((q) => /BEGIN/i.test(q))).toBe(true);
+        expect(queries.some((q) => /COMMIT/i.test(q))).toBe(true);
+      } finally {
+        process.env.DATABASE_URL = prev;
+      }
     });
   });
 });

--- a/utils/db/__tests__/db-service.test.ts
+++ b/utils/db/__tests__/db-service.test.ts
@@ -1,0 +1,147 @@
+import {
+  getTableForKind,
+  shouldKeepOnlyLatest,
+  isReviewEvent,
+  buildReviewDTagFilter,
+  profileNameToSlug,
+  cacheEvents,
+  cacheEvent,
+  getDbPool,
+} from "../db-service";
+
+describe("db-service helpers", () => {
+  test("getTableForKind maps known kinds and returns null for unknown", () => {
+    expect(getTableForKind(30402)).toBe("product_events");
+    expect(getTableForKind(31555)).toBe("review_events");
+    expect(getTableForKind(1059)).toBe("message_events");
+    expect(getTableForKind(0)).toBe("profile_events");
+    expect(getTableForKind(999999)).toBeNull();
+  });
+
+  test("shouldKeepOnlyLatest returns true for configured kinds", () => {
+    const trueKinds = [17375, 37375, 10002, 10063, 0, 30019, 34550];
+    for (const k of trueKinds) {
+      expect(shouldKeepOnlyLatest(k)).toBe(true);
+    }
+
+    expect(shouldKeepOnlyLatest(30402)).toBe(false);
+    expect(shouldKeepOnlyLatest(31555)).toBe(false);
+  });
+
+  test("isReviewEvent identifies review kind", () => {
+    expect(isReviewEvent(31555)).toBe(true);
+    expect(isReviewEvent(30402)).toBe(false);
+  });
+
+  test("buildReviewDTagFilter returns JSON array filter for d tag", () => {
+    const json = buildReviewDTagFilter("my-d-tag");
+    expect(json).toBe(JSON.stringify([["d", "my-d-tag"]]));
+  });
+
+  test("profileNameToSlug sanitizes and slugifies names", () => {
+    expect(profileNameToSlug("")).toBe("");
+    expect(profileNameToSlug("   Hello   World  ")).toBe("Hello-World");
+    expect(profileNameToSlug("Shop #1 / Best!!")).toBe("Shop-1-Best");
+    expect(profileNameToSlug("--Leading and trailing--")).toBe(
+      "Leading-and-trailing"
+    );
+    expect(profileNameToSlug("Multiple   spaces")).toBe("Multiple-spaces");
+    // Removes many special characters
+    expect(profileNameToSlug("Name@with*weird^chars%and+symbols")).toBe(
+      "Namewithweirdcharsandsymbols"
+    );
+  });
+
+  test("profileNameToSlug returns empty for only-special-chars names", () => {
+    expect(profileNameToSlug("!!!@@@###")).toBe("");
+  });
+
+  test("cacheEvents short-circuits on empty input (no DB calls)", async () => {
+    const spy = jest.spyOn({ getDbPool }, "getDbPool");
+    // call with empty array
+    await cacheEvents([]);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("cacheEvent returns early for unknown kind (no DB calls)", async () => {
+    const spy = jest.spyOn({ getDbPool }, "getDbPool");
+    await cacheEvent({
+      id: "e1",
+      pubkey: "p1",
+      created_at: Date.now(),
+      kind: 999999,
+      tags: [],
+      content: "x",
+      sig: "s",
+    } as any);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("cacheEvents groups events and runs transaction (calls BEGIN)", async () => {
+    // Use isolated module loading so we can mock 'pg.Pool' before the module is imported
+    const queries: string[] = [];
+    const client = {
+      query: jest.fn(async (q: any) => {
+        const text = typeof q === "string" ? q : q.text || "";
+        queries.push(text.trim().split("\n")[0]);
+        return { rows: [], rowCount: 1 };
+      }),
+      release: jest.fn(),
+      on: jest.fn(),
+    } as any;
+
+    const pool = {
+      connect: jest.fn(async () => client),
+      on: jest.fn(),
+    } as any;
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock("pg", () => ({
+        Pool: class {
+          constructor() {
+            return pool;
+          }
+        },
+      }));
+      const mod = await import("../db-service");
+
+      const events = [
+        {
+          id: "a1",
+          pubkey: "u1",
+          created_at: 1,
+          kind: 17375,
+          tags: [],
+          content: "",
+          sig: "",
+        },
+        {
+          id: "r1",
+          pubkey: "u1",
+          created_at: 2,
+          kind: 31555,
+          tags: [["d", "prod1"]],
+          content: "",
+          sig: "",
+        },
+        {
+          id: "p1",
+          pubkey: "u2",
+          created_at: 3,
+          kind: 30402,
+          tags: [],
+          content: "",
+          sig: "",
+        },
+      ];
+
+      await mod.cacheEvents(events as any[]);
+
+      // Expect that a transaction was started
+      expect(queries.some((q) => /BEGIN/i.test(q))).toBe(true);
+      expect(queries.some((q) => /COMMIT/i.test(q))).toBe(true);
+    });
+  });
+});

--- a/utils/db/db-service.ts
+++ b/utils/db/db-service.ts
@@ -459,7 +459,7 @@ async function initializeTables(): Promise<void> {
 }
 
 // Map event kinds to table names
-function getTableForKind(kind: number): string | null {
+export function getTableForKind(kind: number): string | null {
   // Products
   if (kind === 30402) return "product_events";
 
@@ -485,14 +485,14 @@ function getTableForKind(kind: number): string | null {
 }
 
 // Helper function to check if event kind should only keep latest per pubkey
-function shouldKeepOnlyLatest(kind: number): boolean {
+export function shouldKeepOnlyLatest(kind: number): boolean {
   // Wallet config (17375), wallet state (37375), relay list (10002), blossom servers (10063)
   // User profile (0), shop profile (30019), community definition (34550)
   return [17375, 37375, 10002, 10063, 0, 30019, 34550].includes(kind);
 }
 
 // Helper function to check if event is a review (needs special handling per product)
-function isReviewEvent(kind: number): boolean {
+export function isReviewEvent(kind: number): boolean {
   return kind === 31555;
 }
 
@@ -1611,7 +1611,7 @@ export async function closeDbPool(): Promise<void> {
   }
 }
 
-function profileNameToSlug(name: string): string {
+export function profileNameToSlug(name: string): string {
   if (!name) return "";
   return name
     .trim()


### PR DESCRIPTION
### Description
- Added focused unit tests for `db-service` helper functions: `getTableForKind`, `shouldKeepOnlyLatest`, `isReviewEvent`, `buildReviewDTagFilter`, `profileNameToSlug`, `cacheEvents`, and `cacheEvent` to validate event-kind routing, review handling, slug generation, and caching behavior.
- Exported `getTableForKind`, `shouldKeepOnlyLatest`, `isReviewEvent`, and `profileNameToSlug` from `utils/db/db-service.ts` so they can be tested directly and reused where needed.
- Verified that `cacheEvents` short-circuits on empty input and that `cacheEvent` returns early for unknown kinds without touching the database, and that grouped events run inside a proper `BEGIN`/`COMMIT` transaction

### Resolved or fixed issue
`none`  

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

### For more details on what to include, see:

[Bug Report Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
[Feature Request Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/feature_request.md)
[Documentation Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/documentation_improvement.md)
[Security Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/security_vulnerability.md)