### PR TITLE
test: enhance ZapsnagButton tests with full purchase flow

### DIFF
--- a/components/__tests__/ZapsnagButton.test.tsx
+++ b/components/__tests__/ZapsnagButton.test.tsx
@@ -137,6 +137,8 @@ const renderComponent = (contextOverrides = {}) => {
 describe("ZapsnagButton Component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNostrManager.fetch.mockReset();
+    mockSigner.signEvent.mockReset();
     window.alert = jest.fn();
 
     Storage.prototype.getItem = jest.fn(() => null);
@@ -256,12 +258,31 @@ describe("ZapsnagButton Component", () => {
   });
 
   test("handles full purchase flow successfully", async () => {
-    mockNostrManager.fetch.mockResolvedValue([
+    const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+    mockNostrManager.fetch.mockResolvedValueOnce([
       {
         created_at: 100,
         content: JSON.stringify({ lud16: "seller@alby.com" }),
       },
     ]);
+
+    const giftWrapEvent = { id: "gift-wrap-event" };
+    const sealEvent = { id: "seal-event" };
+    const finalEvent = { id: "final-event" };
+
+    (nostrHelpers.constructGiftWrappedEvent as jest.Mock).mockResolvedValueOnce(
+      giftWrapEvent
+    );
+    (nostrHelpers.constructMessageSeal as jest.Mock).mockResolvedValueOnce(
+      sealEvent
+    );
+    (nostrHelpers.constructMessageGiftWrap as jest.Mock).mockResolvedValueOnce(
+      finalEvent
+    );
+    (
+      nostrHelpers.sendGiftWrappedMessageEvent as jest.Mock
+    ).mockResolvedValueOnce(undefined);
 
     (zapValidator.validateZapReceipt as jest.Mock).mockResolvedValue(true);
 
@@ -289,16 +310,71 @@ describe("ZapsnagButton Component", () => {
       fireEvent.click(confirmBtn);
     });
 
-    expect(mockNostrManager.fetch).toHaveBeenCalled();
+    expect(mockNostrManager.fetch).toHaveBeenCalledTimes(1);
+    expect(mockNostrManager.fetch).toHaveBeenCalledWith([
+      {
+        kinds: [0],
+        authors: [mockProduct.pubkey],
+      },
+    ]);
+
+    expect(nostrHelpers.constructGiftWrappedEvent).toHaveBeenCalledTimes(1);
+    const giftWrapCall = (nostrHelpers.constructGiftWrappedEvent as jest.Mock)
+      .mock.calls[0];
+    expect(giftWrapCall).toEqual(
+      expect.arrayContaining([
+        "buyer-pubkey",
+        "seller-pubkey",
+        expect.any(String),
+        "zapsnag-order",
+        expect.objectContaining({ isOrder: true, orderId: "1234-order-id" }),
+      ])
+    );
+    expect(JSON.parse(giftWrapCall[2] as string)).toEqual({
+      type: "zapsnag_order",
+      orderId: "1234-order-id",
+      item: mockProduct.id,
+      shipping: {
+        name: "Buyer",
+        address: "Road",
+        unit: "",
+        city: "Town",
+        state: "",
+        zip: "123",
+        country: "US",
+      },
+    });
+
+    expect(nostrHelpers.constructMessageSeal).toHaveBeenCalledWith(
+      mockSigner,
+      giftWrapEvent,
+      "buyer-pubkey",
+      "seller-pubkey"
+    );
+    expect(nostrHelpers.constructMessageGiftWrap).toHaveBeenCalledWith(
+      sealEvent,
+      "ephemeral-pubkey-hex",
+      expect.any(Uint8Array),
+      "seller-pubkey"
+    );
+    expect(
+      Array.from(
+        (nostrHelpers.constructMessageGiftWrap as jest.Mock).mock.calls[0][2]
+      )
+    ).toEqual([1, 2, 3]);
 
     expect(nostrHelpers.constructGiftWrappedEvent).toHaveBeenCalledWith(
       "buyer-pubkey",
       "seller-pubkey",
-      expect.stringContaining("zapsnag_order"),
+      expect.any(String),
       "zapsnag-order",
       expect.objectContaining({ isOrder: true })
     );
-    expect(nostrHelpers.sendGiftWrappedMessageEvent).toHaveBeenCalled();
+    expect(nostrHelpers.sendGiftWrappedMessageEvent).toHaveBeenCalledWith(
+      mockNostrManager,
+      finalEvent,
+      mockSigner
+    );
 
     expect(LightningAddress).toHaveBeenCalledWith("seller@alby.com");
     const mockLnInstance = (LightningAddress as unknown as jest.Mock).mock
@@ -311,6 +387,11 @@ describe("ZapsnagButton Component", () => {
     );
 
     expect(zapValidator.validateZapReceipt).toHaveBeenCalled();
+    expect(zapValidator.validateZapReceipt).toHaveBeenCalledWith(
+      mockNostrManager,
+      mockProduct.id,
+      1700000000
+    );
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
       "shopstr_shipping_info",
@@ -319,6 +400,8 @@ describe("ZapsnagButton Component", () => {
     expect(window.alert).toHaveBeenCalledWith(
       expect.stringContaining("Order Placed & Verified")
     );
+
+    dateNowSpy.mockRestore();
   });
 
   test("handles error if seller has no LUD16", async () => {


### PR DESCRIPTION
### Description
ZapsnagButton’s purchase-flow test now checks the real wiring instead of just “a call happened.” In `ZapsnagButton.test.tsx`. I reset the shared Nostr mock between tests, assert the seller-profile fetch shape, verify the exact zapsnag payload object, confirm the seal/wrap calls receive the prior step outputs in order, and pin zap-receipt validation to the expected inputs. 

### Resolved or fixed issue
`none`  

### Screenshots (if applicable)  
Add screenshots or examples if this PR includes UI-related changes.  

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

### For more details on what to include, see:

[Bug Report Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
[Feature Request Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/feature_request.md)
[Documentation Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/documentation_improvement.md)
[Security Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/security_vulnerability.md)