### PR TITLE
added fetchAllReports tests

### DIFF
--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -801,6 +801,256 @@ describe("fetchReports", () => {
       ["wss://relay.example"]
     );
   });
+
+  it("emits DB-cached reports to context before relay results arrive", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    const product = makeProductEvent({
+      id: "listing-db-first",
+      pubkey: "seller-db-first",
+      created_at: 1,
+      tags: [["d", "item-db-first"]],
+      sig: "sig-product-db-first",
+    });
+    const dbReport = makeReportEvent({
+      id: "report-from-db",
+      pubkey: "reporter-db",
+      created_at: 50,
+      tags: [["e", "listing-db-first", "spam"]],
+      sig: "sig-db-report",
+    });
+    const relayReport = makeReportEvent({
+      id: "report-from-relay",
+      pubkey: "reporter-relay",
+      created_at: 60,
+      tags: [["p", "seller-db-first", "impersonation"]],
+      sig: "sig-relay-report",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(makeDbPayload([dbReport])) as typeof global.fetch;
+
+    const nostr = { fetch: jest.fn().mockResolvedValue([relayReport]) } as any;
+    const editReportsContext = jest.fn();
+
+    await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [product] as any,
+      editReportsContext
+    );
+
+    expect(editReportsContext).toHaveBeenCalledTimes(2);
+    // First call is DB-only, before relay completes
+    expect(editReportsContext.mock.calls[0]).toEqual([
+      [expect.objectContaining({ id: "report-from-db" })],
+      false,
+    ]);
+    // Final call includes both DB and relay reports
+    expect(editReportsContext).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "report-from-db" }),
+        expect.objectContaining({ id: "report-from-relay" }),
+      ]),
+      false
+    );
+  });
+
+  it("passes separate p-based and e-based filter objects to relay fetch", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    const productA = makeProductEvent({
+      id: "prod-pfilter-a",
+      pubkey: "seller-pfilter-a",
+      created_at: 1,
+      tags: [["d", "item-pfilter-a"]],
+      sig: "sig-pfilter-a",
+    });
+    const productB = makeProductEvent({
+      id: "prod-pfilter-b",
+      pubkey: "seller-pfilter-b",
+      created_at: 2,
+      tags: [["d", "item-pfilter-b"]],
+      sig: "sig-pfilter-b",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(makeDbPayload([])) as typeof global.fetch;
+
+    const nostr = { fetch: jest.fn().mockResolvedValue([]) } as any;
+    const editReportsContext = jest.fn();
+
+    await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [productA, productB] as any,
+      editReportsContext
+    );
+
+    const filters = nostr.fetch.mock.calls[0][0] as any[];
+    expect(filters).toHaveLength(2);
+    const pFilter = filters.find((f) => "#p" in f);
+    const eFilter = filters.find((f) => "#e" in f);
+    expect(pFilter).toMatchObject({
+      kinds: [1984],
+      "#p": expect.arrayContaining(["seller-pfilter-a", "seller-pfilter-b"]),
+    });
+    expect(eFilter).toMatchObject({
+      kinds: [1984],
+      "#e": expect.arrayContaining(["prod-pfilter-a", "prod-pfilter-b"]),
+    });
+  });
+
+  it("keeps the relay version of a report when the relay event has a higher created_at", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    const product = makeProductEvent({
+      id: "listing-merge",
+      pubkey: "seller-merge",
+      created_at: 1,
+      tags: [["d", "item-merge"]],
+      sig: "sig-product-merge",
+    });
+    const dbVersion = makeReportEvent({
+      id: "shared-report-id",
+      pubkey: "reporter-merge",
+      created_at: 100,
+      tags: [["e", "listing-merge", "spam"]],
+      content: "db-content",
+      sig: "sig-db-version",
+    });
+    const relayVersionNewer = makeReportEvent({
+      id: "shared-report-id",
+      pubkey: "reporter-merge",
+      created_at: 200,
+      tags: [["e", "listing-merge", "spam"]],
+      content: "relay-content",
+      sig: "sig-relay-version",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(makeDbPayload([dbVersion])) as typeof global.fetch;
+
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([relayVersionNewer]),
+    } as any;
+    const editReportsContext = jest.fn();
+
+    const { reportEvents } = await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [product] as any,
+      editReportsContext
+    );
+
+    expect(reportEvents).toHaveLength(1);
+    expect(reportEvents[0]).toMatchObject({
+      id: "shared-report-id",
+      content: "relay-content",
+      created_at: 200,
+    });
+  });
+
+  it("returns an empty result and skips relay fetch when products array is empty", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(makeDbPayload([])) as typeof global.fetch;
+    const nostr = { fetch: jest.fn() } as any;
+    const editReportsContext = jest.fn();
+
+    const { reportEvents } = await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [],
+      editReportsContext
+    );
+
+    expect(reportEvents).toEqual([]);
+    expect(nostr.fetch).not.toHaveBeenCalled();
+    expect(editReportsContext).toHaveBeenCalledWith([], false);
+  });
+
+  it("caches only relay events that are valid kind 1984 with id, sig, and pubkey", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    const product = makeProductEvent({
+      id: "listing-cache-valid",
+      pubkey: "seller-cache-valid",
+      created_at: 1,
+      tags: [["d", "item-cache-valid"]],
+      sig: "sig-product-cache-valid",
+    });
+    const validReport = makeReportEvent({
+      id: "valid-report-cache",
+      pubkey: "reporter-valid-cache",
+      created_at: 10,
+      tags: [["p", "seller-cache-valid", "spam"]],
+      sig: "sig-valid-cache",
+    });
+    const missingId = makeReportEvent({
+      id: "",
+      pubkey: "reporter-noid",
+      created_at: 11,
+      tags: [["p", "seller-cache-valid", "spam"]],
+      sig: "sig-noid",
+    });
+    const missingSig = makeReportEvent({
+      id: "report-nosig",
+      pubkey: "reporter-nosig",
+      created_at: 12,
+      tags: [["p", "seller-cache-valid", "spam"]],
+      sig: "",
+    });
+    const wrongKind = makeBaseEvent({
+      id: "report-wrongkind",
+      pubkey: "reporter-wrongkind",
+      created_at: 13,
+      kind: 1,
+      tags: [["p", "seller-cache-valid", "spam"]],
+      sig: "sig-wrongkind",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(makeDbPayload([])) as typeof global.fetch;
+
+    const nostr = {
+      fetch: jest
+        .fn()
+        .mockResolvedValue([validReport, missingId, missingSig, wrongKind]),
+    } as any;
+    const editReportsContext = jest.fn();
+
+    await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [product] as any,
+      editReportsContext
+    );
+
+    expect(cacheEventsToDatabase).toHaveBeenCalledTimes(1);
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([validReport]);
+  });
 });
 
 describe("fetchProfile", () => {

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -618,6 +618,191 @@ describe("fetch-service report helpers", () => {
   });
 });
 
