### PR TITLE
feat: add NIP 50 search support for marketplace listings

### DIFF
--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -628,7 +628,9 @@ describe("DisplayProducts search filtering", () => {
 
     await waitFor(() => {
       expect(screen.getAllByText("Deduped Coffee")).toHaveLength(1);
-      expect(screen.queryByTestId("product-relay-product")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("product-relay-product")
+      ).not.toBeInTheDocument();
       expect(screen.getByTestId("product-local-product")).toBeInTheDocument();
     });
   });

--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -129,6 +129,22 @@ const renderDisplayProducts = ({
     </SignerContext.Provider>
   );
 
+const expectNip50RelayFetches = (
+  fetchMock: jest.Mock,
+  expectedFilter: Record<string, unknown>
+) => {
+  expect(fetchMock).toHaveBeenCalledTimes(DEFAULT_NIP50_SEARCH_RELAYS.length);
+  DEFAULT_NIP50_SEARCH_RELAYS.forEach((relay, index) => {
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      index + 1,
+      expect.arrayContaining([expect.objectContaining(expectedFilter)]),
+      {},
+      [relay],
+      NIP50_SEARCH_TIMEOUT_MS
+    );
+  });
+};
+
 describe("DisplayProducts search filtering", () => {
   it("matches literal special characters in search queries", async () => {
     render(
@@ -262,14 +278,10 @@ describe("DisplayProducts search filtering", () => {
     );
 
     await waitFor(() => {
-      expect(nostr.fetch).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ kinds: [30402], search: "coffee" }),
-        ]),
-        {},
-        DEFAULT_NIP50_SEARCH_RELAYS,
-        NIP50_SEARCH_TIMEOUT_MS
-      );
+      expectNip50RelayFetches(nostr.fetch, {
+        kinds: [30402],
+        search: "coffee",
+      });
       expect(screen.getByText("Relay Coffee Beans")).toBeInTheDocument();
     });
   });
@@ -335,18 +347,11 @@ describe("DisplayProducts search filtering", () => {
     });
 
     await waitFor(() => {
-      expect(nostr.fetch).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({
-            kinds: [30402],
-            search: "coffee",
-            authors: [sellerPubkey],
-          }),
-        ]),
-        {},
-        DEFAULT_NIP50_SEARCH_RELAYS,
-        NIP50_SEARCH_TIMEOUT_MS
-      );
+      expectNip50RelayFetches(nostr.fetch, {
+        kinds: [30402],
+        search: "coffee",
+        authors: [sellerPubkey],
+      });
       expect(screen.getByText("Seller Coffee")).toBeInTheDocument();
     });
   });

--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -12,6 +12,10 @@ import {
   SignerContext,
 } from "@/components/utility-components/nostr-context-provider";
 import { NostrEvent, NostrManager } from "@/utils/nostr/nostr-manager";
+import {
+  DEFAULT_NIP50_SEARCH_RELAYS,
+  NIP50_SEARCH_TIMEOUT_MS,
+} from "@/utils/nostr/fetch-service";
 
 jest.mock("next/router", () => ({
   __esModule: true,
@@ -263,7 +267,8 @@ describe("DisplayProducts search filtering", () => {
           expect.objectContaining({ kinds: [30402], search: "coffee" }),
         ]),
         {},
-        ["wss://relay.example"]
+        DEFAULT_NIP50_SEARCH_RELAYS,
+        NIP50_SEARCH_TIMEOUT_MS
       );
       expect(screen.getByText("Relay Coffee Beans")).toBeInTheDocument();
     });
@@ -339,7 +344,8 @@ describe("DisplayProducts search filtering", () => {
           }),
         ]),
         {},
-        ["wss://relay.example"]
+        DEFAULT_NIP50_SEARCH_RELAYS,
+        NIP50_SEARCH_TIMEOUT_MS
       );
       expect(screen.getByText("Seller Coffee")).toBeInTheDocument();
     });
@@ -361,7 +367,7 @@ describe("DisplayProducts search filtering", () => {
     expect(nostr.fetch).not.toHaveBeenCalled();
   });
 
