### PR TITLE
test: enhance SignInModal tests to validate local storage data and signer calls

### DIFF
--- a/components/sign-in/__tests__/SignInModal.test.tsx
+++ b/components/sign-in/__tests__/SignInModal.test.tsx
@@ -97,7 +97,14 @@ describe("SignInModal", () => {
         screen.getByRole("button", { name: /extension sign-in/i })
       );
       await waitFor(() => {
+        expect(mockNewSigner).toHaveBeenCalledWith("nip07", {});
         expect(signer.getPubKey).toHaveBeenCalled();
+        expect(helpers.setLocalStorageDataOnSignIn).toHaveBeenCalledWith({
+          signer,
+          relays: mockRelays.relayList,
+          readRelays: mockRelays.readRelayList,
+          writeRelays: mockRelays.writeRelayList,
+        });
         expect(push).toHaveBeenCalledWith("/marketplace");
       });
     });
@@ -148,7 +155,20 @@ describe("SignInModal", () => {
       await user.type(input, "bunker://valid-token");
 
       await user.click(screen.getByTestId("bunker-submit-btn"));
-      await waitFor(() => expect(push).toHaveBeenCalledWith("/marketplace"));
+      await waitFor(() => {
+        expect(mockNewSigner).toHaveBeenCalledWith("nip46", {
+          bunker: "bunker://valid-token",
+        });
+        expect(signer.connect).toHaveBeenCalled();
+        expect(signer.getPubKey).toHaveBeenCalled();
+        expect(helpers.setLocalStorageDataOnSignIn).toHaveBeenCalledWith({
+          signer,
+          relays: mockRelays.relayList,
+          readRelays: mockRelays.readRelayList,
+          writeRelays: mockRelays.writeRelayList,
+        });
+        expect(push).toHaveBeenCalledWith("/marketplace");
+      });
     });
 
     it("shows a failure modal on connection error", async () => {
@@ -207,7 +227,20 @@ describe("SignInModal", () => {
 
       act(() => jest.runAllTimers());
 
-      await waitFor(() => expect(push).toHaveBeenCalledWith("/marketplace"));
+      await waitFor(() => {
+        expect(mockNewSigner).toHaveBeenCalledWith("nsec", {
+          encryptedPrivKey: "encrypted-key",
+          pubkey: "test-pubkey",
+        });
+        expect(signer.getPubKey).toHaveBeenCalled();
+        expect(helpers.setLocalStorageDataOnSignIn).toHaveBeenCalledWith({
+          signer,
+          relays: mockRelays.relayList,
+          readRelays: mockRelays.readRelayList,
+          writeRelays: mockRelays.writeRelayList,
+        });
+        expect(push).toHaveBeenCalledWith("/marketplace");
+      });
     });
 
     it("shows a failure modal if passphrase is empty", async () => {


### PR DESCRIPTION
### Description
Tightened the `SignInModal` success tests so they now verify the signer flow before navigation: extension sign-in must create the signer and fetch the pubkey, bunker sign-in must connect and fetch the pubkey, and nsec sign-in must build the encrypted signer and fetch the pubkey. Each success path now also asserts that the local-storage/context write happens before redirecting to `/marketplace`.

### Resolved or fixed issue
`none`  

### Screenshots (if applicable)  
Add screenshots or examples if this PR includes UI-related changes.  

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

### For more details on what to include, see:

[Bug Report Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
[Feature Request Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/feature_request.md)
[Documentation Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/documentation_improvement.md)
[Security Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/security_vulnerability.md)