### PR TITLE
Validate OpenGraph preview URLs before rendering

### DIFF
--- a/components/messages/__tests__/link-preview.test.tsx
+++ b/components/messages/__tests__/link-preview.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import LinkPreview from "../link-preview";
+
+describe("LinkPreview", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  it("does not render a script scheme from OpenGraph data as the preview href", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        title: "Order receipt",
+        url: "javascript:alert(1)",
+      }),
+    });
+
+    render(
+      <LinkPreview url="https://attacker.example/order" isUserMessage={false} />
+    );
+
+    const title = await screen.findByText("Order receipt");
+    const previewLink = title.closest("a");
+
+    await waitFor(() => {
+      expect(previewLink).toHaveAttribute(
+        "href",
+        "https://attacker.example/order"
+      );
+    });
+  });
+
+  it("uses safe OpenGraph URLs for the preview href", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        title: "Order receipt",
+        url: "https://seller.example/orders/123",
+      }),
+    });
+
+    render(
+      <LinkPreview url="https://seller.example/listing" isUserMessage={false} />
+    );
+
+    const title = await screen.findByText("Order receipt");
+    expect(title.closest("a")).toHaveAttribute(
+      "href",
+      "https://seller.example/orders/123"
+    );
+  });
+});

--- a/components/messages/link-preview.tsx
+++ b/components/messages/link-preview.tsx
@@ -9,6 +9,19 @@ type OGData = {
 
 type Status = "loading" | "preview" | "link";
 
+function getSafePreviewHref(value: string | undefined, fallback: string) {
+  const candidate = value || fallback;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return fallback;
+    }
+    return parsed.toString();
+  } catch {
+    return fallback;
+  }
+}
+
 const LinkPreview = ({
   url,
   isUserMessage,
@@ -70,7 +83,7 @@ const LinkPreview = ({
 
   return (
     <a
-      href={ogData?.url || url}
+      href={getSafePreviewHref(ogData?.url, url)}
       target="_blank"
       rel="noopener noreferrer"
       className={`mt-1 block overflow-hidden rounded-lg border no-underline transition-opacity hover:opacity-80 ${

--- a/pages/api/__tests__/og-preview.test.ts
+++ b/pages/api/__tests__/og-preview.test.ts
@@ -1,0 +1,108 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const lookupMock = jest.fn();
+
+jest.mock("dns/promises", () => ({
+  lookup: (...args: unknown[]) => lookupMock(...args),
+}));
+
+import handler from "@/pages/api/og-preview";
+import { __resetRateLimitBuckets } from "@/utils/rate-limit";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      return this;
+    },
+    setHeader(key: string, value: string) {
+      this.headers[key] = value;
+      return this;
+    },
+  };
+}
+
+function createRequest(url: string): NextApiRequest {
+  return {
+    method: "GET",
+    query: { url },
+    headers: {},
+    socket: { remoteAddress: "203.0.113.10" },
+  } as unknown as NextApiRequest;
+}
+
+describe("/api/og-preview", () => {
+  beforeEach(() => {
+    __resetRateLimitBuckets();
+    lookupMock.mockReset();
+    lookupMock.mockResolvedValue([{ family: 4, address: "93.184.216.34" }]);
+    global.fetch = jest.fn();
+  });
+
+  it("falls back to the fetched URL when og:url uses a script scheme", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "text/html" : null,
+      },
+      text: async () => `
+        <html>
+          <head>
+            <meta property="og:title" content="Order receipt">
+            <meta property="og:url" content="javascript:alert(1)">
+          </head>
+        </html>
+      `,
+    });
+
+    const res = createResponse();
+    await handler(
+      createRequest("https://attacker.example/order"),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody).toEqual({
+      title: "Order receipt",
+      url: "https://attacker.example/order",
+    });
+  });
+
+  it("resolves safe relative og:url values against the fetched page", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "text/html" : null,
+      },
+      text: async () => `
+        <html>
+          <head>
+            <meta property="og:title" content="Order receipt">
+            <meta property="og:url" content="/orders/123">
+          </head>
+        </html>
+      `,
+    });
+
+    const res = createResponse();
+    await handler(
+      createRequest("https://seller.example/listing"),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody).toEqual({
+      title: "Order receipt",
+      url: "https://seller.example/orders/123",
+    });
+  });
+});

--- a/pages/api/og-preview.ts
+++ b/pages/api/og-preview.ts
@@ -116,6 +116,20 @@ function extractMeta(
   return undefined;
 }
 
+function normalizeHttpUrl(value: string | undefined, baseUrl: string): string {
+  if (!value) return baseUrl;
+
+  try {
+    const parsed = new URL(value.trim(), baseUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return baseUrl;
+    }
+    return parsed.toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -203,7 +217,7 @@ export default async function handler(
       }
     }
 
-    ogData.url = extractMeta(html, "og:url") ?? normalizedUrl;
+    ogData.url = normalizeHttpUrl(extractMeta(html, "og:url"), normalizedUrl);
 
     if (ogData.title) {
       cache.set(normalizedUrl, { data: ogData, timestamp: Date.now() });


### PR DESCRIPTION
there is a script injection issue on this line... 

https://github.com/shopstr-eng/shopstr/blob/e1f7dc33b8d75201f55d223941a3a18e6599699e/pages/api/og-preview.ts#L206 
https://github.com/shopstr-eng/shopstr/blob/e1f7dc33b8d75201f55d223941a3a18e6599699e/components/messages/link-preview.tsx#L73

When a user sends a URL in chat... Shopstr fetches the page's OpenGraph metadata to generate a link preview. The backend returns the og:url as is... no validation check. So if a seller controls that page... they can set og:url to javascript:... and when the buyer clicks the preview card... that script runs directly in their Shopstr browser context.