-  it("shows zapsnag notes returned by NIP-50 relay search", async () => {
+  it("does not show zapsnag notes returned by NIP-50 relay search", async () => {
     const nostr = {
       fetch: jest.fn().mockResolvedValue([
         {
@@ -380,11 +386,8 @@ describe("DisplayProducts search filtering", () => {
     renderDisplayProducts({ nostr });
 
     await waitFor(() => {
-      expect(screen.getByText("Coffee beans")).toBeInTheDocument();
-      expect(screen.getByTestId("product-zapsnag-coffee")).toHaveAttribute(
-        "href",
-        "/listing/zapsnag-coffee"
-      );
+      expect(screen.getByText("No products found...")).toBeInTheDocument();
+      expect(screen.queryByText("Coffee beans")).not.toBeInTheDocument();
     });
   });
 
@@ -588,6 +591,45 @@ describe("DisplayProducts search filtering", () => {
       expect(screen.queryByText("Old Coffee")).not.toBeInTheDocument();
       expect(addNewlyCreatedProductEvent).not.toHaveBeenCalled();
       expect(removeDeletedProductEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  it("deduplicates the same addressable listing across NIP-50 and product context", async () => {
+    const sellerPubkey = "a".repeat(64);
+    const relayProduct = {
+      id: "relay-product",
+      pubkey: sellerPubkey,
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "coffee"],
+        ["title", "Deduped Coffee"],
+        ["price", "12", "USD"],
+        ["image", "https://example.com/relay-coffee.png"],
+      ],
+      content: "Coffee from relay search",
+      sig: "relay-sig",
+    };
+    const localProduct = {
+      ...relayProduct,
+      id: "local-product",
+      created_at: 20,
+      content: "Coffee from product context",
+      sig: "local-sig",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([relayProduct]),
+    };
+
+    renderDisplayProducts({
+      nostr,
+      productEvents: [localProduct],
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Deduped Coffee")).toHaveLength(1);
+      expect(screen.queryByTestId("product-relay-product")).not.toBeInTheDocument();
+      expect(screen.getByTestId("product-local-product")).toBeInTheDocument();
     });
   });
 });

--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -1,14 +1,17 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import DisplayProducts from "../display-products";
 import {
   FollowsContext,
   ProductContext,
   ProfileMapContext,
+  RelaysContext,
 } from "@/utils/context/context";
 import {
   NostrContext,
   SignerContext,
 } from "@/components/utility-components/nostr-context-provider";
+import { NostrEvent, NostrManager } from "@/utils/nostr/nostr-manager";
 
 jest.mock("next/router", () => ({
   __esModule: true,
@@ -26,10 +29,18 @@ jest.mock(
   () =>
     function MockProductCard({
       productData,
+      href,
     }: {
-      productData: { title: string };
+      productData: { id: string; title: string };
+      href?: string | null;
     }) {
-      return <div>{productData.title}</div>;
+      return href ? (
+        <a data-testid={`product-${productData.id}`} href={href}>
+          {productData.title}
+        </a>
+      ) : (
+        <div data-testid={`product-${productData.id}`}>{productData.title}</div>
+      );
     }
 );
 
@@ -37,9 +48,82 @@ jest.mock("../display-product-modal", () => () => null);
 jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
   deleteEvent: jest.fn(),
 }));
-jest.mock("@/utils/url-slugs", () => ({
-  getListingSlug: jest.fn(),
+jest.mock("@/utils/db/db-client", () => ({
+  cacheEventsToDatabase: jest.fn().mockResolvedValue(undefined),
 }));
+jest.mock("@/utils/url-slugs", () => ({
+  getListingSlug: jest.fn((product: { id: string; title?: string }) =>
+    product.title ? product.title.replace(/\s+/g, "-") : product.id
+  ),
+}));
+
+const renderDisplayProducts = ({
+  focusedPubkey,
+  nostr,
+  productEvents = [],
+  relayList = ["wss://relay.example"],
+  selectedSearch = "coffee",
+  addNewlyCreatedProductEvent = jest.fn(),
+  removeDeletedProductEvent = jest.fn(),
+}: {
+  focusedPubkey?: string;
+  nostr: { fetch: jest.Mock };
+  productEvents?: NostrEvent[];
+  relayList?: string[];
+  selectedSearch?: string;
+  addNewlyCreatedProductEvent?: jest.Mock;
+  removeDeletedProductEvent?: jest.Mock;
+}) =>
+  render(
+    <SignerContext.Provider
+      value={{ pubkey: "viewer-pubkey", isLoggedIn: true }}
+    >
+      <NostrContext.Provider
+        value={{ nostr: nostr as unknown as NostrManager }}
+      >
+        <RelaysContext.Provider
+          value={{
+            relayList,
+            readRelayList: [],
+            writeRelayList: [],
+            isLoading: false,
+          }}
+        >
+          <ProfileMapContext.Provider
+            value={{
+              profileData: new Map(),
+              isLoading: false,
+              updateProfileData: jest.fn(),
+            }}
+          >
+            <FollowsContext.Provider
+              value={{
+                followList: [],
+                firstDegreeFollowsLength: 0,
+                isLoading: false,
+              }}
+            >
+              <ProductContext.Provider
+                value={{
+                  productEvents,
+                  isLoading: false,
+                  addNewlyCreatedProductEvent,
+                  removeDeletedProductEvent,
+                }}
+              >
+                <DisplayProducts
+                  focusedPubkey={focusedPubkey}
+                  selectedCategories={new Set()}
+                  selectedLocation=""
+                  selectedSearch={selectedSearch}
+                />
+              </ProductContext.Provider>
+            </FollowsContext.Provider>
+          </ProfileMapContext.Provider>
+        </RelaysContext.Provider>
+      </NostrContext.Provider>
+    </SignerContext.Provider>
+  );
 
 describe("DisplayProducts search filtering", () => {
   it("matches literal special characters in search queries", async () => {
@@ -47,7 +131,7 @@ describe("DisplayProducts search filtering", () => {
       <SignerContext.Provider
         value={{ pubkey: "viewer-pubkey", isLoggedIn: true }}
       >
-        <NostrContext.Provider value={{ nostr: {} as any }}>
+        <NostrContext.Provider value={{ nostr: {} as unknown as NostrManager }}>
           <ProfileMapContext.Provider
             value={{
               profileData: new Map(),
@@ -99,6 +183,411 @@ describe("DisplayProducts search filtering", () => {
 
     await waitFor(() => {
       expect(screen.getByText("C++ Guide")).toBeInTheDocument();
+    });
+  });
+
+  it("shows marketplace listings returned by NIP-50 relay search", async () => {
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([
+        {
+          id: "relay-product-1",
+          pubkey: "relay-seller",
+          created_at: 10,
+          kind: 30402,
+          tags: [
+            ["d", "relay-coffee"],
+            ["title", "Relay Coffee Beans"],
+            ["summary", "Fresh coffee discovered through relay search"],
+            ["price", "12", "USD"],
+            ["image", "https://example.com/coffee.png"],
+          ],
+          content: "Fresh coffee discovered through relay search",
+          sig: "relay-sig",
+        },
+      ]),
+    };
+
+    render(
+      <SignerContext.Provider
+        value={{ pubkey: "viewer-pubkey", isLoggedIn: true }}
+      >
+        <NostrContext.Provider
+          value={{ nostr: nostr as unknown as NostrManager }}
+        >
+          <RelaysContext.Provider
+            value={{
+              relayList: ["wss://relay.example"],
+              readRelayList: [],
+              writeRelayList: [],
+              isLoading: false,
+            }}
+          >
+            <ProfileMapContext.Provider
+              value={{
+                profileData: new Map(),
+                isLoading: false,
+                updateProfileData: jest.fn(),
+              }}
+            >
+              <FollowsContext.Provider
+                value={{
+                  followList: [],
+                  firstDegreeFollowsLength: 0,
+                  isLoading: false,
+                }}
+              >
+                <ProductContext.Provider
+                  value={{
+                    productEvents: [],
+                    isLoading: false,
+                    addNewlyCreatedProductEvent: jest.fn(),
+                    removeDeletedProductEvent: jest.fn(),
+                  }}
+                >
+                  <DisplayProducts
+                    selectedCategories={new Set()}
+                    selectedLocation=""
+                    selectedSearch="coffee"
+                  />
+                </ProductContext.Provider>
+              </FollowsContext.Provider>
+            </ProfileMapContext.Provider>
+          </RelaysContext.Provider>
+        </NostrContext.Provider>
+      </SignerContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(nostr.fetch).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ kinds: [30402], search: "coffee" }),
+        ]),
+        {},
+        ["wss://relay.example"]
+      );
+      expect(screen.getByText("Relay Coffee Beans")).toBeInTheDocument();
+    });
+  });
+
+  it("does not add transient NIP-50 search results to shared product context", async () => {
+    const relayProduct = {
+      id: "relay-product-1",
+      pubkey: "relay-seller",
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "relay-coffee"],
+        ["title", "Relay Coffee Beans"],
+        ["price", "12", "USD"],
+        ["image", "https://example.com/coffee.png"],
+      ],
+      content: "Fresh coffee discovered through relay search",
+      sig: "relay-sig",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([relayProduct]),
+    };
+    const addNewlyCreatedProductEvent = jest.fn();
+    const removeDeletedProductEvent = jest.fn();
+
+    renderDisplayProducts({
+      nostr,
+      addNewlyCreatedProductEvent,
+      removeDeletedProductEvent,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Relay Coffee Beans")).toBeInTheDocument();
+    });
+    expect(addNewlyCreatedProductEvent).not.toHaveBeenCalled();
+    expect(removeDeletedProductEvent).not.toHaveBeenCalled();
+  });
+
+  it("scopes NIP-50 relay search to the focused seller when viewing a storefront", async () => {
+    const sellerPubkey = "a".repeat(64);
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([
+        {
+          id: "seller-product",
+          pubkey: sellerPubkey,
+          created_at: 10,
+          kind: 30402,
+          tags: [
+            ["d", "seller-coffee"],
+            ["title", "Seller Coffee"],
+            ["price", "12", "USD"],
+            ["image", "https://example.com/seller-coffee.png"],
+          ],
+          content: "Fresh storefront coffee",
+          sig: "relay-sig",
+        },
+      ]),
+    };
+
+    renderDisplayProducts({
+      focusedPubkey: sellerPubkey,
+      nostr,
+    });
+
+    await waitFor(() => {
+      expect(nostr.fetch).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kinds: [30402],
+            search: "coffee",
+            authors: [sellerPubkey],
+          }),
+        ]),
+        {},
+        ["wss://relay.example"]
+      );
+      expect(screen.getByText("Seller Coffee")).toBeInTheDocument();
+    });
+  });
+
+  it("does not run NIP-50 relay search for NIP-19 queries", async () => {
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([]),
+    };
+
+    renderDisplayProducts({
+      nostr,
+      selectedSearch: "naddr1invalid",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("No products found...")).toBeInTheDocument();
+    });
+    expect(nostr.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows zapsnag notes returned by NIP-50 relay search", async () => {
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([
+        {
+          id: "zapsnag-coffee",
+          pubkey: "a".repeat(64),
+          created_at: 10,
+          kind: 1,
+          tags: [["t", "shopstr-zapsnag"]],
+          content:
+            "Coffee beans price: 100 sats #zapsnag https://example.com/coffee.png",
+          sig: "relay-sig",
+        },
+      ]),
+    };
+
+    renderDisplayProducts({ nostr });
+
+    await waitFor(() => {
+      expect(screen.getByText("Coffee beans")).toBeInTheDocument();
+      expect(screen.getByTestId("product-zapsnag-coffee")).toHaveAttribute(
+        "href",
+        "/listing/zapsnag-coffee"
+      );
+    });
+  });
+
+  it("uses an exact naddr link for NIP-50-only listings with title collisions", async () => {
+    const relaySeller = "a".repeat(64);
+    const localSeller = "b".repeat(64);
+    const relayProduct = {
+      id: "relay-product-1",
+      pubkey: relaySeller,
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "relay-coffee"],
+        ["title", "Collision Coffee"],
+        ["price", "12", "USD"],
+        ["image", "https://example.com/relay-coffee.png"],
+      ],
+      content: "Relay-only collision coffee",
+      sig: "relay-sig",
+    };
+    const localProduct = {
+      id: "local-product-1",
+      pubkey: localSeller,
+      created_at: 9,
+      kind: 30402,
+      tags: [
+        ["d", "local-coffee"],
+        ["title", "Collision Coffee"],
+        ["price", "10", "USD"],
+        ["image", "https://example.com/local-coffee.png"],
+      ],
+      content: "Local collision coffee",
+      sig: "local-sig",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([relayProduct]),
+    };
+
+    renderDisplayProducts({
+      nostr,
+      productEvents: [localProduct],
+    });
+
+    await waitFor(() => {
+      const relayLink = screen.getByTestId("product-relay-product-1");
+      expect(relayLink.getAttribute("href")).toMatch(/^\/listing\/naddr1/);
+      expect(relayLink.getAttribute("href")).not.toBe(
+        "/listing/Collision-Coffee"
+      );
+    });
+  });
+
+  it("keeps an exact naddr link after product context receives the NIP-50 listing", async () => {
+    const relayProduct = {
+      id: "relay-product-1",
+      pubkey: "a".repeat(64),
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "relay-coffee"],
+        ["title", "Relay Coffee Beans"],
+        ["price", "12", "USD"],
+        ["image", "https://example.com/relay-coffee.png"],
+      ],
+      content: "Relay-only coffee",
+      sig: "relay-sig",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([relayProduct]),
+    };
+    let setContextProductEvents:
+      | Dispatch<SetStateAction<NostrEvent[]>>
+      | undefined;
+
+    function StatefulDisplayProducts() {
+      const [contextProductEvents, setProductEvents] = useState<NostrEvent[]>(
+        []
+      );
+      setContextProductEvents = setProductEvents;
+
+      return (
+        <SignerContext.Provider
+          value={{ pubkey: "viewer-pubkey", isLoggedIn: true }}
+        >
+          <NostrContext.Provider
+            value={{ nostr: nostr as unknown as NostrManager }}
+          >
+            <RelaysContext.Provider
+              value={{
+                relayList: ["wss://relay.example"],
+                readRelayList: [],
+                writeRelayList: [],
+                isLoading: false,
+              }}
+            >
+              <ProfileMapContext.Provider
+                value={{
+                  profileData: new Map(),
+                  isLoading: false,
+                  updateProfileData: jest.fn(),
+                }}
+              >
+                <FollowsContext.Provider
+                  value={{
+                    followList: [],
+                    firstDegreeFollowsLength: 0,
+                    isLoading: false,
+                  }}
+                >
+                  <ProductContext.Provider
+                    value={{
+                      productEvents: contextProductEvents,
+                      isLoading: false,
+                      addNewlyCreatedProductEvent: jest.fn(),
+                      removeDeletedProductEvent: jest.fn(),
+                    }}
+                  >
+                    <DisplayProducts
+                      selectedCategories={new Set()}
+                      selectedLocation=""
+                      selectedSearch="coffee"
+                    />
+                  </ProductContext.Provider>
+                </FollowsContext.Provider>
+              </ProfileMapContext.Provider>
+            </RelaysContext.Provider>
+          </NostrContext.Provider>
+        </SignerContext.Provider>
+      );
+    }
+
+    render(<StatefulDisplayProducts />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("product-relay-product-1")).toHaveAttribute(
+        "href",
+        expect.stringMatching(/^\/listing\/naddr1/)
+      );
+    });
+
+    act(() => {
+      setContextProductEvents?.([relayProduct as NostrEvent]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("product-relay-product-1")).toHaveAttribute(
+        "href",
+        expect.stringMatching(/^\/listing\/naddr1/)
+      );
+      expect(screen.getByTestId("product-relay-product-1")).not.toHaveAttribute(
+        "href",
+        "/listing/Relay-Coffee-Beans"
+      );
+    });
+  });
+
+  it("keeps the newer local replaceable listing over a stale NIP-50 result", async () => {
+    const sellerPubkey = "a".repeat(64);
+    const staleRelayProduct = {
+      id: "stale-product",
+      pubkey: sellerPubkey,
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "coffee"],
+        ["title", "Old Coffee"],
+        ["price", "12", "USD"],
+        ["image", "https://example.com/old-coffee.png"],
+      ],
+      content: "Coffee listing before update",
+      sig: "stale-sig",
+    };
+    const newerLocalProduct = {
+      ...staleRelayProduct,
+      id: "newer-product",
+      created_at: 20,
+      tags: [
+        ["d", "coffee"],
+        ["title", "Updated Coffee"],
+        ["price", "12", "USD"],
+        ["image", "https://example.com/updated-coffee.png"],
+      ],
+      content: "Coffee listing after update",
+      sig: "newer-sig",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([staleRelayProduct]),
+    };
+    const addNewlyCreatedProductEvent = jest.fn();
+    const removeDeletedProductEvent = jest.fn();
+
+    renderDisplayProducts({
+      nostr,
+      productEvents: [newerLocalProduct],
+      addNewlyCreatedProductEvent,
+      removeDeletedProductEvent,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated Coffee")).toBeInTheDocument();
+      expect(screen.queryByText("Old Coffee")).not.toBeInTheDocument();
+      expect(addNewlyCreatedProductEvent).not.toHaveBeenCalled();
+      expect(removeDeletedProductEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useContext } from "react";
 import { deleteEvent } from "@/utils/nostr/nostr-helper-functions";
 import { NostrEvent } from "../utils/types/types";
-import { ProductContext, FollowsContext } from "../utils/context/context";
+import {
+  ProductContext,
+  FollowsContext,
+  RelaysContext,
+} from "../utils/context/context";
 import ProductCard from "./utility-components/product-card";
 import DisplayProductModal from "./display-product-modal";
 import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
@@ -18,6 +22,19 @@ import {
 } from "@/components/utility-components/nostr-context-provider";
 import { getListingSlug } from "@/utils/url-slugs";
 import { productSatisfiesAllFilters } from "@/utils/parsers/product-filter-helpers";
+import {
+  dedupeProductEvents,
+  fetchNip50ProductSearch,
+  getProductEventKey,
+} from "@/utils/nostr/fetch-service";
+import { nip19 } from "nostr-tools";
+
+const isNip19SearchQuery = (search: string) => {
+  const normalizedSearch = search.trim();
+  return (
+    normalizedSearch.includes("naddr1") || normalizedSearch.includes("npub1")
+  );
+};
 
 const DisplayProducts = ({
   focusedPubkey,
@@ -42,8 +59,13 @@ const DisplayProducts = ({
 }) => {
   const [productEvents, setProductEvents] = useState<ProductData[]>([]);
   const [isProductsLoading, setIsProductLoading] = useState(true);
+  const [nip50ProductEvents, setNip50ProductEvents] = useState<NostrEvent[]>(
+    []
+  );
+  const [isNip50SearchLoading, setIsNip50SearchLoading] = useState(false);
   const productEventContext = useContext(ProductContext);
   const followsContext = useContext(FollowsContext);
+  const relaysContext = useContext(RelaysContext);
   const [focusedProduct, setFocusedProduct] = useState<ProductData>();
   const [showModal, setShowModal] = useState(false);
 
@@ -57,6 +79,15 @@ const DisplayProducts = ({
 
   const { nostr } = useContext(NostrContext);
   const { signer, pubkey: userPubkey } = useContext(SignerContext);
+
+  const searchRelaysKey = Array.from(
+    new Set([
+      ...(relaysContext.relayList || []),
+      ...(relaysContext.readRelayList || []),
+    ])
+  )
+    .filter(Boolean)
+    .join("|");
 
   // Load saved page from session storage on mount
   useEffect(() => {
@@ -76,16 +107,68 @@ const DisplayProducts = ({
   }, [focusedPubkey]);
 
   useEffect(() => {
+    const normalizedSearch = selectedSearch.trim();
+
+    if (!normalizedSearch || isNip19SearchQuery(normalizedSearch) || !nostr) {
+      setNip50ProductEvents([]);
+      setIsNip50SearchLoading(false);
+      return;
+    }
+
+    const relaysToSearch = searchRelaysKey ? searchRelaysKey.split("|") : [];
+
+    if (relaysToSearch.length === 0) {
+      setNip50ProductEvents([]);
+      setIsNip50SearchLoading(false);
+      return;
+    }
+
+    let didCancel = false;
+    setIsNip50SearchLoading(true);
+
+    fetchNip50ProductSearch(nostr, relaysToSearch, normalizedSearch, {
+      authors: focusedPubkey ? [focusedPubkey] : undefined,
+    })
+      .then(({ productEvents }) => {
+        if (didCancel) return;
+        setNip50ProductEvents(productEvents);
+      })
+      .catch((error) => {
+        if (didCancel) return;
+        setNip50ProductEvents([]);
+        console.error("Failed to search products with NIP-50:", error);
+      })
+      .finally(() => {
+        if (didCancel) return;
+        setIsNip50SearchLoading(false);
+      });
+
+    return () => {
+      didCancel = true;
+    };
+  }, [selectedSearch, focusedPubkey, nostr, searchRelaysKey]);
+
+  useEffect(() => {
     if (!productEventContext) return;
     const hasProducts =
       productEventContext.productEvents &&
       productEventContext.productEvents.length > 0;
-    if (hasProducts) {
-      const sortedProductEvents = [...productEventContext.productEvents].sort(
-        (a: NostrEvent, b: NostrEvent) => b.created_at - a.created_at
-      );
+    const hasNip50Products = nip50ProductEvents.length > 0;
+    const sourceProductEvents =
+      selectedSearch.trim() && !isNip19SearchQuery(selectedSearch)
+        ? dedupeProductEvents([
+            ...nip50ProductEvents,
+            ...[...(productEventContext.productEvents || [])].sort(
+              (a: NostrEvent, b: NostrEvent) => b.created_at - a.created_at
+            ),
+          ])
+        : [...(productEventContext.productEvents || [])].sort(
+            (a: NostrEvent, b: NostrEvent) => b.created_at - a.created_at
+          );
+
+    if (hasProducts || hasNip50Products) {
       const parsedProductData: ProductData[] = [];
-      sortedProductEvents.forEach((event) => {
+      sourceProductEvents.forEach((event) => {
         if (wotFilter) {
           if (!followsContext.isLoading && followsContext.followList) {
             const followList = followsContext.followList;
@@ -123,7 +206,7 @@ const DisplayProducts = ({
       setProductEvents([]);
       setIsProductLoading(false);
     }
-  }, [productEventContext, wotFilter]);
+  }, [productEventContext, wotFilter, nip50ProductEvents, selectedSearch]);
 
   useEffect(() => {
     if (focusedPubkey && setCategories) {
@@ -247,10 +330,35 @@ const DisplayProducts = ({
       return `/listing/${product.id}`;
     }
 
-    const allParsed = productEventContext.productEvents
-      .filter((e: NostrEvent) => e.kind !== 1)
-      .map((e: NostrEvent) => parseTags(e))
-      .filter((p: ProductData | undefined): p is ProductData => !!p);
+    const rawProductEvent = product.rawEvent;
+    const isNip50SearchResult =
+      rawProductEvent?.kind === 30402 &&
+      nip50ProductEvents.some(
+        (event: NostrEvent) =>
+          event.kind === 30402 &&
+          getProductEventKey(event) === getProductEventKey(rawProductEvent)
+      );
+
+    if (isNip50SearchResult) {
+      const dTag = rawProductEvent.tags.find((tag) => tag[0] === "d")?.[1];
+      if (dTag) {
+        try {
+          return `/listing/${nip19.naddrEncode({
+            identifier: dTag,
+            pubkey: rawProductEvent.pubkey,
+            kind: rawProductEvent.kind,
+          })}`;
+        } catch {
+          // Fall back to the slug path if this event cannot form a valid naddr.
+        }
+      }
+    }
+
+    const allParsed = productEvents.filter(
+      (productData) =>
+        productData.d !== "zapsnag" &&
+        !productData.categories?.includes("zapsnag")
+    );
 
     const slug = getListingSlug(product, allParsed);
     if (slug) {
@@ -294,7 +402,7 @@ const DisplayProducts = ({
   return (
     <>
       <div className="w-full md:pl-4">
-        {!isMyListings && isProductsLoading ? (
+        {!isMyListings && (isProductsLoading || isNip50SearchLoading) ? (
           <div className="mt-6 mb-6 flex items-center justify-center">
             <ShopstrSpinner />
           </div>
@@ -337,6 +445,7 @@ const DisplayProducts = ({
         )}
         {!isMyListings &&
           !isProductsLoading &&
+          !isNip50SearchLoading &&
           filteredProducts.length === 0 && (
             <div className="mt-20 flex flex-grow items-center justify-center py-10">
               <div className="bg-light-fg dark:bg-dark-fg w-full max-w-lg rounded-lg p-8 text-center shadow-lg">

--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -117,12 +117,6 @@ const DisplayProducts = ({
 
     const relaysToSearch = searchRelaysKey ? searchRelaysKey.split("|") : [];
 
-    if (relaysToSearch.length === 0) {
-      setNip50ProductEvents([]);
-      setIsNip50SearchLoading(false);
-      return;
-    }
-
     let didCancel = false;
     setIsNip50SearchLoading(true);
 

--- a/components/home/marketplace.tsx
+++ b/components/home/marketplace.tsx
@@ -94,7 +94,7 @@ function MarketplacePage({
   );
   const [selectedLocation, setSelectedLocation] = useState("");
   const [selectedSearch, setSelectedSearch] = useState("");
-  const debouncedSearch = useDebounce(selectedSearch, 300);
+  const debouncedSearch = useDebounce(selectedSearch, 500);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const [wotFilter, setWotFilter] = useState(false);

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -24,6 +24,24 @@ const makeBaseEvent = (overrides: Record<string, any> = {}) => ({
   ...overrides,
 });
 
+const expectNip50RelayFetches = (
+  fetchMock: jest.Mock,
+  relays = DEFAULT_NIP50_SEARCH_RELAYS
+) => {
+  expect(fetchMock).toHaveBeenCalledTimes(relays.length);
+  relays.forEach((relay, index) => {
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      index + 1,
+      expect.arrayContaining([
+        expect.objectContaining({ kinds: [30402], search: "coffee" }),
+      ]),
+      {},
+      [relay],
+      NIP50_SEARCH_TIMEOUT_MS
+    );
+  });
+};
+
 describe("fetchAllPosts - NIP-99 and relay merge behavior", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -591,16 +609,9 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expect(nostr.fetch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ kinds: [30402], search: "coffee" }),
-      ]),
-      {},
-      DEFAULT_NIP50_SEARCH_RELAYS,
-      NIP50_SEARCH_TIMEOUT_MS
-    );
+    expectNip50RelayFetches(nostr.fetch);
     expect(result.productEvents).toEqual([newer]);
-    expect(cacheEventsToDatabase).toHaveBeenCalledWith([older, newer]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([newer]);
   });
 
   it("waits for relevant kind 30402 search results to be cached before returning them", async () => {
@@ -757,12 +768,40 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expect(nostr.fetch).toHaveBeenCalledWith(
-      expect.any(Array),
-      {},
-      DEFAULT_NIP50_SEARCH_RELAYS,
-      NIP50_SEARCH_TIMEOUT_MS
+    expectNip50RelayFetches(nostr.fetch);
+    expect(result.productEvents).toEqual([searchListing]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([searchListing]);
+  });
+
+  it("keeps NIP-50 results from responsive relays when another search relay times out", async () => {
+    const searchListing = {
+      id: "responsive-product",
+      pubkey: "responsive-seller",
+      created_at: 30,
+      kind: 30402,
+      tags: [
+        ["d", "responsive-coffee"],
+        ["title", "Responsive Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "responsive coffee",
+      sig: "sig-responsive",
+    };
+    const nostr = {
+      fetch: jest.fn((_, __, relays: string[]) =>
+        relays[0] === DEFAULT_NIP50_SEARCH_RELAYS[1]
+          ? Promise.resolve([searchListing])
+          : Promise.reject(new Error("Timeout"))
+      ),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      [],
+      "coffee"
     );
+
+    expectNip50RelayFetches(nostr.fetch);
     expect(result.productEvents).toEqual([searchListing]);
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([searchListing]);
   });
@@ -785,12 +824,7 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expect(nostr.fetch).toHaveBeenCalledWith(
-      expect.any(Array),
-      {},
-      searchRelays,
-      NIP50_SEARCH_TIMEOUT_MS
-    );
+    expectNip50RelayFetches(nostr.fetch, searchRelays);
   });
 
   it("uses default NIP-50 relays when no selected relays are available", async () => {
@@ -817,12 +851,7 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expect(nostr.fetch).toHaveBeenCalledWith(
-      expect.any(Array),
-      {},
-      DEFAULT_NIP50_SEARCH_RELAYS,
-      NIP50_SEARCH_TIMEOUT_MS
-    );
+    expectNip50RelayFetches(nostr.fetch);
     expect(result.productEvents).toEqual([fallbackListing]);
   });
 

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -721,9 +721,7 @@ describe("fetch-service NIP-50 search helpers", () => {
       sig: "sig-newer",
     };
     const nostr = {
-      fetch: jest
-        .fn()
-        .mockResolvedValue([firstRelayResult, secondRelayResult]),
+      fetch: jest.fn().mockResolvedValue([firstRelayResult, secondRelayResult]),
     };
 
     const result = await fetchNip50ProductSearch(
@@ -732,10 +730,7 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expect(result.productEvents).toEqual([
-      firstRelayResult,
-      secondRelayResult,
-    ]);
+    expect(result.productEvents).toEqual([firstRelayResult, secondRelayResult]);
   });
 
   it("routes search to curated NIP-50 relays instead of general user relays", async () => {

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -1,6 +1,7 @@
 import { NostrEvent, NostrManager } from "../nostr-manager";
 import {
   buildNip50ProductSearchFilters,
+  DEFAULT_NIP50_SEARCH_RELAYS,
   dedupeProductEvents,
   fetchNip50ProductSearch,
 } from "../fetch-service";
@@ -643,8 +644,12 @@ describe("fetch-service NIP-50 search helpers", () => {
       return result;
     });
 
-    await Promise.resolve();
+    for (let index = 0; index < 5 && !resolveCache; index += 1) {
+      await Promise.resolve();
+    }
+
     expect(didResolve).toBe(false);
+    expect(resolveCache).toBeDefined();
 
     resolveCache();
     const result = await searchPromise;
@@ -692,6 +697,81 @@ describe("fetch-service NIP-50 search helpers", () => {
 
     expect(result.productEvents).toEqual([relevant]);
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([relevant]);
+  });
+
+  it("falls back to default NIP-50 relays when selected relays return no relevant product results", async () => {
+    const fallbackListing = {
+      id: "fallback-product",
+      pubkey: "fallback-seller",
+      created_at: 30,
+      kind: 30402,
+      tags: [
+        ["d", "fallback-coffee"],
+        ["title", "Fallback Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "fallback coffee",
+      sig: "sig-fallback",
+    };
+    const nostr = {
+      fetch: jest
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([fallbackListing]),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://relay.without-search.example"],
+      "coffee"
+    );
+
+    expect(nostr.fetch).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Array),
+      {},
+      ["wss://relay.without-search.example"]
+    );
+    expect(nostr.fetch).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Array),
+      {},
+      DEFAULT_NIP50_SEARCH_RELAYS
+    );
+    expect(result.productEvents).toEqual([fallbackListing]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([fallbackListing]);
+  });
+
+  it("uses default NIP-50 relays when no selected relays are available", async () => {
+    const fallbackListing = {
+      id: "default-product",
+      pubkey: "fallback-seller",
+      created_at: 40,
+      kind: 30402,
+      tags: [
+        ["d", "default-coffee"],
+        ["title", "Default Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "default coffee",
+      sig: "sig-default",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([fallbackListing]),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      [],
+      "coffee"
+    );
+
+    expect(nostr.fetch).toHaveBeenCalledWith(
+      expect.any(Array),
+      {},
+      DEFAULT_NIP50_SEARCH_RELAYS
+    );
+    expect(result.productEvents).toEqual([fallbackListing]);
   });
 
   it("returns matching zapsnag notes from NIP-50 search without caching them as products", async () => {

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_NIP50_SEARCH_RELAYS,
   dedupeProductEvents,
   fetchNip50ProductSearch,
+  NIP50_SEARCH_TIMEOUT_MS,
 } from "../fetch-service";
 
 jest.mock("@/utils/db/db-client", () => ({
@@ -507,7 +508,7 @@ describe("fetch-service NIP-50 search helpers", () => {
     jest.clearAllMocks();
   });
 
-  it("builds NIP-50 search filters for marketplace listings and flash sales", () => {
+  it("builds NIP-50 search filters only for marketplace listings", () => {
     expect(
       buildNip50ProductSearchFilters("  cold   brew  ", {
         authors: ["seller-1"],
@@ -516,13 +517,6 @@ describe("fetch-service NIP-50 search helpers", () => {
     ).toEqual([
       {
         kinds: [30402],
-        search: "cold brew",
-        limit: 25,
-        authors: ["seller-1"],
-      },
-      {
-        kinds: [1],
-        "#t": ["shopstr-zapsnag", "zapsnag"],
         search: "cold brew",
         limit: 25,
         authors: ["seller-1"],
@@ -600,10 +594,10 @@ describe("fetch-service NIP-50 search helpers", () => {
     expect(nostr.fetch).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ kinds: [30402], search: "coffee" }),
-        expect.objectContaining({ kinds: [1], search: "coffee" }),
       ]),
       {},
-      ["wss://relay.example"]
+      DEFAULT_NIP50_SEARCH_RELAYS,
+      NIP50_SEARCH_TIMEOUT_MS
     );
     expect(result.productEvents).toEqual([newer]);
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([older, newer]);
@@ -699,8 +693,53 @@ describe("fetch-service NIP-50 search helpers", () => {
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([relevant]);
   });
 
-  it("falls back to default NIP-50 relays when selected relays return no relevant product results", async () => {
-    const fallbackListing = {
+  it("preserves relay relevance order for distinct NIP-50 search results", async () => {
+    const firstRelayResult = {
+      id: "older-but-more-relevant",
+      pubkey: "seller-1",
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "coffee-1"],
+        ["title", "Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "Top-ranked coffee result",
+      sig: "sig-older",
+    };
+    const secondRelayResult = {
+      id: "newer-but-less-relevant",
+      pubkey: "seller-2",
+      created_at: 100,
+      kind: 30402,
+      tags: [
+        ["d", "coffee-2"],
+        ["title", "Coffee Roaster"],
+        ["price", "20", "USD"],
+      ],
+      content: "Second-ranked coffee result",
+      sig: "sig-newer",
+    };
+    const nostr = {
+      fetch: jest
+        .fn()
+        .mockResolvedValue([firstRelayResult, secondRelayResult]),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      [],
+      "coffee"
+    );
+
+    expect(result.productEvents).toEqual([
+      firstRelayResult,
+      secondRelayResult,
+    ]);
+  });
+
+  it("routes search to curated NIP-50 relays instead of general user relays", async () => {
+    const searchListing = {
       id: "fallback-product",
       pubkey: "fallback-seller",
       created_at: 30,
@@ -714,32 +753,49 @@ describe("fetch-service NIP-50 search helpers", () => {
       sig: "sig-fallback",
     };
     const nostr = {
-      fetch: jest
-        .fn()
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([fallbackListing]),
+      fetch: jest.fn().mockResolvedValue([searchListing]),
     };
 
     const result = await fetchNip50ProductSearch(
       nostr as unknown as NostrManager,
-      ["wss://relay.without-search.example"],
+      ["wss://relay.damus.io", "wss://nos.lol"],
       "coffee"
     );
 
-    expect(nostr.fetch).toHaveBeenNthCalledWith(
-      1,
+    expect(nostr.fetch).toHaveBeenCalledWith(
       expect.any(Array),
       {},
-      ["wss://relay.without-search.example"]
+      DEFAULT_NIP50_SEARCH_RELAYS,
+      NIP50_SEARCH_TIMEOUT_MS
     );
-    expect(nostr.fetch).toHaveBeenNthCalledWith(
-      2,
+    expect(result.productEvents).toEqual([searchListing]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([searchListing]);
+  });
+
+  it("keeps known selected NIP-50 relays while dropping unsupported selected relays", async () => {
+    const selectedSearchRelay = "wss://relay.nostr.band";
+    const searchRelays = [
+      selectedSearchRelay,
+      ...DEFAULT_NIP50_SEARCH_RELAYS.filter(
+        (relay) => relay !== selectedSearchRelay
+      ),
+    ];
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([]),
+    };
+
+    await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://relay.damus.io", "relay.nostr.band/", "wss://nos.lol"],
+      "coffee"
+    );
+
+    expect(nostr.fetch).toHaveBeenCalledWith(
       expect.any(Array),
       {},
-      DEFAULT_NIP50_SEARCH_RELAYS
+      searchRelays,
+      NIP50_SEARCH_TIMEOUT_MS
     );
-    expect(result.productEvents).toEqual([fallbackListing]);
-    expect(cacheEventsToDatabase).toHaveBeenCalledWith([fallbackListing]);
   });
 
   it("uses default NIP-50 relays when no selected relays are available", async () => {
@@ -769,12 +825,13 @@ describe("fetch-service NIP-50 search helpers", () => {
     expect(nostr.fetch).toHaveBeenCalledWith(
       expect.any(Array),
       {},
-      DEFAULT_NIP50_SEARCH_RELAYS
+      DEFAULT_NIP50_SEARCH_RELAYS,
+      NIP50_SEARCH_TIMEOUT_MS
     );
     expect(result.productEvents).toEqual([fallbackListing]);
   });
 
-  it("returns matching zapsnag notes from NIP-50 search without caching them as products", async () => {
+  it("ignores non-listing events returned by NIP-50 search relays", async () => {
     const zapsnagNote = {
       id: "zapsnag-coffee",
       pubkey: "seller-1",
@@ -795,7 +852,7 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expect(result.productEvents).toEqual([zapsnagNote]);
+    expect(result.productEvents).toEqual([]);
     expect(cacheEventsToDatabase).not.toHaveBeenCalled();
   });
 });

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -1,3 +1,16 @@
+import { NostrEvent, NostrManager } from "../nostr-manager";
+import {
+  buildNip50ProductSearchFilters,
+  dedupeProductEvents,
+  fetchNip50ProductSearch,
+} from "../fetch-service";
+
+jest.mock("@/utils/db/db-client", () => ({
+  cacheEventsToDatabase: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { cacheEventsToDatabase } = jest.requireMock("@/utils/db/db-client");
+
 const makeBaseEvent = (overrides: Record<string, any> = {}) => ({
   id: "event-id",
   pubkey: "pubkey",
@@ -72,7 +85,7 @@ describe("fetchAllPosts - NIP-99 and relay merge behavior", () => {
     expect(profileSetFromProducts).toEqual(new Set(["seller"]));
   });
 
-  it("includes kind 1 zapsnag notes alongside kind 30402 product events and caches both", async () => {
+  it("includes kind 1 zapsnag notes alongside kind 30402 product events and only caches products", async () => {
     const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
 
     jest.doMock("@/utils/db/db-client", () => ({
@@ -118,7 +131,7 @@ describe("fetchAllPosts - NIP-99 and relay merge behavior", () => {
     expect(productEvents).toEqual(
       expect.arrayContaining([product, zapsnagNote])
     );
-    expect(cacheEventsToDatabase).toHaveBeenCalledWith([product, zapsnagNote]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([product]);
     expect(profileSetFromProducts).toEqual(new Set(["seller-p"]));
   });
 
@@ -485,6 +498,225 @@ describe("getUniqueProofs", () => {
     expect(dedupedProofs).toEqual([firstProof, uniqueProof]);
     expect(dedupedProofs).not.toContain(duplicateProof);
     expect(dedupedProofs).toHaveLength(2);
+  });
+});
+
+describe("fetch-service NIP-50 search helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("builds NIP-50 search filters for marketplace listings and flash sales", () => {
+    expect(
+      buildNip50ProductSearchFilters("  cold   brew  ", {
+        authors: ["seller-1"],
+        limit: 25,
+      })
+    ).toEqual([
+      {
+        kinds: [30402],
+        search: "cold brew",
+        limit: 25,
+        authors: ["seller-1"],
+      },
+      {
+        kinds: [1],
+        "#t": ["shopstr-zapsnag", "zapsnag"],
+        search: "cold brew",
+        limit: 25,
+        authors: ["seller-1"],
+      },
+    ]);
+  });
+
+  it("deduplicates replaceable listing events by address and keeps the latest version", () => {
+    const older = {
+      id: "older",
+      pubkey: "seller-1",
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "coffee"],
+        ["title", "Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "old coffee",
+      sig: "sig-older",
+    };
+    const newer = {
+      ...older,
+      id: "newer",
+      created_at: 20,
+      content: "new coffee",
+      sig: "sig-newer",
+    };
+
+    expect(dedupeProductEvents([older, newer] as NostrEvent[])).toEqual([
+      newer,
+    ]);
+  });
+
+  it("fetches NIP-50 product results, deduplicates them, and caches valid events", async () => {
+    const older = {
+      id: "older",
+      pubkey: "seller-1",
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "coffee"],
+        ["title", "Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "old coffee",
+      sig: "sig-older",
+    };
+    const newer = {
+      ...older,
+      id: "newer",
+      created_at: 20,
+      content: "new coffee",
+      sig: "sig-newer",
+    };
+    const invalid = {
+      id: "",
+      pubkey: "seller-2",
+      created_at: 30,
+      kind: 30402,
+      tags: [["d", "tea"]],
+      content: "tea",
+      sig: "sig-invalid",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([older, newer, invalid]),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://relay.example"],
+      "coffee"
+    );
+
+    expect(nostr.fetch).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ kinds: [30402], search: "coffee" }),
+        expect.objectContaining({ kinds: [1], search: "coffee" }),
+      ]),
+      {},
+      ["wss://relay.example"]
+    );
+    expect(result.productEvents).toEqual([newer]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([older, newer]);
+  });
+
+  it("waits for relevant kind 30402 search results to be cached before returning them", async () => {
+    const product = {
+      id: "coffee-product",
+      pubkey: "seller-1",
+      created_at: 20,
+      kind: 30402,
+      tags: [
+        ["d", "coffee"],
+        ["title", "Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "Fresh roasted coffee",
+      sig: "sig-coffee",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([product]),
+    };
+    let resolveCache!: () => void;
+    (cacheEventsToDatabase as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCache = resolve;
+        })
+    );
+
+    let didResolve = false;
+    const searchPromise = fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://relay.example"],
+      "coffee"
+    ).then((result) => {
+      didResolve = true;
+      return result;
+    });
+
+    await Promise.resolve();
+    expect(didResolve).toBe(false);
+
+    resolveCache();
+    const result = await searchPromise;
+
+    expect(result.productEvents).toEqual([product]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([product]);
+  });
+
+  it("filters unsupported-relay noise before returning or caching search results", async () => {
+    const relevant = {
+      id: "coffee-product",
+      pubkey: "seller-1",
+      created_at: 20,
+      kind: 30402,
+      tags: [
+        ["d", "coffee"],
+        ["title", "Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "Fresh roasted coffee",
+      sig: "sig-coffee",
+    };
+    const unrelated = {
+      id: "tea-product",
+      pubkey: "seller-2",
+      created_at: 30,
+      kind: 30402,
+      tags: [
+        ["d", "tea"],
+        ["title", "Tea Leaves"],
+        ["price", "8", "USD"],
+      ],
+      content: "Green tea",
+      sig: "sig-tea",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([unrelated, relevant]),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://relay.example"],
+      "coffee"
+    );
+
+    expect(result.productEvents).toEqual([relevant]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([relevant]);
+  });
+
+  it("returns matching zapsnag notes from NIP-50 search without caching them as products", async () => {
+    const zapsnagNote = {
+      id: "zapsnag-coffee",
+      pubkey: "seller-1",
+      created_at: 20,
+      kind: 1,
+      tags: [["t", "shopstr-zapsnag"]],
+      content:
+        "Coffee beans price: 100 sats #zapsnag https://example.com/coffee.png",
+      sig: "sig-zapsnag",
+    };
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([zapsnagNote]),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://relay.example"],
+      "coffee"
+    );
+
+    expect(result.productEvents).toEqual([zapsnagNote]);
+    expect(cacheEventsToDatabase).not.toHaveBeenCalled();
   });
 });
 
@@ -1224,10 +1456,7 @@ describe("fetchAllPosts", () => {
       new Set(["seller", "zapsnag-seller"])
     );
     expect(editProductContext).toHaveBeenLastCalledWith(productEvents, false);
-    expect(cacheEventsToDatabase).toHaveBeenCalledWith([
-      newerRelayListing,
-      relayNoteListing,
-    ]);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([newerRelayListing]);
   });
 });
 

--- a/utils/nostr/__tests__/nostr-manager.test.ts
+++ b/utils/nostr/__tests__/nostr-manager.test.ts
@@ -16,6 +16,8 @@ const FakePool = jest.fn().mockImplementation(() => fakePoolInstance);
 const nip07 = { fromJSON: jest.fn() };
 const nsec = { fromJSON: jest.fn() };
 const nip46 = { fromJSON: jest.fn() };
+let timeoutOptionsMock: any[];
+let latestAbortController: AbortController | undefined;
 
 describe("NostrManager", () => {
   let NostrManager: any;
@@ -25,6 +27,8 @@ describe("NostrManager", () => {
     jest.clearAllMocks();
     relayConnectMock = jest.fn().mockResolvedValue(undefined);
     relayCloseMock = jest.fn().mockResolvedValue(undefined);
+    timeoutOptionsMock = [];
+    latestAbortController = undefined;
 
     jest.doMock("nostr-tools", () => ({
       SimplePool: FakePool,
@@ -40,8 +44,14 @@ describe("NostrManager", () => {
       NostrNIP46Signer: nip46,
     }));
     jest.doMock("../../timeout", () => ({
-      newPromiseWithTimeout: (fn: any) =>
-        new Promise((resolve, reject) => fn(resolve, reject)),
+      newPromiseWithTimeout: (fn: any, options: any) => {
+        timeoutOptionsMock.push(options);
+        const abortController = new AbortController();
+        latestAbortController = abortController;
+        return new Promise((resolve, reject) =>
+          fn(resolve, reject, abortController.signal)
+        );
+      },
     }));
 
     const mod = await import("../nostr-manager");
@@ -192,6 +202,63 @@ describe("NostrManager", () => {
       await publishPromise;
 
       expect(fakePoolInstance.publish).toHaveBeenCalledWith(["p1"], evt);
+    });
+  });
+
+  describe("fetch()", () => {
+    let mgr: any;
+    const waitForSubscribeMap = async () => {
+      for (
+        let index = 0;
+        index < 5 && fakePoolInstance.subscribeMap.mock.calls.length === 0;
+        index += 1
+      ) {
+        await Promise.resolve();
+      }
+      for (let index = 0; index < 5; index += 1) {
+        await Promise.resolve();
+      }
+    };
+
+    beforeEach(() => {
+      mgr = new NostrManager(["u1"], { readable: true });
+      mgr.relays[0].sleeping = false;
+      verifyEventMock.mockReturnValue(true);
+    });
+
+    it("forwards timeout options and closes the subscription on EOSE", async () => {
+      const subClose = jest.fn();
+      fakePoolInstance.subscribeMap.mockReturnValueOnce({ close: subClose });
+
+      const fetchPromise = mgr.fetch([{ kinds: [30402] }], {}, ["u1"], 1234);
+      await waitForSubscribeMap();
+
+      const params = fakePoolInstance.subscribeMap.mock.calls[0][1];
+      params.onevent({ id: "product-1" });
+      params.oneose();
+
+      await expect(fetchPromise).resolves.toEqual([{ id: "product-1" }]);
+      expect(timeoutOptionsMock).toEqual([{ timeout: 1234 }]);
+      expect(subClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the subscription when the fetch timeout aborts", async () => {
+      const subClose = jest.fn();
+      fakePoolInstance.subscribeMap.mockReturnValueOnce({ close: subClose });
+
+      const fetchPromise = mgr.fetch([{ kinds: [30402] }], {}, ["u1"], 1234);
+      await waitForSubscribeMap();
+
+      latestAbortController!.abort();
+      await Promise.resolve();
+
+      expect(subClose).toHaveBeenCalledTimes(1);
+
+      const params = fakePoolInstance.subscribeMap.mock.calls[0][1];
+      params.oneose();
+      await fetchPromise;
+
+      expect(subClose).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -180,15 +180,24 @@ export async function fetchNip50ProductSearch(
 
   const searchRelays = getNip50SearchRelays(relays);
 
-  const fetchSearchEvents = (targetRelays: string[]) => {
+  const fetchSearchEvents = async (targetRelays: string[]) => {
     if (targetRelays.length === 0) return Promise.resolve([]);
 
-    return nostr
-      .fetch(filters, {}, targetRelays, NIP50_SEARCH_TIMEOUT_MS)
-      .catch((error) => {
-        console.warn("Failed to search products with NIP-50 relays:", error);
-        return [];
-      });
+    const relayResults = await Promise.all(
+      targetRelays.map((relay) =>
+        nostr
+          .fetch(filters, {}, [relay], NIP50_SEARCH_TIMEOUT_MS)
+          .catch((error) => {
+            console.warn(
+              `Failed to search products with NIP-50 relay ${relay}:`,
+              error
+            );
+            return [];
+          })
+      )
+    );
+
+    return relayResults.flat();
   };
 
   const filterSearchProductEvents = (events: NostrEvent[]) =>
@@ -203,7 +212,11 @@ export async function fetchNip50ProductSearch(
     eventMatchesProductSearch(event, searchQuery)
   );
 
-  const cacheableProductEvents = relevantSearchProductEvents.filter(
+  const dedupedSearchProductEvents = dedupeProductEvents(
+    relevantSearchProductEvents
+  );
+
+  const cacheableProductEvents = dedupedSearchProductEvents.filter(
     (event) => event.kind === 30402
   );
 
@@ -216,7 +229,7 @@ export async function fetchNip50ProductSearch(
   }
 
   return {
-    productEvents: dedupeProductEvents(relevantSearchProductEvents),
+    productEvents: dedupedSearchProductEvents,
   };
 }
 

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -20,6 +20,8 @@ import {
   ProductData,
   parseTags,
 } from "@/utils/parsers/product-parser-functions";
+import { productSatisfiesSearchFilter } from "@/utils/parsers/product-filter-helpers";
+import { parseZapsnagNote } from "@/utils/parsers/zapsnag-parser";
 import { parseCommunityEvent } from "../parsers/community-parser-functions";
 import { calculateWeightedScore } from "@/utils/parsers/review-parser-functions";
 import { hashToCurve } from "@cashu/cashu-ts";
@@ -37,6 +39,139 @@ interface NipProfile {
   created_at: number;
   content: { nip05?: string; [key: string]: any };
   nip05Verified: boolean;
+}
+
+type SearchFilter = Filter & { search: string };
+
+const PRODUCT_SEARCH_LIMIT = 100;
+
+export function getProductEventKey(event: NostrEvent): string {
+  if (event.kind === 30402) {
+    const dTag = event.tags?.find((tag: string[]) => tag[0] === "d")?.[1];
+    if (dTag) return `${event.kind}:${event.pubkey}:${dTag}`;
+  }
+
+  return `${event.kind}:${event.id}`;
+}
+
+export function dedupeProductEvents(events: NostrEvent[]): NostrEvent[] {
+  const eventMap = new Map<string, NostrEvent>();
+  const orderedKeys: string[] = [];
+
+  for (const event of events) {
+    if (!event?.id) continue;
+
+    const key = getProductEventKey(event);
+    const existing = eventMap.get(key);
+
+    if (!existing) {
+      orderedKeys.push(key);
+      eventMap.set(key, event);
+      continue;
+    }
+
+    if ((event.created_at ?? 0) >= (existing.created_at ?? 0)) {
+      eventMap.set(key, event);
+    }
+  }
+
+  return orderedKeys
+    .map((key) => eventMap.get(key))
+    .filter((event): event is NostrEvent => !!event);
+}
+
+export function buildNip50ProductSearchFilters(
+  searchQuery: string,
+  options: { authors?: string[]; limit?: number } = {}
+): SearchFilter[] {
+  const search = searchQuery.trim().replace(/\s+/g, " ");
+  if (!search) return [];
+
+  const limit = options.limit ?? PRODUCT_SEARCH_LIMIT;
+  const baseFilter = {
+    search,
+    limit,
+    ...(options.authors?.length ? { authors: options.authors } : {}),
+  };
+
+  return [
+    {
+      ...baseFilter,
+      kinds: [30402],
+    },
+    {
+      ...baseFilter,
+      kinds: [1],
+      "#t": ["shopstr-zapsnag", "zapsnag"],
+    },
+  ];
+}
+
+function eventMatchesProductSearch(
+  event: NostrEvent,
+  searchQuery: string
+): boolean {
+  if (event.kind === 30402) {
+    const parsedProduct = parseTags(event);
+    return (
+      !!parsedProduct &&
+      productSatisfiesSearchFilter(parsedProduct, searchQuery)
+    );
+  }
+
+  if (event.kind === 1) {
+    const tags = event.tags
+      ?.filter((tag) => tag[0] === "t")
+      .map((tag) => tag[1]);
+    if (!tags?.some((tag) => tag === "shopstr-zapsnag" || tag === "zapsnag")) {
+      return false;
+    }
+
+    return productSatisfiesSearchFilter(parseZapsnagNote(event), searchQuery);
+  }
+
+  return false;
+}
+
+export async function fetchNip50ProductSearch(
+  nostr: NostrManager,
+  relays: string[],
+  searchQuery: string,
+  options: { authors?: string[]; limit?: number } = {}
+): Promise<{
+  productEvents: NostrEvent[];
+}> {
+  const filters = buildNip50ProductSearchFilters(searchQuery, options);
+  if (!filters.length || !relays.length) {
+    return { productEvents: [] };
+  }
+
+  const fetchedEvents = await nostr.fetch(filters, {}, relays);
+  const searchProductEvents = fetchedEvents.filter(
+    (event) =>
+      event.id &&
+      event.sig &&
+      event.pubkey &&
+      (event.kind === 30402 || event.kind === 1)
+  );
+  const relevantSearchProductEvents = searchProductEvents.filter((event) =>
+    eventMatchesProductSearch(event, searchQuery)
+  );
+  const cacheableProductEvents = relevantSearchProductEvents.filter(
+    (event) => event.kind === 30402
+  );
+
+  if (cacheableProductEvents.length > 0) {
+    try {
+      await cacheEventsToDatabase(cacheableProductEvents);
+    } catch (error) {
+      console.error("Failed to cache NIP-50 product search events:", error);
+    }
+  }
+
+  return {
+    productEvents: dedupeProductEvents(relevantSearchProductEvents),
+  };
 }
 
 export function getUniqueProofs(proofs: Proof[]): Proof[] {
@@ -69,11 +204,7 @@ export const fetchAllPosts = async (
       const dbProductsMap = new Map<string, NostrEvent>();
 
       const getEventKey = (event: NostrEvent): string => {
-        if (event.kind === 30402) {
-          const dTag = event.tags?.find((tag: string[]) => tag[0] === "d")?.[1];
-          if (dTag) return `${event.pubkey}:${dTag}`;
-        }
-        return event.id;
+        return getProductEventKey(event);
       };
       const isValidProductRelayEvent = (
         event: NostrEvent | null | undefined
@@ -135,7 +266,10 @@ export const fetchAllPosts = async (
       }
 
       // Cache valid product events to database
-      const validProductEvents = fetchedEvents.filter(isValidProductRelayEvent);
+      const validProductEvents = fetchedEvents.filter(
+        (event): event is NostrEvent =>
+          isValidProductRelayEvent(event) && event.kind === 30402
+      );
       if (validProductEvents.length > 0) {
         cacheEventsToDatabase(validProductEvents).catch((error) =>
           console.error("Failed to cache products to database:", error)

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -193,11 +193,7 @@ export async function fetchNip50ProductSearch(
 
   const filterSearchProductEvents = (events: NostrEvent[]) =>
     events.filter(
-      (event) =>
-        event.id &&
-        event.sig &&
-        event.pubkey &&
-        event.kind === 30402
+      (event) => event.id && event.sig && event.pubkey && event.kind === 30402
     );
 
   let searchProductEvents = filterSearchProductEvents(

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -44,6 +44,35 @@ interface NipProfile {
 type SearchFilter = Filter & { search: string };
 
 const PRODUCT_SEARCH_LIMIT = 100;
+export const DEFAULT_NIP50_SEARCH_RELAYS = [
+  "wss://relay.noswhere.com",
+  "wss://search.nos.today",
+  "wss://antiprimal.net",
+  "wss://relay.ditto.pub",
+];
+
+function normalizeRelayUrl(relay: string): string {
+  const trimmedRelay = relay.trim();
+  if (!trimmedRelay) return "";
+
+  const relayWithProtocol = /^wss?:\/\//i.test(trimmedRelay)
+    ? trimmedRelay
+    : `wss://${trimmedRelay}`;
+
+  return relayWithProtocol.replace(/\/+$/, "");
+}
+
+function getUniqueRelayUrls(relays: string[]): string[] {
+  const relayMap = new Map<string, string>();
+
+  for (const relay of relays) {
+    const normalizedRelay = normalizeRelayUrl(relay);
+    if (!normalizedRelay) continue;
+    relayMap.set(normalizedRelay.toLowerCase(), normalizedRelay);
+  }
+
+  return Array.from(relayMap.values());
+}
 
 export function getProductEventKey(event: NostrEvent): string {
   if (event.kind === 30402) {
@@ -142,21 +171,54 @@ export async function fetchNip50ProductSearch(
   productEvents: NostrEvent[];
 }> {
   const filters = buildNip50ProductSearchFilters(searchQuery, options);
-  if (!filters.length || !relays.length) {
+  if (!filters.length) {
     return { productEvents: [] };
   }
 
-  const fetchedEvents = await nostr.fetch(filters, {}, relays);
-  const searchProductEvents = fetchedEvents.filter(
-    (event) =>
-      event.id &&
-      event.sig &&
-      event.pubkey &&
-      (event.kind === 30402 || event.kind === 1)
+  const primaryRelays = getUniqueRelayUrls(relays);
+  const primaryRelaySet = new Set(
+    primaryRelays.map((relay) => relay.toLowerCase())
   );
-  const relevantSearchProductEvents = searchProductEvents.filter((event) =>
+  const fallbackRelays = getUniqueRelayUrls(
+    DEFAULT_NIP50_SEARCH_RELAYS.filter(
+      (relay) => !primaryRelaySet.has(normalizeRelayUrl(relay).toLowerCase())
+    )
+  );
+
+  const fetchSearchEvents = (targetRelays: string[]) => {
+    if (targetRelays.length === 0) return Promise.resolve([]);
+
+    return nostr.fetch(filters, {}, targetRelays).catch((error) => {
+      console.warn("Failed to search products with NIP-50 relays:", error);
+      return [];
+    });
+  };
+
+  const filterSearchProductEvents = (events: NostrEvent[]) =>
+    events.filter(
+      (event) =>
+        event.id &&
+        event.sig &&
+        event.pubkey &&
+        (event.kind === 30402 || event.kind === 1)
+    );
+
+  let searchProductEvents = filterSearchProductEvents(
+    await fetchSearchEvents(primaryRelays)
+  );
+  let relevantSearchProductEvents = searchProductEvents.filter((event) =>
     eventMatchesProductSearch(event, searchQuery)
   );
+
+  if (relevantSearchProductEvents.length === 0) {
+    searchProductEvents = filterSearchProductEvents(
+      await fetchSearchEvents(fallbackRelays)
+    );
+    relevantSearchProductEvents = searchProductEvents.filter((event) =>
+      eventMatchesProductSearch(event, searchQuery)
+    );
+  }
+
   const cacheableProductEvents = relevantSearchProductEvents.filter(
     (event) => event.kind === 30402
   );

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -21,7 +21,6 @@ import {
   parseTags,
 } from "@/utils/parsers/product-parser-functions";
 import { productSatisfiesSearchFilter } from "@/utils/parsers/product-filter-helpers";
-import { parseZapsnagNote } from "@/utils/parsers/zapsnag-parser";
 import { parseCommunityEvent } from "../parsers/community-parser-functions";
 import { calculateWeightedScore } from "@/utils/parsers/review-parser-functions";
 import { hashToCurve } from "@cashu/cashu-ts";
@@ -44,7 +43,10 @@ interface NipProfile {
 type SearchFilter = Filter & { search: string };
 
 const PRODUCT_SEARCH_LIMIT = 100;
+export const NIP50_SEARCH_TIMEOUT_MS = 10_000;
 export const DEFAULT_NIP50_SEARCH_RELAYS = [
+  "wss://relay.nostr.band",
+  "wss://nostr.wine",
   "wss://relay.noswhere.com",
   "wss://search.nos.today",
   "wss://antiprimal.net",
@@ -72,6 +74,23 @@ function getUniqueRelayUrls(relays: string[]): string[] {
   }
 
   return Array.from(relayMap.values());
+}
+
+function getNip50SearchRelays(relays: string[]): string[] {
+  const knownSearchRelaySet = new Set(
+    DEFAULT_NIP50_SEARCH_RELAYS.map((relay) => relay.toLowerCase())
+  );
+  const selectedSearchRelays = getUniqueRelayUrls(relays).filter((relay) =>
+    knownSearchRelaySet.has(relay.toLowerCase())
+  );
+  const selectedSearchRelaySet = new Set(
+    selectedSearchRelays.map((relay) => relay.toLowerCase())
+  );
+  const backupSearchRelays = DEFAULT_NIP50_SEARCH_RELAYS.filter(
+    (relay) => !selectedSearchRelaySet.has(relay.toLowerCase())
+  );
+
+  return [...selectedSearchRelays, ...backupSearchRelays];
 }
 
 export function getProductEventKey(event: NostrEvent): string {
@@ -128,11 +147,6 @@ export function buildNip50ProductSearchFilters(
       ...baseFilter,
       kinds: [30402],
     },
-    {
-      ...baseFilter,
-      kinds: [1],
-      "#t": ["shopstr-zapsnag", "zapsnag"],
-    },
   ];
 }
 
@@ -146,17 +160,6 @@ function eventMatchesProductSearch(
       !!parsedProduct &&
       productSatisfiesSearchFilter(parsedProduct, searchQuery)
     );
-  }
-
-  if (event.kind === 1) {
-    const tags = event.tags
-      ?.filter((tag) => tag[0] === "t")
-      .map((tag) => tag[1]);
-    if (!tags?.some((tag) => tag === "shopstr-zapsnag" || tag === "zapsnag")) {
-      return false;
-    }
-
-    return productSatisfiesSearchFilter(parseZapsnagNote(event), searchQuery);
   }
 
   return false;
@@ -175,23 +178,17 @@ export async function fetchNip50ProductSearch(
     return { productEvents: [] };
   }
 
-  const primaryRelays = getUniqueRelayUrls(relays);
-  const primaryRelaySet = new Set(
-    primaryRelays.map((relay) => relay.toLowerCase())
-  );
-  const fallbackRelays = getUniqueRelayUrls(
-    DEFAULT_NIP50_SEARCH_RELAYS.filter(
-      (relay) => !primaryRelaySet.has(normalizeRelayUrl(relay).toLowerCase())
-    )
-  );
+  const searchRelays = getNip50SearchRelays(relays);
 
   const fetchSearchEvents = (targetRelays: string[]) => {
     if (targetRelays.length === 0) return Promise.resolve([]);
 
-    return nostr.fetch(filters, {}, targetRelays).catch((error) => {
-      console.warn("Failed to search products with NIP-50 relays:", error);
-      return [];
-    });
+    return nostr
+      .fetch(filters, {}, targetRelays, NIP50_SEARCH_TIMEOUT_MS)
+      .catch((error) => {
+        console.warn("Failed to search products with NIP-50 relays:", error);
+        return [];
+      });
   };
 
   const filterSearchProductEvents = (events: NostrEvent[]) =>
@@ -200,24 +197,15 @@ export async function fetchNip50ProductSearch(
         event.id &&
         event.sig &&
         event.pubkey &&
-        (event.kind === 30402 || event.kind === 1)
+        event.kind === 30402
     );
 
   let searchProductEvents = filterSearchProductEvents(
-    await fetchSearchEvents(primaryRelays)
+    await fetchSearchEvents(searchRelays)
   );
   let relevantSearchProductEvents = searchProductEvents.filter((event) =>
     eventMatchesProductSearch(event, searchQuery)
   );
-
-  if (relevantSearchProductEvents.length === 0) {
-    searchProductEvents = filterSearchProductEvents(
-      await fetchSearchEvents(fallbackRelays)
-    );
-    relevantSearchProductEvents = searchProductEvents.filter((event) =>
-      eventMatchesProductSearch(event, searchQuery)
-    );
-  }
 
   const cacheableProductEvents = relevantSearchProductEvents.filter(
     (event) => event.kind === 30402

--- a/utils/nostr/nostr-manager.ts
+++ b/utils/nostr/nostr-manager.ts
@@ -174,55 +174,58 @@ export class NostrManager {
     relayUrls?: string[],
     timeout?: number
   ): Promise<NostrEvent[]> {
-    return await newPromiseWithTimeout(async (resolve, _reject, abortSignal) => {
-      if (!params) {
-        params = {};
-      }
-
-      if (!params.onevent) {
-        params.onevent = () => {};
-      }
-
-      if (!params.oneose) {
-        params.oneose = () => {};
-      }
-
-      const onEvent = params.onevent;
-      const onEose = params.oneose;
-      const fetchedEvents: Array<NostrEvent> = [];
-      let sub: NostrSub | undefined;
-      let didCloseSub = false;
-      let didResolve = false;
-
-      const closeSubIfNeeded = async () => {
-        if (!sub || didCloseSub) return;
-        didCloseSub = true;
-        await sub.close();
-      };
-
-      abortSignal.addEventListener("abort", () => {
-        closeSubIfNeeded().catch(console.error);
-      });
-
-      params.onevent = (event: NostrEvent) => {
-        fetchedEvents.push(event);
-        return onEvent!(event);
-      };
-
-      params.oneose = () => {
-        closeSubIfNeeded().catch(console.error);
-        if (!didResolve) {
-          didResolve = true;
-          resolve(fetchedEvents);
+    return await newPromiseWithTimeout(
+      async (resolve, _reject, abortSignal) => {
+        if (!params) {
+          params = {};
         }
-        return onEose!();
-      };
 
-      sub = await this.subscribe(filters, params, relayUrls);
-      if (abortSignal.aborted) {
-        await closeSubIfNeeded();
-      }
-    }, { timeout });
+        if (!params.onevent) {
+          params.onevent = () => {};
+        }
+
+        if (!params.oneose) {
+          params.oneose = () => {};
+        }
+
+        const onEvent = params.onevent;
+        const onEose = params.oneose;
+        const fetchedEvents: Array<NostrEvent> = [];
+        let sub: NostrSub | undefined;
+        let didCloseSub = false;
+        let didResolve = false;
+
+        const closeSubIfNeeded = async () => {
+          if (!sub || didCloseSub) return;
+          didCloseSub = true;
+          await sub.close();
+        };
+
+        abortSignal.addEventListener("abort", () => {
+          closeSubIfNeeded().catch(console.error);
+        });
+
+        params.onevent = (event: NostrEvent) => {
+          fetchedEvents.push(event);
+          return onEvent!(event);
+        };
+
+        params.oneose = () => {
+          closeSubIfNeeded().catch(console.error);
+          if (!didResolve) {
+            didResolve = true;
+            resolve(fetchedEvents);
+          }
+          return onEose!();
+        };
+
+        sub = await this.subscribe(filters, params, relayUrls);
+        if (abortSignal.aborted) {
+          await closeSubIfNeeded();
+        }
+      },
+      { timeout }
+    );
   }
 
   public async publish(event: NostrEvent, relayUrls?: string[]): Promise<void> {

--- a/utils/nostr/nostr-manager.ts
+++ b/utils/nostr/nostr-manager.ts
@@ -171,9 +171,10 @@ export class NostrManager {
   public async fetch(
     filters: NostrFilter[],
     params?: SubscribeManyParams,
-    relayUrls?: string[]
+    relayUrls?: string[],
+    timeout?: number
   ): Promise<NostrEvent[]> {
-    return await newPromiseWithTimeout(async (resolve, _reject) => {
+    return await newPromiseWithTimeout(async (resolve, _reject, abortSignal) => {
       if (!params) {
         params = {};
       }
@@ -199,6 +200,10 @@ export class NostrManager {
         await sub.close();
       };
 
+      abortSignal.addEventListener("abort", () => {
+        closeSubIfNeeded().catch(console.error);
+      });
+
       params.onevent = (event: NostrEvent) => {
         fetchedEvents.push(event);
         return onEvent!(event);
@@ -214,7 +219,10 @@ export class NostrManager {
       };
 
       sub = await this.subscribe(filters, params, relayUrls);
-    });
+      if (abortSignal.aborted) {
+        await closeSubIfNeeded();
+      }
+    }, { timeout });
   }
 
   public async publish(event: NostrEvent, relayUrls?: string[]): Promise<void> {


### PR DESCRIPTION
this PR adds Nip 50 search for marketplace listings so Shopstr can ask search capable relays for matching products instead of only filtering locally. It keeps regular browsing separate, uses backup search relays, deduplicates listing results, and handles slow relays better so one bad relay does not break the whole search.

<img width="1280" height="832" alt="Screenshot 2026-06-10 at 04 58 45" src="https://github.com/user-attachments/assets/24760027-341a-4540-b202-dbdc35d76aef" />

<img width="729" height="402" alt="Screenshot 2026-06-10 at 05 30 19" src="https://github.com/user-attachments/assets/2e087920-84d5-4a16-b3a8-bbc88e9bf681" />



<img width="1280" height="832" alt="Screenshot 2026-06-10 at 05 16 47" src="https://github.com/user-attachments/assets/69aff0cf-3211-4a0d-9dd5-17f8ad634a9c" />