+describe("fetchReports", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("includes reports matched by listing e-tag and reports matched by seller p-tag", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    const productA = makeProductEvent({
+      id: "prod-a",
+      pubkey: "seller-a",
+      created_at: 1,
+      tags: [["d", "item-a"]],
+      sig: "sig-prod-a",
+    });
+    const productB = makeProductEvent({
+      id: "prod-b",
+      pubkey: "seller-b",
+      created_at: 2,
+      tags: [["d", "item-b"]],
+      sig: "sig-prod-b",
+    });
+    const reportByETag = makeReportEvent({
+      id: "report-e",
+      pubkey: "reporter-1",
+      created_at: 10,
+      tags: [["e", "prod-a", "spam"]],
+      sig: "sig-report-e",
+    });
+    const reportByPTag = makeReportEvent({
+      id: "report-p",
+      pubkey: "reporter-2",
+      created_at: 11,
+      tags: [["p", "seller-b", "impersonation"]],
+      sig: "sig-report-p",
+    });
+    const reportIrrelevant = makeReportEvent({
+      id: "report-irrelevant",
+      pubkey: "reporter-3",
+      created_at: 12,
+      tags: [["p", "unknown-seller", "spam"]],
+      sig: "sig-irrelevant",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        makeDbPayload([reportByETag, reportByPTag, reportIrrelevant])
+      ) as typeof global.fetch;
+
+    const nostr = { fetch: jest.fn().mockResolvedValue([]) } as any;
+    const editReportsContext = jest.fn();
+
+    const { reportEvents } = await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [productA, productB] as any,
+      editReportsContext
+    );
+
+    expect(reportEvents.map((e) => e.id)).toEqual(
+      expect.arrayContaining(["report-e", "report-p"])
+    );
+    expect(reportEvents.map((e) => e.id)).not.toContain("report-irrelevant");
+  });
+
+  it("discards DB report rows that reference neither loaded product IDs nor seller pubkeys", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    const product = makeProductEvent({
+      id: "known-listing",
+      pubkey: "known-seller",
+      created_at: 1,
+      tags: [["d", "item"]],
+      sig: "sig-product",
+    });
+    const relevantByEventId = makeReportEvent({
+      id: "relevant-e",
+      pubkey: "reporter-1",
+      created_at: 10,
+      tags: [["e", "known-listing", "spam"]],
+      sig: "sig-relevant-e",
+    });
+    const irrelevantWrongSeller = makeReportEvent({
+      id: "irrelevant-seller",
+      pubkey: "reporter-2",
+      created_at: 11,
+      tags: [["p", "stranger-seller", "spam"]],
+      sig: "sig-irrelevant-seller",
+    });
+    const irrelevantWrongListing = makeReportEvent({
+      id: "irrelevant-listing",
+      pubkey: "reporter-3",
+      created_at: 12,
+      tags: [["e", "unknown-listing", "spam"]],
+      sig: "sig-irrelevant-listing",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        makeDbPayload([
+          relevantByEventId,
+          irrelevantWrongSeller,
+          irrelevantWrongListing,
+        ])
+      ) as typeof global.fetch;
+
+    const nostr = { fetch: jest.fn().mockResolvedValue([]) } as any;
+    const editReportsContext = jest.fn();
+
+    const { reportEvents } = await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [product] as any,
+      editReportsContext
+    );
+
+    expect(reportEvents).toHaveLength(1);
+    expect(reportEvents[0]?.id).toBe("relevant-e");
+  });
+
+  it("additionalProfilePubkeys expands the seller-pubkey match set for DB query and relay filter", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/utils/db/db-client", () => ({ cacheEventsToDatabase }));
+
+    const { fetchReports } = await import("../fetch-service");
+
+    const product = makeProductEvent({
+      id: "listing-1",
+      pubkey: "seller-1",
+      created_at: 1,
+      tags: [["d", "item"]],
+      sig: "sig-product",
+    });
+    const extraReviewerReport = makeReportEvent({
+      id: "report-extra",
+      pubkey: "reporter-x",
+      created_at: 20,
+      tags: [["p", "extra-reviewer", "spam"]],
+      sig: "sig-extra",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        makeDbPayload([extraReviewerReport])
+      ) as typeof global.fetch;
+
+    const nostr = { fetch: jest.fn().mockResolvedValue([]) } as any;
+    const editReportsContext = jest.fn();
+
+    const { reportEvents } = await fetchReports(
+      nostr,
+      ["wss://relay.example"],
+      [product] as any,
+      editReportsContext,
+      ["extra-reviewer"]
+    );
+
+    expect(reportEvents.map((e) => e.id)).toContain("report-extra");
+
+    const dbUrl = (global.fetch as jest.Mock).mock.calls[0]?.[0] as string;
+    expect(dbUrl).toContain("p=extra-reviewer");
+
+    expect(nostr.fetch).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kinds: [1984],
+          "#p": expect.arrayContaining(["extra-reviewer"]),
+        }),
+      ]),
+      {},
+      ["wss://relay.example"]
+    );
+  });
+});
+
 describe("fetchProfile", () => {
   const pubkey =
     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";


### PR DESCRIPTION
### Description
- DB-first behavior — asserts `editReportsContext` is called twice: once with only the DB report (before relay), then again with the merged DB+relay set.
- Both p-based and e-based relay filters — verifies nostr.fetch receives exactly two filter objects, one with #p and one with #e, covering all product IDs and seller pubkeys.
- Merge precedence (newest wins) — seeds DB with created_at: 100 and relay with created_at: 200 for the same event ID; asserts the relay version (content: "relay-content") survives in the final result.
- Empty products skips relay — passes [] as products; asserts nostr.fetch is never called and the result is empty.
- Only valid 1984 events cached — relay returns one valid report plus three invalids (missing id, missing sig, wrong kind); asserts cacheEventsToDatabase is called exactly once with only the valid event.

### Resolved or fixed issue
`none`  

### Screenshots (if applicable)  
Add screenshots or examples if this PR includes UI-related changes.  

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

### For more details on what to include, see:

[Bug Report Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
[Feature Request Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/feature_request.md)
[Documentation Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/documentation_improvement.md)
[Security Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/security_vulnerability.md)