### PR TITLE
Implement Read Tools - Search Product, Get Product Details and Get Reviews

### DIFF
--- a/packages/shopstr-mcp/README.md
+++ b/packages/shopstr-mcp/README.md
@@ -92,6 +92,7 @@ npm --prefix packages/shopstr-mcp test
 ```
 
 ## For Verification
+
 ```sh
 npx @modelcontextprotocol/inspector node shopstr/packages/shopstr-mcp/dist/index.js
 ```

--- a/packages/shopstr-mcp/README.md
+++ b/packages/shopstr-mcp/README.md
@@ -2,10 +2,10 @@
 
 Standalone read-only MCP server package for Shopstr marketplace data.
 
-This package currently contains the standalone MCP shell plus shared read-only
-infrastructure for relay access, validation, JSON-safe parsing, deduplication,
-structured errors, timeouts, and audit logging. Listing, seller, review, and
-community tools will be added in follow-up PRs.
+This package currently contains the standalone MCP shell, shared read-only
+infrastructure, and the first relay-backed read tools for public Shopstr
+marketplace data. Seller, storefront, reputation, prompt, and resource features
+will be added in follow-up PRs.
 
 ## Current Scope
 
@@ -13,11 +13,44 @@ community tools will be added in follow-up PRs.
 - Reads relay, timeout, cache, and log-level settings from environment
   variables.
 - Starts an MCP server over stdio for local MCP-compatible clients.
-- Registers disabled placeholders so `tools/list`, `resources/list`, and
-  `prompts/list` return valid empty lists until real read tools are added.
+- Registers relay-backed core read tools:
+  `search_products`, `get_product_details`, and `get_reviews`.
+- Registers disabled resource and prompt placeholders so `resources/list` and
+  `prompts/list` return valid empty lists until those features are added.
 - Provides reusable infrastructure modules for upcoming tools:
   `nostr-manager`, `relay-fetch`, `parse-tags`, `dedup`, `validation`,
   `errors`, `timeout`, and `audit-log`.
+
+## Tools
+
+- `search_products`: search public product listings by keyword, category,
+  location, currency, and price range. Price filters require `currency`.
+  Category searches are pushed down to relays with `#t` when possible, then
+  checked again client-side with a broad fallback if no category-tagged results
+  match. Hidden Gamma listings are excluded from search results. Responses are
+  capped at 37 products for MCP token budgeting, even when a higher `limit` is
+  requested.
+- `get_product_details`: fetch one product listing by `productAddress`
+  (`30402:<seller-pubkey>:<product-d-tag>`) or by 64-character `productId`.
+  When given `productId`, the tool first resolves the product coordinate and
+  then fetches the latest replaceable listing for that coordinate so agents do
+  not accidentally use stale event IDs.
+- `get_reviews`: fetch public reviews for a product address, product ID, or
+  seller pubkey. Product reviews use the Shopstr/Gamma `#d` address model and
+  also query the standard `#a` address model. `productId` is resolved to a
+  product address when possible and keeps a legacy `#e` fallback. Seller review
+  lookups first derive the seller's product addresses, query Gamma/standard
+  product review targets, and keep legacy `#p` as a fallback.
+
+Product responses expose Gamma-compatible fields where available, including
+structured image objects, `productType`, `productFormat`, `visibility`
+(`hidden`, `on-sale`, or `pre-order`), `stock`, and structured
+`shippingOptions`. The parser keeps legacy Shopstr fields such as `quantity`,
+embedded `shipping`, and subscription tags as fallback data when present.
+
+Tool responses include relay degradation metadata in `_meta`, including queried
+relays, successful relays, failed relays, coverage, response time, hints, and
+truncation flags when response budgeting applies.
 
 ## Usage
 
@@ -56,4 +89,9 @@ and audit logging.
 ```sh
 npm --prefix packages/shopstr-mcp run build
 npm --prefix packages/shopstr-mcp test
+```
+
+## For Verification
+```sh
+npx @modelcontextprotocol/inspector node shopstr/packages/shopstr-mcp/dist/index.js
 ```

--- a/packages/shopstr-mcp/src/dedup.ts
+++ b/packages/shopstr-mcp/src/dedup.ts
@@ -1,7 +1,27 @@
 import type { NostrEvent } from "./types.js";
 
+// Add a window of 15 min in future to prevent from a event from far future to override a valid event caused by a malicious client.
+const MAX_FUTURE_SKEW_S = 15 * 60;
+
+function isBetterEvent(candidate: NostrEvent, existing: NostrEvent): boolean {
+  const cutoff = Math.floor(Date.now() / 1000) + MAX_FUTURE_SKEW_S;
+  const candidateFuture = candidate.created_at > cutoff;
+  const existingFuture = existing.created_at > cutoff;
+
+  // Prefer non-future over future
+  if (candidateFuture && !existingFuture) return false;
+  if (!candidateFuture && existingFuture) return true;
+
+  // Both same bucket - newest wins
+  return candidate.created_at > existing.created_at;
+}
+
 export function getDTag(event: NostrEvent): string | undefined {
   return event.tags?.find((tag) => tag[0] === "d")?.[1];
+}
+
+function getTagValue(event: NostrEvent, key: string): string | undefined {
+  return event.tags?.find((tag) => tag[0] === key)?.[1];
 }
 
 export function getParameterizedReplaceableCoordinate(
@@ -23,7 +43,7 @@ export function mergeAndDeduplicateProducts(
         ? (getParameterizedReplaceableCoordinate(event) ?? event.id)
         : event.id;
     const existing = byCoordinate.get(coordinate);
-    if (!existing || event.created_at > existing.created_at) {
+    if (!existing || isBetterEvent(event, existing)) {
       byCoordinate.set(coordinate, event);
     }
   }
@@ -36,4 +56,46 @@ export function mergeAndDeduplicateProducts(
   }
 
   return Array.from(byId.values()).sort((a, b) => b.created_at - a.created_at);
+}
+
+export function mergeAndDeduplicateReviews(
+  events: readonly NostrEvent[]
+): NostrEvent[] {
+  const latestByReviewerAndTarget = new Map<string, NostrEvent>();
+
+  for (const event of events) {
+    const target = getReviewTarget(event);
+    const coordinate =
+      event.kind === 31555 && target ? `${event.pubkey}:${target}` : event.id;
+    const existing = latestByReviewerAndTarget.get(coordinate);
+    if (!existing || isBetterEvent(event, existing)) {
+      latestByReviewerAndTarget.set(coordinate, event);
+    }
+  }
+
+  const byId = new Map<string, NostrEvent>();
+  for (const event of latestByReviewerAndTarget.values()) {
+    if (!byId.has(event.id)) {
+      byId.set(event.id, event);
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => b.created_at - a.created_at);
+}
+
+function getReviewTarget(event: NostrEvent): string | undefined {
+  const aTag = getTagValue(event, "a");
+  if (aTag) return `a:${aTag}`;
+
+  const dTag = getDTag(event);
+  if (dTag?.startsWith("a:30402:")) return dTag;
+  if (dTag?.startsWith("30402:")) return `a:${dTag}`;
+
+  const eTag = getTagValue(event, "e");
+  if (eTag) return `e:${eTag}`;
+
+  const pTag = getTagValue(event, "p");
+  if (pTag) return `p:${pTag}`;
+
+  return dTag ? `d:${dTag}` : undefined;
 }

--- a/packages/shopstr-mcp/src/dedup.ts
+++ b/packages/shopstr-mcp/src/dedup.ts
@@ -1,6 +1,6 @@
 import type { NostrEvent } from "./types.js";
 
-// Add a window of 15 min in future to prevent from a event from far future to override a valid event caused by a malicious client.
+// Add a window of 15 min in future to prevent an event from far future to override a valid event caused by a malicious client.
 const MAX_FUTURE_SKEW_S = 15 * 60;
 
 function isBetterEvent(candidate: NostrEvent, existing: NostrEvent): boolean {

--- a/packages/shopstr-mcp/src/index.ts
+++ b/packages/shopstr-mcp/src/index.ts
@@ -9,7 +9,7 @@ const config = loadConfig();
 const logger = createLogger(config.logLevel);
 let isShuttingDown = false;
 
-const server = createMcpServer(config);
+const server = createMcpServer(config, { logger });
 
 async function shutdown(reason: string): Promise<void> {
   if (isShuttingDown) return;

--- a/packages/shopstr-mcp/src/nostr-manager.ts
+++ b/packages/shopstr-mcp/src/nostr-manager.ts
@@ -1,16 +1,9 @@
-import {
-  SimplePool,
-  type Event as NostrToolsEvent,
-  type Filter,
-  verifyEvent,
-} from "nostr-tools";
+import { SimplePool, verifyEvent } from "nostr-tools";
 import type { SubscribeManyParams, SubCloser } from "nostr-tools/abstract-pool";
 
 import type { Logger } from "./logger.js";
 import { TimeoutError } from "./timeout.js";
-
-export type NostrEvent = NostrToolsEvent;
-export type NostrFilter = Filter;
+import type { NostrEvent, NostrFilter } from "./types.js";
 
 export type NostrRelay = {
   url: string;
@@ -109,6 +102,7 @@ export class NostrManager {
     this.gcTimeout = setTimeout(() => {
       void this.gc();
     }, this.params.gcInterval);
+    this.gcTimeout.unref?.();
   }
 
   private async gc(): Promise<void> {

--- a/packages/shopstr-mcp/src/parse-tags.ts
+++ b/packages/shopstr-mcp/src/parse-tags.ts
@@ -52,7 +52,7 @@ function getCappedTagValues(
   return results;
 }
 
-//  Extract capped, structured image objects from image tags according toGamma spec: ["image", "<url>", "<dimensions>", "<sorting-order>"]
+//  Extract capped, structured image objects from image tags according to Gamma spec: ["image", "<url>", "<dimensions>", "<sorting-order>"]
 function getCappedImages(tags: string[][]): ProductImage[] {
   const images: ProductImage[] = [];
   for (const tag of tags) {

--- a/packages/shopstr-mcp/src/parse-tags.ts
+++ b/packages/shopstr-mcp/src/parse-tags.ts
@@ -2,9 +2,11 @@ import type {
   NostrEvent,
   PriceStatus,
   PricingBlock,
+  ProductImage,
   ProductResponse,
   ProfileResponse,
   ReviewResponse,
+  ShippingOptionRef,
   ShippingOptionsType,
 } from "./types.js";
 
@@ -21,21 +23,62 @@ type ParsedShippingTag = {
   shippingCost: number;
 };
 
+//  Maximum number of repeated tags we will extract per field.
+const TAG_CAPS = {
+  image: 10,
+  t: 20,
+  size: 50,
+  volume: 50,
+  weight: 50,
+  bulk: 50,
+  pickup_location: 20,
+  shipping_option: 10,
+} as const;
+
 function getTagValue(tags: string[][], key: string): string | undefined {
   return tags.find((tag) => tag[0] === key)?.[1];
 }
 
-function getAllTagValues(tags: string[][], key: string): string[] {
-  return tags
-    .filter((tag) => tag[0] === key)
-    .map((tag) => tag[1])
-    .filter((value): value is string => Boolean(value));
+function getCappedTagValues(
+  tags: string[][],
+  key: string,
+  cap: number
+): string[] {
+  const results: string[] = [];
+  for (const tag of tags) {
+    if (results.length >= cap) break;
+    if (tag[0] === key && tag[1]) results.push(tag[1]);
+  }
+  return results;
+}
+
+//  Extract capped, structured image objects from image tags according toGamma spec: ["image", "<url>", "<dimensions>", "<sorting-order>"]
+function getCappedImages(tags: string[][]): ProductImage[] {
+  const images: ProductImage[] = [];
+  for (const tag of tags) {
+    if (images.length >= TAG_CAPS.image) break;
+    if (tag[0] !== "image" || !tag[1]) continue;
+    const img: ProductImage = { url: tag[1] };
+    if (tag[2] && tag[2] !== "") img.dimensions = tag[2];
+    const order = parseNumber(tag[3]);
+    if (order !== undefined) img.order = order;
+    images.push(img);
+  }
+  return images;
 }
 
 function parseNumber(value: string | undefined): number | undefined {
   if (value === undefined || value.trim() === "") return;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseNonNegativeInteger(
+  value: string | undefined
+): number | undefined {
+  const parsed = parseNumber(value);
+  if (parsed === undefined || parsed < 0 || !Number.isInteger(parsed)) return;
+  return parsed;
 }
 
 export function parseShippingTag(
@@ -120,6 +163,74 @@ export function buildPricingBlock(
   };
 }
 
+/**
+ * Parse the product type tag: ["type", "simple|variable|variation", "digital|physical"]
+ * Defaults: simple, digital (per Gamma spec).
+ */
+function parseProductType(tags: string[][]): {
+  productType: "simple" | "variable" | "variation";
+  productFormat: "digital" | "physical";
+} {
+  const typeTag = tags.find((tag) => tag[0] === "type");
+  const validTypes = ["simple", "variable", "variation"] as const;
+  const validFormats = ["digital", "physical"] as const;
+
+  const rawType = typeTag?.[1]?.toLowerCase();
+  const rawFormat = typeTag?.[2]?.toLowerCase();
+
+  return {
+    productType: validTypes.includes(rawType as (typeof validTypes)[number])
+      ? (rawType as (typeof validTypes)[number])
+      : "simple",
+    productFormat: validFormats.includes(
+      rawFormat as (typeof validFormats)[number]
+    )
+      ? (rawFormat as (typeof validFormats)[number])
+      : "digital",
+  };
+}
+
+function parseSubscription(
+  tags: string[][],
+  priceTag: string[] | undefined
+): { enabled: boolean; discount?: number; frequencies: string[] } {
+  // Gamma spec: frequency is the 4th element of the price tag
+  const gammaFrequency = priceTag?.[3]?.trim();
+
+  const legacyEnabled = getTagValue(tags, "subscription") === "true";
+  const legacyFrequencyTag = tags.find(
+    (tag) => tag[0] === "subscription_frequency"
+  );
+  const legacyFrequencies = legacyFrequencyTag
+    ? legacyFrequencyTag.slice(1)
+    : [];
+
+  const subscriptionDiscount = parseNumber(
+    getTagValue(tags, "subscription_discount")
+  );
+
+  if (gammaFrequency) {
+    return {
+      enabled: true,
+      ...(subscriptionDiscount !== undefined && {
+        discount: subscriptionDiscount,
+      }),
+      frequencies: [
+        gammaFrequency,
+        ...legacyFrequencies.filter((f) => f !== gammaFrequency),
+      ],
+    };
+  }
+
+  return {
+    enabled: legacyEnabled,
+    ...(subscriptionDiscount !== undefined && {
+      discount: subscriptionDiscount,
+    }),
+    frequencies: legacyFrequencies,
+  };
+}
+
 export function parseProductEvent(event: NostrEvent): ProductResponse {
   const tags = event.tags || [];
   const priceTag = tags.find((tag) => tag[0] === "price");
@@ -131,10 +242,38 @@ export function parseProductEvent(event: NostrEvent): ProductResponse {
     priceTag === undefined ? "missing" : hasValidPrice ? "known" : "invalid";
   const currency = priceTag?.[2]?.trim() || undefined;
   const parsedShipping = parseShippingFromTags(tags);
-  const quantity = parseNumber(getTagValue(tags, "quantity"));
+  // Gamma spec: stock tag, with fallback to legacy quantity
+  const gammaStock = parseNonNegativeInteger(getTagValue(tags, "stock"));
+  const legacyQuantity = parseNonNegativeInteger(getTagValue(tags, "quantity"));
+  const stock = gammaStock ?? legacyQuantity;
+
+  // Gamma spec: structured shipping_option with extra cost
+  const shippingOptions: ShippingOptionRef[] = [];
+  for (const tag of tags) {
+    if (shippingOptions.length >= TAG_CAPS.shipping_option) break;
+    if (tag[0] !== "shipping_option" || !tag[1]) continue;
+    const ref: ShippingOptionRef = { reference: tag[1] };
+    const extraCost = parseNumber(tag[2]);
+    if (extraCost !== undefined && extraCost >= 0) ref.extraCost = extraCost;
+    shippingOptions.push(ref);
+  }
+
+  // Gamma spec: visibility (default: on-sale)
+  const rawVisibility = getTagValue(tags, "visibility")?.toLowerCase();
+  const visibility: "hidden" | "on-sale" | "pre-order" =
+    rawVisibility === "hidden" || rawVisibility === "pre-order"
+      ? rawVisibility
+      : "on-sale";
+
+  // Gamma spec: product type and format
+  const { productType, productFormat } = parseProductType(tags);
+
+  // Gamma spec: structured images with dimensions and sorting
+  const images = getCappedImages(tags);
 
   const sizes = tags
     .filter((tag) => tag[0] === "size" && tag[1])
+    .slice(0, TAG_CAPS.size)
     .map((tag) => ({
       size: tag[1] as string,
       ...(parseNumber(tag[2]) !== undefined && {
@@ -144,6 +283,7 @@ export function parseProductEvent(event: NostrEvent): ProductResponse {
 
   const volumes = tags
     .filter((tag) => tag[0] === "volume" && tag[1])
+    .slice(0, TAG_CAPS.volume)
     .map((tag) => ({
       volume: tag[1] as string,
       ...(parseNumber(tag[2]) !== undefined && { price: parseNumber(tag[2]) }),
@@ -151,6 +291,7 @@ export function parseProductEvent(event: NostrEvent): ProductResponse {
 
   const weights = tags
     .filter((tag) => tag[0] === "weight" && tag[1])
+    .slice(0, TAG_CAPS.weight)
     .map((tag) => ({
       weight: tag[1] as string,
       ...(parseNumber(tag[2]) !== undefined && { price: parseNumber(tag[2]) }),
@@ -158,19 +299,20 @@ export function parseProductEvent(event: NostrEvent): ProductResponse {
 
   const bulk = tags
     .filter((tag) => tag[0] === "bulk" && tag[1] && tag[2])
+    .slice(0, TAG_CAPS.bulk)
     .map((tag) => ({
       units: parseNumber(tag[1]) ?? 0,
       price: parseNumber(tag[2]) ?? 0,
     }))
     .filter((entry) => entry.units > 0 && entry.price >= 0);
 
-  const subscriptionFrequencyTag = tags.find(
-    (tag) => tag[0] === "subscription_frequency"
+  const pickupLocations = getCappedTagValues(
+    tags,
+    "pickup_location",
+    TAG_CAPS.pickup_location
   );
-  const subscriptionDiscount = parseNumber(
-    getTagValue(tags, "subscription_discount")
-  );
-  const pickupLocations = getAllTagValues(tags, "pickup_location");
+  const categories = getCappedTagValues(tags, "t", TAG_CAPS.t);
+
   const publishedAt = getTagValue(tags, "published_at");
   const expiration = parseNumber(getTagValue(tags, "valid_until"));
   const contentWarning = tags.some((tag) => {
@@ -179,6 +321,8 @@ export function parseProductEvent(event: NostrEvent): ProductResponse {
     return tag[0] === "l" && tag[2] === "content-warning";
   });
 
+  const subscription = parseSubscription(tags, priceTag);
+
   return {
     id: event.id,
     pubkey: event.pubkey,
@@ -186,15 +330,20 @@ export function parseProductEvent(event: NostrEvent): ProductResponse {
     title: getTagValue(tags, "title") || "",
     summary: getTagValue(tags, "summary") || "",
     ...(publishedAt && { publishedAt }),
-    images: getAllTagValues(tags, "image"),
-    categories: getAllTagValues(tags, "t"),
+    images,
+    categories,
     location: getTagValue(tags, "location") || "",
     ...(hasValidPrice && { price: validPrice }),
     ...(currency && { currency }),
     priceStatus,
+    productType,
+    productFormat,
+    visibility,
     ...(parsedShipping && { shippingType: parsedShipping.shippingType }),
     ...(parsedShipping && { shippingCost: parsedShipping.shippingCost }),
-    ...(quantity !== undefined && { quantity }),
+    ...(shippingOptions.length > 0 && { shippingOptions }),
+    ...(stock !== undefined && { stock }),
+    ...(legacyQuantity !== undefined && { quantity: legacyQuantity }),
     ...(getTagValue(tags, "condition") && {
       condition: getTagValue(tags, "condition"),
     }),
@@ -224,15 +373,7 @@ export function parseProductEvent(event: NostrEvent): ProductResponse {
         parsedShipping?.shippingCost
       ),
     }),
-    subscription: {
-      enabled: getTagValue(tags, "subscription") === "true",
-      ...(subscriptionDiscount !== undefined && {
-        discount: subscriptionDiscount,
-      }),
-      frequencies: subscriptionFrequencyTag
-        ? subscriptionFrequencyTag.slice(1)
-        : [],
-    },
+    subscription,
   };
 }
 

--- a/packages/shopstr-mcp/src/relay-fetch.ts
+++ b/packages/shopstr-mcp/src/relay-fetch.ts
@@ -1,15 +1,9 @@
 import type { SubscribeManyParams } from "nostr-tools/abstract-pool";
 
+import type { NostrManager } from "./nostr-manager.js";
 import type { NostrEvent, NostrFilter, RelayFetchMeta } from "./types.js";
 
-export type RelayFetchClient = {
-  fetch: (
-    filters: NostrFilter[],
-    params?: SubscribeManyParams,
-    relayUrls?: string[],
-    options?: { timeoutMs?: number }
-  ) => Promise<NostrEvent[]>;
-};
+export type RelayFetchClient = Pick<NostrManager, "fetch">;
 
 export type RelayFetchResult = {
   events: NostrEvent[];

--- a/packages/shopstr-mcp/src/server.ts
+++ b/packages/shopstr-mcp/src/server.ts
@@ -1,37 +1,43 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { ShopstrMcpConfig } from "./config.js";
+import { createLogger, type Logger } from "./logger.js";
+import { NostrManager } from "./nostr-manager.js";
+import { registerCoreTools } from "./tools/index.js";
 
-export function createMcpServer(config: ShopstrMcpConfig): McpServer {
+export type McpServerDependencies = {
+  logger?: Pick<Logger, "warn">;
+  nostr?: Pick<NostrManager, "fetch" | "close">;
+};
+
+export function createMcpServer(
+  config: ShopstrMcpConfig,
+  dependencies: McpServerDependencies = {}
+): McpServer {
+  const logger = dependencies.logger ?? createLogger(config.logLevel);
+  const nostr =
+    dependencies.nostr ??
+    new NostrManager(config.relays, {
+      connectionTimeout: config.relayConnectTimeoutMs,
+      logger,
+    });
   const server = new McpServer({
     name: "shopstr-mcp",
     version: config.version,
   });
 
-  registerEmptyCapabilityHandlers(server);
+  registerCoreTools(server, {
+    nostr,
+    relays: config.relays,
+    timeoutMs: config.defaultToolTimeoutMs,
+  });
+  registerPlaceholderCapabilityHandlers(server);
+  attachNostrCloseHandler(server, nostr);
 
   return server;
 }
 
-function registerEmptyCapabilityHandlers(server: McpServer): void {
-  const placeholderTool = server.registerTool(
-    "setup_placeholder_tool",
-    {
-      description:
-        "Disabled setup placeholder used to initialize MCP tool discovery.",
-      inputSchema: {},
-    },
-    async () => ({
-      content: [
-        {
-          type: "text",
-          text: "Shopstr MCP read tools are not registered in this setup PR.",
-        },
-      ],
-    })
-  );
-  placeholderTool.disable();
-
+function registerPlaceholderCapabilityHandlers(server: McpServer): void {
   const placeholderResource = server.registerResource(
     "setup-placeholder-resource",
     "shopstr://setup-placeholder",
@@ -69,4 +75,23 @@ function registerEmptyCapabilityHandlers(server: McpServer): void {
     })
   );
   placeholderPrompt.disable();
+}
+
+function attachNostrCloseHandler(
+  server: McpServer,
+  nostr: Pick<NostrManager, "close">
+): void {
+  const closeMcpServer = server.close.bind(server);
+  let closed = false;
+
+  server.close = async () => {
+    if (closed) return;
+    closed = true;
+
+    const results = await Promise.allSettled([closeMcpServer(), nostr.close()]);
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected"
+    );
+    if (rejected) throw rejected.reason;
+  };
 }

--- a/packages/shopstr-mcp/src/tools/common.ts
+++ b/packages/shopstr-mcp/src/tools/common.ts
@@ -1,0 +1,94 @@
+import type { ZodError } from "zod";
+
+import {
+  MCP_ERROR_CODES,
+  createErrorResponse,
+  type ToolMeta,
+  type ToolTextResponse,
+} from "../errors.js";
+import type { RelayFetchMeta } from "../types.js";
+
+export const PRODUCT_KIND = 30402;
+export const REVIEW_KIND = 31555;
+export const PRODUCT_RESPONSE_BUDGET = 37;
+export const REVIEW_RESPONSE_BUDGET = 50;
+export const RELAY_RETRY_AFTER_MS = 2_000;
+
+export function formatValidationError(error: ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "input";
+      return `${path}: ${issue.message}`;
+    })
+    .join("; ");
+}
+
+export function createValidationErrorResponse(
+  error: ZodError
+): ToolTextResponse {
+  return createErrorResponse(
+    `Invalid input: ${formatValidationError(error)}`,
+    MCP_ERROR_CODES.VALIDATION_ERROR,
+    false,
+    undefined,
+    {
+      _hints: ["Check the tool input schema and retry with valid arguments."],
+    }
+  );
+}
+
+export function buildToolMeta(
+  relayMeta: RelayFetchMeta,
+  fields: {
+    hints?: string[];
+    resultCount?: number;
+    totalMatches?: number;
+    truncated?: boolean;
+    dataFreshness?: string | null;
+  } = {}
+): ToolMeta {
+  return {
+    ...relayMeta,
+    dataSource: "nostr_relays",
+    ...(fields.dataFreshness !== undefined && {
+      dataFreshness: fields.dataFreshness,
+    }),
+    ...(fields.resultCount !== undefined && {
+      resultCount: fields.resultCount,
+    }),
+    ...(fields.totalMatches !== undefined && {
+      totalMatches: fields.totalMatches,
+    }),
+    ...(fields.truncated !== undefined && { _truncated: fields.truncated }),
+    _hints: fields.hints ?? [],
+  };
+}
+
+export function allRelaysFailed(meta: RelayFetchMeta): boolean {
+  return meta.relaysQueried.length > 0 && meta.relaysSucceeded.length === 0;
+}
+
+export function createRelayUnavailableResponse(
+  meta: RelayFetchMeta,
+  hints: string[] = ["Retry later or configure additional relays."]
+): ToolTextResponse {
+  return createErrorResponse(
+    "All configured relays failed to return data.",
+    MCP_ERROR_CODES.RELAY_UNAVAILABLE,
+    true,
+    RELAY_RETRY_AFTER_MS,
+    buildToolMeta(meta, { hints })
+  );
+}
+
+export function getDataFreshness(
+  items: readonly { createdAt: number }[]
+): string | null {
+  const latestTimestamp = items.reduce(
+    (latest, item) => Math.max(latest, item.createdAt || 0),
+    0
+  );
+  return latestTimestamp
+    ? new Date(latestTimestamp * 1000).toISOString()
+    : null;
+}

--- a/packages/shopstr-mcp/src/tools/context.ts
+++ b/packages/shopstr-mcp/src/tools/context.ts
@@ -1,0 +1,7 @@
+import type { RelayFetchClient } from "../relay-fetch.js";
+
+export type CoreToolContext = {
+  nostr: RelayFetchClient;
+  relays: string[];
+  timeoutMs: number;
+};

--- a/packages/shopstr-mcp/src/tools/get-product-details.ts
+++ b/packages/shopstr-mcp/src/tools/get-product-details.ts
@@ -1,0 +1,160 @@
+import { z } from "zod";
+
+import { getDTag, mergeAndDeduplicateProducts } from "../dedup.js";
+import {
+  MCP_ERROR_CODES,
+  createErrorResponse,
+  createSuccessResponse,
+  type ToolTextResponse,
+} from "../errors.js";
+import { parseProductEvent } from "../parse-tags.js";
+import { fetchFromRelays } from "../relay-fetch.js";
+import type { NostrFilter } from "../types.js";
+import {
+  parseProductAddress,
+  productDetailsInputSchema,
+} from "../validation.js";
+import {
+  PRODUCT_KIND,
+  allRelaysFailed,
+  buildToolMeta,
+  createRelayUnavailableResponse,
+  createValidationErrorResponse,
+  getDataFreshness,
+} from "./common.js";
+import type { CoreToolContext } from "./context.js";
+
+export const getProductDetailsInputSchema = {
+  productId: z
+    .string()
+    .optional()
+    .describe("The product event ID as 64-character hex"),
+  productAddress: z
+    .string()
+    .optional()
+    .describe("Product address as 30402:<seller-pubkey>:<product-d-tag>"),
+};
+
+/**
+ * Resolve a productId to a product coordinate by doing a pre-flight fetch.
+ * Returns the pubkey and dTag so we can query by coordinate for the latest version.
+ */
+async function resolveCoordinateFromId(
+  productId: string,
+  context: CoreToolContext
+): Promise<{
+  pubkey?: string;
+  dTag?: string;
+  errorResponse?: ToolTextResponse;
+}> {
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [{ kinds: [PRODUCT_KIND], ids: [productId] }],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  if (allRelaysFailed(relayResult.meta)) {
+    return {
+      errorResponse: createRelayUnavailableResponse(relayResult.meta, [
+        "Could not resolve productId; retry later or pass productAddress directly.",
+      ]),
+    };
+  }
+
+  const event = relayResult.events.find(
+    (e) => e.kind === PRODUCT_KIND && e.id === productId
+  );
+  if (!event) return {};
+
+  const dTag = getDTag(event);
+  return dTag ? { pubkey: event.pubkey, dTag } : {};
+}
+
+export async function handleGetProductDetails(
+  args: Record<string, unknown>,
+  context: CoreToolContext
+): Promise<ToolTextResponse> {
+  const parsed = productDetailsInputSchema.safeParse(args);
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const { productId, productAddress } = parsed.data;
+
+  let coordinateFilter: NostrFilter | undefined;
+  let fallbackId: string | undefined;
+  const hints: string[] = [];
+
+  if (productAddress) {
+    // Product Address already provided, parse it to build a coordinate filter
+    const parts = parseProductAddress(productAddress);
+    if (parts) {
+      coordinateFilter = {
+        kinds: [PRODUCT_KIND],
+        authors: [parts.pubkey],
+        "#d": [parts.dTag],
+      };
+    }
+  }
+
+  if (!coordinateFilter && productId) {
+    // pre-flight check to resolve the coordinate
+    const resolved = await resolveCoordinateFromId(productId, context);
+    if (resolved.errorResponse) return resolved.errorResponse;
+
+    if (resolved.pubkey && resolved.dTag) {
+      coordinateFilter = {
+        kinds: [PRODUCT_KIND],
+        authors: [resolved.pubkey],
+        "#d": [resolved.dTag],
+      };
+    } else {
+      // Could not resolve coordinate; fall back to exact ID lookup
+      fallbackId = productId;
+      hints.push(
+        "Could not resolve productId to a coordinate; using exact-id lookup which may return stale data."
+      );
+    }
+  }
+
+  const relayFilter: NostrFilter = coordinateFilter ?? {
+    kinds: [PRODUCT_KIND],
+    ids: [fallbackId!],
+  };
+
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [relayFilter],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  if (allRelaysFailed(relayResult.meta)) {
+    return createRelayUnavailableResponse(relayResult.meta);
+  }
+
+  const deduped = mergeAndDeduplicateProducts(relayResult.events);
+  const event = deduped[0];
+  if (!event) {
+    hints.push(
+      "Use search_products with keyword, category, or location filters to discover products."
+    );
+    return createErrorResponse(
+      "Product not found.",
+      MCP_ERROR_CODES.NOT_FOUND,
+      false,
+      undefined,
+      buildToolMeta(relayResult.meta, { hints })
+    );
+  }
+
+  const product = parseProductEvent(event);
+  const successMeta = buildToolMeta(relayResult.meta, {
+    resultCount: 1,
+    totalMatches: 1,
+    truncated: false,
+    dataFreshness: getDataFreshness([product]),
+    hints,
+  });
+
+  return createSuccessResponse({ product }, successMeta, 1);
+}

--- a/packages/shopstr-mcp/src/tools/get-reviews.ts
+++ b/packages/shopstr-mcp/src/tools/get-reviews.ts
@@ -1,0 +1,313 @@
+import { z } from "zod";
+
+import {
+  getParameterizedReplaceableCoordinate,
+  mergeAndDeduplicateProducts,
+  mergeAndDeduplicateReviews,
+} from "../dedup.js";
+import { createSuccessResponse, type ToolTextResponse } from "../errors.js";
+import { parseReviewEvent } from "../parse-tags.js";
+import { fetchFromRelays } from "../relay-fetch.js";
+import type { NostrEvent, NostrFilter } from "../types.js";
+import { reviewsInputSchema } from "../validation.js";
+import {
+  PRODUCT_KIND,
+  REVIEW_KIND,
+  REVIEW_RESPONSE_BUDGET,
+  allRelaysFailed,
+  buildToolMeta,
+  createRelayUnavailableResponse,
+  createValidationErrorResponse,
+  getDataFreshness,
+} from "./common.js";
+import type { CoreToolContext } from "./context.js";
+
+export const getReviewsInputSchema = {
+  productId: z
+    .string()
+    .optional()
+    .describe("Product event ID; MCP resolves it to the product address"),
+  productAddress: z
+    .string()
+    .optional()
+    .describe("Product address as 30402:<seller-pubkey>:<product-d-tag>"),
+  sellerPubkey: z
+    .string()
+    .optional()
+    .describe("Seller public key as hex or npub"),
+};
+
+function hasTag(event: NostrEvent, key: string, value: string): boolean {
+  return event.tags.some((tag) => tag[0] === key && tag[1] === value);
+}
+
+function reviewMatchesTarget(
+  event: NostrEvent,
+  productAddresses: readonly string[],
+  productId?: string,
+  sellerPubkey?: string
+): boolean {
+  const dTag = event.tags.find((tag) => tag[0] === "d")?.[1] ?? "";
+
+  if (
+    productAddresses.length > 0 &&
+    !productAddresses.some((address) => hasProductAddress(event, address)) &&
+    !(productId && hasTag(event, "e", productId))
+  ) {
+    return false;
+  }
+
+  if (
+    productId &&
+    productAddresses.length === 0 &&
+    !hasTag(event, "e", productId) &&
+    !dTag.includes(productId)
+  ) {
+    return false;
+  }
+
+  if (
+    sellerPubkey &&
+    !hasTag(event, "p", sellerPubkey) &&
+    !eventReferencesSeller(event, sellerPubkey)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function hasProductAddress(event: NostrEvent, productAddress: string): boolean {
+  return (
+    hasTag(event, "d", `a:${productAddress}`) ||
+    hasTag(event, "d", productAddress) ||
+    hasTag(event, "a", productAddress)
+  );
+}
+
+function eventReferencesSeller(
+  event: NostrEvent,
+  sellerPubkey: string
+): boolean {
+  return event.tags.some((tag) => {
+    const [key, value] = tag;
+    return (
+      typeof value === "string" &&
+      (key === "d" || key === "a") &&
+      value.includes(sellerPubkey)
+    );
+  });
+}
+
+function createReviewFilter(fields: Partial<NostrFilter>): NostrFilter {
+  return {
+    kinds: [REVIEW_KIND],
+    limit: 500,
+    ...fields,
+  };
+}
+
+function buildReviewFilters(
+  productAddresses: readonly string[],
+  productId?: string,
+  sellerPubkey?: string
+): NostrFilter[] {
+  const filters: NostrFilter[] = [];
+
+  for (const productAddress of productAddresses) {
+    filters.push(
+      createReviewFilter({ "#d": [`a:${productAddress}`, productAddress] }),
+      createReviewFilter({ "#a": [productAddress] })
+    );
+  }
+
+  if (productId) filters.push(createReviewFilter({ "#e": [productId] }));
+  if (sellerPubkey) filters.push(createReviewFilter({ "#p": [sellerPubkey] }));
+
+  return filters.length > 0 ? filters : [createReviewFilter({})];
+}
+
+function addProductAddressesFromEvents(
+  events: readonly NostrEvent[],
+  productAddresses: Set<string>
+): void {
+  for (const event of mergeAndDeduplicateProducts(events)) {
+    const coordinate = getParameterizedReplaceableCoordinate(event);
+    if (coordinate) productAddresses.add(coordinate);
+  }
+}
+
+async function resolveProductAddressFromProductId(
+  productId: string,
+  context: CoreToolContext
+): Promise<{ address?: string; errorResponse?: ToolTextResponse }> {
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [
+      {
+        kinds: [PRODUCT_KIND],
+        ids: [productId],
+      },
+    ],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  if (allRelaysFailed(relayResult.meta)) {
+    return {
+      errorResponse: createRelayUnavailableResponse(relayResult.meta, [
+        "Could not resolve productId to a product address; retry later or pass productAddress directly.",
+      ]),
+    };
+  }
+
+  const productEvent = relayResult.events.find(
+    (event) => event.kind === PRODUCT_KIND && event.id === productId
+  );
+
+  return {
+    address: productEvent
+      ? getParameterizedReplaceableCoordinate(productEvent)
+      : undefined,
+  };
+}
+
+async function resolveProductAddressesFromSellerPubkey(
+  sellerPubkey: string,
+  context: CoreToolContext
+): Promise<{ addresses: string[]; errorResponse?: ToolTextResponse }> {
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [
+      {
+        kinds: [PRODUCT_KIND],
+        authors: [sellerPubkey],
+        limit: 500,
+      },
+    ],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  if (allRelaysFailed(relayResult.meta)) {
+    return {
+      addresses: [],
+      errorResponse: createRelayUnavailableResponse(relayResult.meta, [
+        "Could not resolve seller products to review addresses; retry later or query a specific productAddress.",
+      ]),
+    };
+  }
+
+  const addresses = new Set<string>();
+  addProductAddressesFromEvents(relayResult.events, addresses);
+  return { addresses: Array.from(addresses) };
+}
+
+function buildReviewHints(
+  totalMatches: number,
+  returnedCount: number,
+  addressResolutionHint?: string
+): string[] {
+  const hints: string[] = [];
+  if (addressResolutionHint) hints.push(addressResolutionHint);
+  if (totalMatches > returnedCount) {
+    hints.push(
+      "Too many reviews matched; narrow by productAddress, productId, or sellerPubkey for a smaller response."
+    );
+  }
+  return hints;
+}
+
+export async function handleGetReviews(
+  args: Record<string, unknown>,
+  context: CoreToolContext
+): Promise<ToolTextResponse> {
+  const parsed = reviewsInputSchema.safeParse(args);
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const { productAddress, productId, sellerPubkey } = parsed.data;
+  const productAddresses = new Set<string>();
+  if (productAddress) productAddresses.add(productAddress);
+
+  let addressResolutionHint: string | undefined;
+  if (productId && !productAddress) {
+    const resolved = await resolveProductAddressFromProductId(
+      productId,
+      context
+    );
+    if (resolved.errorResponse) return resolved.errorResponse;
+    if (resolved.address) {
+      productAddresses.add(resolved.address);
+    } else {
+      addressResolutionHint =
+        "Could not resolve productId to a product address; used legacy #e review lookup only.";
+    }
+  }
+
+  if (sellerPubkey) {
+    const resolved = await resolveProductAddressesFromSellerPubkey(
+      sellerPubkey,
+      context
+    );
+    if (resolved.errorResponse) return resolved.errorResponse;
+    for (const address of resolved.addresses) {
+      productAddresses.add(address);
+    }
+    if (resolved.addresses.length === 0) {
+      addressResolutionHint =
+        addressResolutionHint ??
+        "Could not resolve seller products to review addresses; used legacy #p review lookup only.";
+    }
+  }
+
+  const resolvedProductAddresses = Array.from(productAddresses);
+  const relayFilters = buildReviewFilters(
+    resolvedProductAddresses,
+    productId,
+    sellerPubkey
+  );
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    relayFilters,
+    { timeoutMs: context.timeoutMs }
+  );
+
+  if (allRelaysFailed(relayResult.meta)) {
+    return createRelayUnavailableResponse(relayResult.meta);
+  }
+
+  const reviewEvents = mergeAndDeduplicateReviews(relayResult.events).filter(
+    (event) =>
+      reviewMatchesTarget(
+        event,
+        resolvedProductAddresses,
+        productId,
+        sellerPubkey
+      )
+  );
+  const reviews = reviewEvents.map(parseReviewEvent);
+  const returnedReviews = reviews.slice(0, REVIEW_RESPONSE_BUDGET);
+  const truncated = returnedReviews.length < reviews.length;
+  const hints = buildReviewHints(
+    reviews.length,
+    returnedReviews.length,
+    addressResolutionHint
+  );
+  const meta = buildToolMeta(relayResult.meta, {
+    resultCount: returnedReviews.length,
+    totalMatches: reviews.length,
+    truncated,
+    dataFreshness: getDataFreshness(returnedReviews),
+    hints,
+  });
+
+  return createSuccessResponse(
+    {
+      count: returnedReviews.length,
+      totalMatches: reviews.length,
+      reviews: returnedReviews,
+    },
+    meta,
+    returnedReviews.length
+  );
+}

--- a/packages/shopstr-mcp/src/tools/index.ts
+++ b/packages/shopstr-mcp/src/tools/index.ts
@@ -1,0 +1,52 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { wrapWithAudit } from "../audit-log.js";
+import type { CoreToolContext } from "./context.js";
+import {
+  getProductDetailsInputSchema,
+  handleGetProductDetails,
+} from "./get-product-details.js";
+import { getReviewsInputSchema, handleGetReviews } from "./get-reviews.js";
+import {
+  handleSearchProducts,
+  searchProductsInputSchema,
+} from "./search-products.js";
+
+export function registerCoreTools(
+  server: McpServer,
+  context: CoreToolContext
+): void {
+  server.registerTool(
+    "search_products",
+    {
+      description:
+        "Search public Shopstr product listings by keyword, category, location, currency, or price range.",
+      inputSchema: searchProductsInputSchema,
+    },
+    wrapWithAudit("search_products", (args, _extra) =>
+      handleSearchProducts(args, context)
+    )
+  );
+
+  server.registerTool(
+    "get_product_details",
+    {
+      description: "Get full details for a public Shopstr product listing.",
+      inputSchema: getProductDetailsInputSchema,
+    },
+    wrapWithAudit("get_product_details", (args, _extra) =>
+      handleGetProductDetails(args, context)
+    )
+  );
+
+  server.registerTool(
+    "get_reviews",
+    {
+      description: "Get public reviews for a Shopstr product or seller.",
+      inputSchema: getReviewsInputSchema,
+    },
+    wrapWithAudit("get_reviews", (args, _extra) =>
+      handleGetReviews(args, context)
+    )
+  );
+}

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -186,7 +186,8 @@ export async function handleSearchProducts(
     }
   }
 
-  const responseLimit = Math.min(filters.limit, PRODUCT_RESPONSE_BUDGET);
+  const requestedLimit = filters.limit ?? PRODUCT_RESPONSE_BUDGET;
+  const responseLimit = Math.min(requestedLimit, PRODUCT_RESPONSE_BUDGET);
   const returnedProducts = products.slice(0, responseLimit);
   const truncated = returnedProducts.length < products.length;
   const hints = buildSearchHints(

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -1,0 +1,214 @@
+import { z } from "zod";
+
+import { mergeAndDeduplicateProducts } from "../dedup.js";
+import { createSuccessResponse, type ToolTextResponse } from "../errors.js";
+import { parseProductEvent } from "../parse-tags.js";
+import { fetchFromRelays } from "../relay-fetch.js";
+import type { NostrFilter, ProductResponse } from "../types.js";
+import { searchProductsSchema } from "../validation.js";
+import {
+  PRODUCT_KIND,
+  PRODUCT_RESPONSE_BUDGET,
+  allRelaysFailed,
+  buildToolMeta,
+  createRelayUnavailableResponse,
+  createValidationErrorResponse,
+  getDataFreshness,
+} from "./common.js";
+import type { CoreToolContext } from "./context.js";
+
+export const searchProductsInputSchema = {
+  keyword: z
+    .string()
+    .max(200)
+    .optional()
+    .describe("Search keyword to match against product title or summary"),
+  category: z.string().max(100).optional().describe("Product category tag"),
+  location: z.string().max(100).optional().describe("Product location"),
+  minPrice: z.number().min(0).finite().optional().describe("Minimum price"),
+  maxPrice: z.number().min(0).finite().optional().describe("Maximum price"),
+  currency: z
+    .string()
+    .max(10)
+    .optional()
+    .describe("Currency code required when using price filters"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      `Requested result count. Responses are capped at ${PRODUCT_RESPONSE_BUDGET} products for MCP token budgeting.`
+    ),
+};
+
+type SearchProductsInput = z.infer<typeof searchProductsSchema>;
+
+function productMatchesFilters(
+  product: ProductResponse,
+  filters: SearchProductsInput
+): boolean {
+  // hidden products never returned in search results.
+  if (product.visibility === "hidden") return false;
+
+  if (filters.keyword) {
+    const keyword = filters.keyword.toLowerCase();
+    const searchableText = [
+      product.title,
+      product.summary,
+      product.location,
+      ...product.categories,
+    ]
+      .join(" ")
+      .toLowerCase();
+    if (!searchableText.includes(keyword)) return false;
+  }
+
+  if (filters.category) {
+    const category = filters.category.toLowerCase();
+    if (!product.categories.some((value) => value.toLowerCase() === category)) {
+      return false;
+    }
+  }
+
+  if (filters.location) {
+    const location = filters.location.toLowerCase();
+    if (!product.location.toLowerCase().includes(location)) return false;
+  }
+
+  if (filters.currency) {
+    if (product.currency?.toLowerCase() !== filters.currency.toLowerCase()) {
+      return false;
+    }
+  }
+
+  if (filters.minPrice !== undefined || filters.maxPrice !== undefined) {
+    if (product.priceStatus !== "known" || product.price === undefined) {
+      return false;
+    }
+    if (filters.minPrice !== undefined && product.price < filters.minPrice) {
+      return false;
+    }
+    if (filters.maxPrice !== undefined && product.price > filters.maxPrice) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function buildSearchHints(
+  filters: SearchProductsInput,
+  totalMatches: number,
+  returnedCount: number
+): string[] {
+  const hints: string[] = [];
+  if (totalMatches > returnedCount) {
+    hints.push(
+      "Too many products matched; narrow the search with keyword, category, location, currency, or price filters."
+    );
+  }
+  if (!filters.keyword && !filters.category && !filters.location) {
+    hints.push(
+      "Add keyword, category, or location filters for a more focused product search."
+    );
+  }
+  if (
+    (filters.minPrice !== undefined || filters.maxPrice !== undefined) &&
+    !filters.currency
+  ) {
+    hints.push("Currency is required for price filters.");
+  }
+  return hints;
+}
+
+function buildSearchFilters(filters: SearchProductsInput): {
+  primary: NostrFilter;
+  fallback: NostrFilter | undefined;
+} {
+  const base: NostrFilter = { kinds: [PRODUCT_KIND], limit: 500 };
+
+  if (filters.category) {
+    const variants = new Set([
+      filters.category,
+      filters.category.toLowerCase(),
+    ]);
+    return {
+      primary: { ...base, "#t": Array.from(variants) },
+      fallback: base, // Fall back to broad query if #t returns nothing
+    };
+  }
+
+  return { primary: base, fallback: undefined };
+}
+
+export async function handleSearchProducts(
+  args: Record<string, unknown>,
+  context: CoreToolContext
+): Promise<ToolTextResponse> {
+  const parsed = searchProductsSchema.safeParse(args);
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const filters = parsed.data;
+  const { primary, fallback } = buildSearchFilters(filters);
+
+  let relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [primary],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  if (allRelaysFailed(relayResult.meta)) {
+    return createRelayUnavailableResponse(relayResult.meta);
+  }
+
+  let products = mergeAndDeduplicateProducts(relayResult.events)
+    .map(parseProductEvent)
+    .filter((product) => productMatchesFilters(product, filters));
+
+  // Fallback: if targeted #t query returned nothing and we have a broad fallback,
+  // retry with the broad filter (merchant may have written category in description
+  // but forgotten the official #t tag).
+  if (products.length === 0 && fallback) {
+    relayResult = await fetchFromRelays(
+      context.nostr,
+      context.relays,
+      [fallback],
+      { timeoutMs: context.timeoutMs }
+    );
+
+    if (!allRelaysFailed(relayResult.meta)) {
+      products = mergeAndDeduplicateProducts(relayResult.events)
+        .map(parseProductEvent)
+        .filter((product) => productMatchesFilters(product, filters));
+    }
+  }
+
+  const responseLimit = Math.min(filters.limit, PRODUCT_RESPONSE_BUDGET);
+  const returnedProducts = products.slice(0, responseLimit);
+  const truncated = returnedProducts.length < products.length;
+  const hints = buildSearchHints(
+    filters,
+    products.length,
+    returnedProducts.length
+  );
+  const meta = buildToolMeta(relayResult.meta, {
+    resultCount: returnedProducts.length,
+    totalMatches: products.length,
+    truncated,
+    dataFreshness: getDataFreshness(returnedProducts),
+    hints,
+  });
+
+  return createSuccessResponse(
+    {
+      count: returnedProducts.length,
+      totalMatches: products.length,
+      products: returnedProducts,
+    },
+    meta,
+    returnedProducts.length
+  );
+}

--- a/packages/shopstr-mcp/src/types.ts
+++ b/packages/shopstr-mcp/src/types.ts
@@ -22,6 +22,17 @@ export type PricingBlock = {
 
 export type PriceStatus = "known" | "missing" | "invalid";
 
+export type ProductImage = {
+  url: string;
+  dimensions?: string;
+  order?: number;
+};
+
+export type ShippingOptionRef = {
+  reference: string;
+  extraCost?: number;
+};
+
 export type ProductResponse = {
   id: string;
   pubkey: string;
@@ -29,14 +40,19 @@ export type ProductResponse = {
   title: string;
   summary: string;
   publishedAt?: string;
-  images: string[];
+  images: ProductImage[];
   categories: string[];
   location: string;
   price?: number;
   currency?: string;
   priceStatus: PriceStatus;
+  productType?: "simple" | "variable" | "variation";
+  productFormat?: "digital" | "physical";
+  visibility?: "hidden" | "on-sale" | "pre-order";
   shippingType?: ShippingOptionsType;
   shippingCost?: number;
+  shippingOptions?: ShippingOptionRef[];
+  stock?: number;
   quantity?: number;
   condition?: string;
   status?: string;

--- a/packages/shopstr-mcp/src/validation.ts
+++ b/packages/shopstr-mcp/src/validation.ts
@@ -2,6 +2,13 @@ import { nip19 } from "nostr-tools";
 import { z } from "zod";
 
 const HEX_64_RE = /^[0-9a-f]{64}$/;
+const PRODUCT_ADDRESS_KIND = "30402";
+
+export type ProductAddressParts = {
+  coordinate: string;
+  pubkey: string;
+  dTag: string;
+};
 
 export function isHex64(value: string): boolean {
   return HEX_64_RE.test(value);
@@ -34,6 +41,31 @@ export function canonicalizeSearch(input: string): string {
   return input.trim().replace(/\s+/g, " ");
 }
 
+export function parseProductAddress(
+  input: string
+): ProductAddressParts | undefined {
+  const trimmed = input.trim();
+  const coordinate =
+    trimmed.slice(0, 2).toLowerCase() === "a:" ? trimmed.slice(2) : trimmed;
+  const [kind, pubkeyInput, ...dTagParts] = coordinate.split(":");
+  const pubkey = pubkeyInput?.toLowerCase() ?? "";
+  const dTag = dTagParts.join(":");
+
+  if (kind !== PRODUCT_ADDRESS_KIND || !isHex64(pubkey) || dTag.length === 0) {
+    return;
+  }
+
+  return {
+    coordinate: `${PRODUCT_ADDRESS_KIND}:${pubkey}:${dTag}`,
+    pubkey,
+    dTag,
+  };
+}
+
+export function canonicalizeProductAddress(input: string): string {
+  return parseProductAddress(input)?.coordinate ?? input.trim();
+}
+
 const hex64Schema = z
   .string()
   .transform(canonicalizeHex)
@@ -45,6 +77,15 @@ export const pubkeySchema = z
   .refine(isHex64, "Expected a 64-character hex pubkey or npub");
 
 export const eventIdSchema = hex64Schema;
+
+export const productAddressSchema = z
+  .string()
+  .max(300)
+  .transform(canonicalizeProductAddress)
+  .refine(
+    (value) => parseProductAddress(value) !== undefined,
+    "Expected a product address like 30402:<seller-pubkey>:<product-d-tag>"
+  );
 
 export const searchSchema = z
   .string()
@@ -101,9 +142,15 @@ export const searchProductsSchema = z
     }
   );
 
-export const productIdInputSchema = z.object({
-  productId: eventIdSchema,
-});
+export const productDetailsInputSchema = z
+  .object({
+    productId: eventIdSchema.optional(),
+    productAddress: productAddressSchema.optional(),
+  })
+  .refine(
+    (data) => data.productId !== undefined || data.productAddress !== undefined,
+    { message: "Either productId or productAddress is required" }
+  );
 
 export const pubkeyInputSchema = z.object({
   pubkey: pubkeySchema,
@@ -112,11 +159,15 @@ export const pubkeyInputSchema = z.object({
 export const reviewsInputSchema = z
   .object({
     productId: eventIdSchema.optional(),
+    productAddress: productAddressSchema.optional(),
     sellerPubkey: pubkeySchema.optional(),
   })
   .refine(
-    (data) => data.productId !== undefined || data.sellerPubkey !== undefined,
+    (data) =>
+      data.productId !== undefined ||
+      data.productAddress !== undefined ||
+      data.sellerPubkey !== undefined,
     {
-      message: "Either productId or sellerPubkey is required",
+      message: "Either productId, productAddress, or sellerPubkey is required",
     }
   );

--- a/packages/shopstr-mcp/test/dedup.node.mjs
+++ b/packages/shopstr-mcp/test/dedup.node.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getParameterizedReplaceableCoordinate,
   mergeAndDeduplicateProducts,
+  mergeAndDeduplicateReviews,
 } from "../dist/dedup.js";
 
 const hex = (char) => char.repeat(64);
@@ -54,4 +55,91 @@ test("deduplicates identical event ids after coordinate merge", () => {
 
   assert.equal(deduped.length, 1);
   assert.equal(deduped[0].id, hex("4"));
+});
+
+test("deduplicates reviews by reviewer and target d-tag", () => {
+  const older = event({
+    id: hex("5"),
+    kind: 31555,
+    created_at: 10,
+    tags: [["d", "reviewer:product"]],
+  });
+  const newer = event({
+    id: hex("6"),
+    kind: 31555,
+    created_at: 20,
+    tags: [["d", "reviewer:product"]],
+  });
+  const other = event({
+    id: hex("7"),
+    kind: 31555,
+    pubkey: hex("d"),
+    created_at: 15,
+    tags: [["d", "reviewer:product"]],
+  });
+
+  const deduped = mergeAndDeduplicateReviews([older, newer, other]);
+
+  assert.deepEqual(
+    deduped.map((item) => item.id),
+    [hex("6"), hex("7")]
+  );
+});
+
+test("deduplicates Gamma d-tag and standard a-tag reviews by product address", () => {
+  const productAddress = `30402:${hex("8")}:product-1`;
+  const gammaReview = event({
+    id: hex("8"),
+    kind: 31555,
+    created_at: 10,
+    tags: [["d", `a:${productAddress}`]],
+  });
+  const standardReview = event({
+    id: hex("9"),
+    kind: 31555,
+    created_at: 20,
+    tags: [
+      ["d", productAddress],
+      ["a", productAddress],
+    ],
+  });
+
+  const deduped = mergeAndDeduplicateReviews([gammaReview, standardReview]);
+
+  assert.deepEqual(
+    deduped.map((item) => item.id),
+    [hex("9")]
+  );
+});
+
+test("far-future product does not beat a current valid product for the same coordinate", () => {
+  const now = Math.floor(Date.now() / 1000);
+  const valid = event({ id: hex("c"), created_at: now - 60 }); // 1 minute ago
+  const future = event({ id: hex("d"), created_at: now + 999999 }); // far future
+
+  const deduped = mergeAndDeduplicateProducts([future, valid]);
+
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].id, hex("c"), "should prefer the non-future event");
+});
+
+test("far-future review does not beat a current valid review for the same target", () => {
+  const now = Math.floor(Date.now() / 1000);
+  const valid = event({
+    id: hex("e"),
+    kind: 31555,
+    created_at: now - 60,
+    tags: [["d", "reviewer:product"]],
+  });
+  const future = event({
+    id: hex("f"),
+    kind: 31555,
+    created_at: now + 999999,
+    tags: [["d", "reviewer:product"]],
+  });
+
+  const deduped = mergeAndDeduplicateReviews([future, valid]);
+
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].id, hex("e"), "should prefer the non-future event");
 });

--- a/packages/shopstr-mcp/test/get-product-details.node.mjs
+++ b/packages/shopstr-mcp/test/get-product-details.node.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handleGetProductDetails } from "../dist/tools/get-product-details.js";
+
+const hex = (char) => char.repeat(64);
+
+function productEvent(overrides = {}) {
+  return {
+    id: hex("a"),
+    pubkey: hex("b"),
+    created_at: 100,
+    kind: 30402,
+    tags: [
+      ["d", "product"],
+      ["title", "Linen Shirt"],
+      ["summary", "A nice shirt"],
+      ["price", "10", "USD"],
+    ],
+    content: "",
+    sig: "c".repeat(128),
+    ...overrides,
+  };
+}
+
+function context(fetchImpl) {
+  return {
+    relays: ["wss://relay.example.com"],
+    timeoutMs: 100,
+    nostr: {
+      async fetch(filters) {
+        return fetchImpl(filters);
+      },
+    },
+  };
+}
+
+test("get_product_details returns a product by event id via coordinate resolution", async () => {
+  const productId = hex("1");
+  const ctx = context((filters) => {
+    // Pre-flight: return the product by id
+    if (filters.some((f) => f.ids?.includes(productId))) {
+      return [productEvent({ id: productId })];
+    }
+    // Coordinate fetch: return the latest version
+    if (filters.some((f) => f["#d"]?.includes("product"))) {
+      return [productEvent({ id: productId })];
+    }
+    return [];
+  });
+
+  const response = await handleGetProductDetails({ productId }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.resultCount, 1);
+  assert.equal(body.product.id, productId);
+  assert.equal(body.product.title, "Linen Shirt");
+  assert.equal(body._meta.resultCount, 1);
+});
+
+test("get_product_details accepts productAddress and skips pre-flight", async () => {
+  const productAddress = `30402:${hex("b")}:product`;
+  let fetchCallCount = 0;
+  const ctx = context((filters) => {
+    fetchCallCount++;
+    // Should only be called once (coordinate fetch), no pre-flight
+    if (filters.some((f) => f["#d"]?.includes("product"))) {
+      return [productEvent()];
+    }
+    return [];
+  });
+
+  const response = await handleGetProductDetails({ productAddress }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(fetchCallCount, 1, "should skip pre-flight with productAddress");
+  assert.equal(response.resultCount, 1);
+  assert.equal(body.product.title, "Linen Shirt");
+});
+
+test("get_product_details returns not found when relays have no matching product", async () => {
+  const response = await handleGetProductDetails(
+    { productId: hex("1") },
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "NOT_FOUND");
+});
+
+test("get_product_details requires either productId or productAddress", async () => {
+  const response = await handleGetProductDetails(
+    {},
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "VALIDATION_ERROR");
+});
+
+test("get_product_details fetches latest version via coordinate when product is updated", async () => {
+  const oldId = hex("1");
+  const newId = hex("2");
+  const ctx = context((filters) => {
+    // Pre-flight: return the old version by id
+    if (filters.some((f) => f.ids?.includes(oldId))) {
+      return [productEvent({ id: oldId, created_at: 10 })];
+    }
+    // Coordinate fetch: return the newer version
+    if (filters.some((f) => f["#d"]?.includes("product"))) {
+      return [
+        productEvent({
+          id: newId,
+          created_at: 20,
+          tags: [
+            ["d", "product"],
+            ["title", "Updated Linen Shirt"],
+            ["summary", "Updated description"],
+            ["price", "50", "USD"],
+          ],
+        }),
+      ];
+    }
+    return [];
+  });
+
+  const response = await handleGetProductDetails({ productId: oldId }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  // Should return the LATEST version (new price), not the old stale one
+  assert.equal(response.resultCount, 1);
+  assert.equal(body.product.id, newId);
+  assert.equal(body.product.title, "Updated Linen Shirt");
+  assert.equal(body.product.price, 50);
+});

--- a/packages/shopstr-mcp/test/get-reviews.node.mjs
+++ b/packages/shopstr-mcp/test/get-reviews.node.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handleGetReviews } from "../dist/tools/get-reviews.js";
+
+const hex = (char) => char.repeat(64);
+const productId = hex("9");
+const sellerPubkey = hex("8");
+const productAddress = `30402:${sellerPubkey}:product-1`;
+
+function reviewEvent(overrides = {}) {
+  return {
+    id: hex("a"),
+    pubkey: hex("b"),
+    created_at: 100,
+    kind: 31555,
+    tags: [
+      ["d", `${hex("b")}:${productId}`],
+      ["e", productId],
+      ["rating", "5", "quality"],
+    ],
+    content: "Great product",
+    sig: "c".repeat(128),
+    ...overrides,
+  };
+}
+
+function productEvent(overrides = {}) {
+  return {
+    id: productId,
+    pubkey: sellerPubkey,
+    created_at: 90,
+    kind: 30402,
+    tags: [["d", "product-1"]],
+    content: "",
+    sig: "d".repeat(128),
+    ...overrides,
+  };
+}
+
+function context(fetchImpl) {
+  const calls = [];
+  return {
+    calls,
+    relays: ["wss://relay.example.com"],
+    timeoutMs: 100,
+    nostr: {
+      async fetch(filters) {
+        calls.push(filters);
+        return fetchImpl(filters);
+      },
+    },
+  };
+}
+
+test("get_reviews queries Gamma #d and standard #a product review models", async () => {
+  const ctx = context((filters) => {
+    if (filters.some((filter) => filter.kinds?.includes(30402))) {
+      return [productEvent()];
+    }
+
+    return [
+      reviewEvent({
+        id: hex("1"),
+        created_at: 10,
+        tags: [
+          ["d", `a:${productAddress}`],
+          ["rating", "5", "quality"],
+        ],
+        content: "Old Gamma review",
+      }),
+      reviewEvent({
+        id: hex("2"),
+        created_at: 20,
+        tags: [
+          ["d", productAddress],
+          ["a", productAddress],
+          ["rating", "4", "quality"],
+        ],
+        content: "New standard review",
+      }),
+      reviewEvent({
+        id: hex("3"),
+        pubkey: hex("d"),
+        created_at: 15,
+        tags: [
+          ["d", `a:${productAddress}`],
+          ["rating", "4", "shipping"],
+        ],
+        content: "Second reviewer",
+      }),
+    ];
+  });
+
+  const response = await handleGetReviews({ productId }, ctx);
+  const body = JSON.parse(response.content[0].text);
+  const reviewFilters = ctx.calls[1];
+
+  assert.equal(response.resultCount, 2);
+  assert.equal(body.count, 2);
+  assert.deepEqual(
+    body.reviews.map((review) => review.id),
+    [hex("2"), hex("3")]
+  );
+  assert.deepEqual(body.reviews[0].ratings, { quality: 4 });
+  assert.equal(
+    reviewFilters.some((filter) =>
+      filter["#d"]?.includes(`a:${productAddress}`)
+    ),
+    true
+  );
+  assert.equal(
+    reviewFilters.some((filter) => filter["#a"]?.includes(productAddress)),
+    true
+  );
+  assert.equal(
+    reviewFilters.some((filter) => filter["#e"]?.includes(productId)),
+    true
+  );
+});
+
+test("get_reviews accepts productAddress without a product lookup", async () => {
+  const ctx = context((filters) => {
+    assert.equal(
+      filters.some((filter) => filter.kinds?.includes(30402)),
+      false
+    );
+    return [
+      reviewEvent({
+        id: hex("4"),
+        tags: [
+          ["d", `a:${productAddress}`],
+          ["rating", "5", "quality"],
+        ],
+      }),
+    ];
+  });
+
+  const response = await handleGetReviews(
+    { productAddress: `a:${productAddress}` },
+    ctx
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(ctx.calls.length, 1);
+  assert.equal(body.count, 1);
+  assert.equal(body.reviews[0].d, `a:${productAddress}`);
+});
+
+test("get_reviews resolves seller products and queries product-address reviews", async () => {
+  const secondProductAddress = `30402:${sellerPubkey}:product-2`;
+  const ctx = context((filters) => {
+    if (filters.some((filter) => filter.authors?.includes(sellerPubkey))) {
+      return [
+        productEvent(),
+        productEvent({
+          id: hex("7"),
+          tags: [["d", "product-2"]],
+        }),
+      ];
+    }
+
+    return [
+      reviewEvent({
+        id: hex("5"),
+        tags: [
+          ["d", `a:${productAddress}`],
+          ["rating", "1", "thumb"],
+        ],
+      }),
+      reviewEvent({
+        id: hex("6"),
+        tags: [
+          ["d", `a:${secondProductAddress}`],
+          ["rating", "0.5", "quality"],
+        ],
+      }),
+    ];
+  });
+
+  const response = await handleGetReviews({ sellerPubkey }, ctx);
+  const body = JSON.parse(response.content[0].text);
+  const productFilters = ctx.calls[0];
+  const reviewFilters = ctx.calls[1];
+
+  assert.equal(
+    productFilters.some((filter) => filter.authors?.includes(sellerPubkey)),
+    true
+  );
+  assert.equal(
+    reviewFilters.some((filter) =>
+      filter["#d"]?.includes(`a:${productAddress}`)
+    ),
+    true
+  );
+  assert.equal(
+    reviewFilters.some((filter) =>
+      filter["#a"]?.includes(secondProductAddress)
+    ),
+    true
+  );
+  assert.equal(
+    reviewFilters.some((filter) => filter["#p"]?.includes(sellerPubkey)),
+    true
+  );
+  assert.equal(body.count, 2);
+});
+
+test("get_reviews requires productId, productAddress, or sellerPubkey", async () => {
+  const response = await handleGetReviews(
+    {},
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "VALIDATION_ERROR");
+});

--- a/packages/shopstr-mcp/test/nostr-manager.node.mjs
+++ b/packages/shopstr-mcp/test/nostr-manager.node.mjs
@@ -3,6 +3,16 @@ import test from "node:test";
 
 import { NostrManager } from "../dist/nostr-manager.js";
 
+test("gc timer does not keep the Node.js process alive", async () => {
+  const manager = new NostrManager([], { gcInterval: 60_000 });
+
+  try {
+    assert.equal(manager.gcTimeout.hasRef(), false);
+  } finally {
+    await manager.close();
+  }
+});
+
 test("relay reconnect refreshes the underlying relay handle", async () => {
   const manager = new NostrManager([], { gcInterval: 60_000 });
   const handles = [];

--- a/packages/shopstr-mcp/test/parse-tags.node.mjs
+++ b/packages/shopstr-mcp/test/parse-tags.node.mjs
@@ -30,7 +30,7 @@ test("parses product events into JSON-safe response objects", () => {
         ["title", "Linen Shirt"],
         ["summary", "A nice shirt"],
         ["published_at", "1700000000"],
-        ["image", "https://example.com/shirt.png"],
+        ["image", "https://example.com/shirt.png", "800x600", "1"],
         ["t", "Clothing"],
         ["location", "NYC"],
         ["price", "10", "USD"],
@@ -55,6 +55,9 @@ test("parses product events into JSON-safe response objects", () => {
   assert.equal(product.priceStatus, "known");
   assert.equal(product.currency, "USD");
   assert.equal(product.pricing.totalEstimate, 12);
+  assert.deepEqual(product.images, [
+    { url: "https://example.com/shirt.png", dimensions: "800x600", order: 1 },
+  ]);
   assert.deepEqual(product.sizes, [{ size: "XL", quantity: 5 }]);
   assert.deepEqual(product.volumes, [{ volume: "500ml", price: 12.5 }]);
   assert.deepEqual(product.weights, [{ weight: "1kg", price: 9 }]);
@@ -118,4 +121,189 @@ test("parses review ratings by rating type", () => {
 
   assert.equal(review.d, "review:product");
   assert.deepEqual(review.ratings, { thumb: 1, quality: 4.5 });
+});
+
+test("caps images at 10 and parses dimensions and sorting order", () => {
+  const tags = [];
+  for (let i = 0; i < 25; i++) {
+    tags.push(["image", `https://example.com/${i}.png`, `${i}x${i}`, `${i}`]);
+  }
+  const product = parseProductEvent(event({ tags }));
+
+  assert.equal(product.images.length, 10);
+  assert.equal(product.images[0].url, "https://example.com/0.png");
+  assert.equal(product.images[0].dimensions, "0x0");
+  assert.equal(product.images[0].order, 0);
+  assert.equal(product.images[9].url, "https://example.com/9.png");
+});
+
+test("caps categories at 20", () => {
+  const tags = [];
+  for (let i = 0; i < 30; i++) {
+    tags.push(["t", `category-${i}`]);
+  }
+  const product = parseProductEvent(event({ tags }));
+
+  assert.equal(product.categories.length, 20);
+});
+
+test("parses Gamma subscription frequency from price tag 4th element", () => {
+  const product = parseProductEvent(
+    event({
+      tags: [
+        ["d", "sub-product"],
+        ["title", "Monthly Box"],
+        ["price", "10", "USD", "M"],
+      ],
+    })
+  );
+
+  assert.equal(product.subscription.enabled, true);
+  assert.deepEqual(product.subscription.frequencies, ["M"]);
+});
+
+test("falls back to legacy subscription tags when no Gamma frequency", () => {
+  const product = parseProductEvent(
+    event({
+      tags: [
+        ["d", "legacy-sub"],
+        ["title", "Legacy Sub"],
+        ["price", "10", "USD"],
+        ["subscription", "true"],
+        ["subscription_frequency", "weekly", "monthly"],
+      ],
+    })
+  );
+
+  assert.equal(product.subscription.enabled, true);
+  assert.deepEqual(product.subscription.frequencies, ["weekly", "monthly"]);
+});
+
+test("defaults product type to simple/digital when missing", () => {
+  const product = parseProductEvent(
+    event({
+      tags: [
+        ["d", "basic-product"],
+        ["title", "Basic Item"],
+      ],
+    })
+  );
+
+  assert.equal(product.productType, "simple");
+  assert.equal(product.productFormat, "digital");
+});
+
+test("parses Gamma product type tag", () => {
+  const product = parseProductEvent(
+    event({
+      tags: [
+        ["d", "physical-product"],
+        ["title", "T-Shirt"],
+        ["type", "variable", "physical"],
+      ],
+    })
+  );
+
+  assert.equal(product.productType, "variable");
+  assert.equal(product.productFormat, "physical");
+});
+
+test("extracts structured shipping_option with extra cost", () => {
+  const product = parseProductEvent(
+    event({
+      tags: [
+        ["d", "shipped-product"],
+        ["title", "Shipped Item"],
+        ["shipping_option", `30406:${hex("a")}:standard-shipping`, "5"],
+        ["shipping_option", `30406:${hex("a")}:express-shipping`],
+        ["shipping_option", `30406:${hex("a")}:bad-shipping`, "-1"],
+      ],
+    })
+  );
+
+  assert.equal(product.shippingOptions.length, 3);
+  assert.equal(
+    product.shippingOptions[0].reference,
+    `30406:${hex("a")}:standard-shipping`
+  );
+  assert.equal(product.shippingOptions[0].extraCost, 5);
+  assert.equal(product.shippingOptions[1].extraCost, undefined);
+  assert.equal(product.shippingOptions[2].extraCost, undefined);
+});
+
+test("defaults visibility to on-sale when tag is absent", () => {
+  const product = parseProductEvent(
+    event({
+      tags: [
+        ["d", "on-sale-product"],
+        ["title", "On Sale"],
+      ],
+    })
+  );
+
+  assert.equal(product.visibility, "on-sale");
+});
+
+test("parses Gamma visibility tags", () => {
+  const hiddenProduct = parseProductEvent(
+    event({
+      tags: [
+        ["d", "hidden-product"],
+        ["title", "Hidden"],
+        ["visibility", "hidden"],
+      ],
+    })
+  );
+  const preorderProduct = parseProductEvent(
+    event({
+      tags: [
+        ["d", "preorder-product"],
+        ["title", "Preorder"],
+        ["visibility", "pre-order"],
+      ],
+    })
+  );
+
+  assert.equal(hiddenProduct.visibility, "hidden");
+  assert.equal(preorderProduct.visibility, "pre-order");
+});
+
+test("parses Gamma stock tag with fallback to legacy quantity", () => {
+  const gammaProduct = parseProductEvent(
+    event({
+      tags: [
+        ["d", "stocked"],
+        ["title", "Stocked Item"],
+        ["stock", "25"],
+        ["quantity", "10"],
+      ],
+    })
+  );
+  assert.equal(gammaProduct.stock, 25);
+  assert.equal(gammaProduct.quantity, 10);
+
+  const invalidStockProduct = parseProductEvent(
+    event({
+      tags: [
+        ["d", "invalid-stock"],
+        ["title", "Invalid Stock Item"],
+        ["stock", "1.5"],
+        ["quantity", "-2"],
+      ],
+    })
+  );
+  assert.equal(invalidStockProduct.stock, undefined);
+  assert.equal(invalidStockProduct.quantity, undefined);
+
+  const legacyProduct = parseProductEvent(
+    event({
+      tags: [
+        ["d", "legacy-qty"],
+        ["title", "Legacy Item"],
+        ["quantity", "15"],
+      ],
+    })
+  );
+  assert.equal(legacyProduct.stock, 15);
+  assert.equal(legacyProduct.quantity, 15);
 });

--- a/packages/shopstr-mcp/test/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/search-products.node.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handleSearchProducts } from "../dist/tools/search-products.js";
+
+const hex = (char) => char.repeat(64);
+
+function productEvent(overrides = {}) {
+  return {
+    id: hex("a"),
+    pubkey: hex("b"),
+    created_at: 100,
+    kind: 30402,
+    tags: [
+      ["d", "product"],
+      ["title", "Hardware Wallet"],
+      ["summary", "Cold storage wallet"],
+      ["price", "40", "USD"],
+      ["t", "Electronics"],
+      ["location", "NYC"],
+    ],
+    content: "",
+    sig: "c".repeat(128),
+    ...overrides,
+  };
+}
+
+function context(eventsByRelay) {
+  return {
+    relays: Object.keys(eventsByRelay),
+    timeoutMs: 100,
+    nostr: {
+      async fetch(_filters, _params, relayUrls) {
+        const relay = relayUrls[0];
+        const result = eventsByRelay[relay];
+        if (result instanceof Error) throw result;
+        return result;
+      },
+    },
+  };
+}
+
+test("search_products filters, deduplicates, budgets, and reports relay degradation", async () => {
+  const goodRelay = "wss://good.example.com";
+  const badRelay = "wss://bad.example.com";
+  const response = await handleSearchProducts(
+    {
+      keyword: "wallet",
+      maxPrice: 50,
+      currency: "USD",
+    },
+    context({
+      [goodRelay]: [
+        productEvent({
+          id: hex("1"),
+          created_at: 10,
+          tags: [
+            ["d", "wallet"],
+            ["title", "Old Hardware Wallet"],
+            ["summary", "Older model"],
+            ["price", "45", "USD"],
+            ["t", "Electronics"],
+          ],
+        }),
+        productEvent({
+          id: hex("2"),
+          created_at: 20,
+          tags: [
+            ["d", "wallet"],
+            ["title", "New Hardware Wallet"],
+            ["summary", "Newer model"],
+            ["price", "40", "USD"],
+            ["t", "Electronics"],
+          ],
+        }),
+        productEvent({
+          id: hex("3"),
+          created_at: 30,
+          tags: [
+            ["d", "expensive-wallet"],
+            ["title", "Premium Wallet"],
+            ["summary", "Too expensive"],
+            ["price", "500", "USD"],
+            ["t", "Electronics"],
+          ],
+        }),
+      ],
+      [badRelay]: new Error("relay down"),
+    })
+  );
+
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(response.resultCount, 1);
+  assert.equal(body.count, 1);
+  assert.equal(body.products[0].id, hex("2"));
+  assert.equal(body.products[0].price, 40);
+  assert.equal(body._meta.degraded, true);
+  assert.deepEqual(body._meta.relaysSucceeded, [goodRelay]);
+  assert.equal(body._meta.relaysFailed[0].url, badRelay);
+});
+
+test("search_products requires currency with price filters", async () => {
+  const response = await handleSearchProducts(
+    { maxPrice: 50 },
+    context({ "wss://relay.example.com": [] })
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "VALIDATION_ERROR");
+});
+
+test("search_products pushes category down to relay with #t filter", async () => {
+  let capturedFilters;
+  const ctx = {
+    relays: ["wss://relay.example.com"],
+    timeoutMs: 100,
+    nostr: {
+      async fetch(filters) {
+        capturedFilters = filters;
+        return [
+          productEvent({
+            id: hex("1"),
+            tags: [
+              ["d", "electronics-product"],
+              ["title", "USB Cable"],
+              ["price", "5", "USD"],
+              ["t", "Electronics"],
+            ],
+          }),
+        ];
+      },
+    },
+  };
+
+  const response = await handleSearchProducts({ category: "Electronics" }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  // Verify the relay received a #t filter
+  assert.equal(
+    capturedFilters.some(
+      (f) =>
+        f["#t"]?.includes("Electronics") || f["#t"]?.includes("electronics")
+    ),
+    true,
+    "should push category down to relay via #t"
+  );
+  assert.equal(body.count, 1);
+  assert.equal(body.products[0].title, "USB Cable");
+});
+
+test("search_products falls back to broad query when #t category returns no matches", async () => {
+  let fetchCallCount = 0;
+  const ctx = {
+    relays: ["wss://relay.example.com"],
+    timeoutMs: 100,
+    nostr: {
+      async fetch(filters) {
+        fetchCallCount++;
+        // First call: targeted #t query returns nothing
+        if (filters.some((f) => f["#t"])) {
+          return [];
+        }
+        // Second call: broad query returns the product (category in description)
+        return [
+          productEvent({
+            id: hex("1"),
+            tags: [
+              ["d", "shoe-product"],
+              ["title", "Running Shoes"],
+              ["summary", "Great shoes for running"],
+              ["price", "100", "USD"],
+              ["t", "shoes"], // lowercase, different from "Shoes"
+            ],
+          }),
+        ];
+      },
+    },
+  };
+
+  const response = await handleSearchProducts({ category: "shoes" }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(fetchCallCount, 2, "should try targeted then fallback");
+  assert.equal(body.count, 1);
+});
+
+test("search_products excludes hidden products", async () => {
+  const response = await handleSearchProducts(
+    {},
+    context({
+      "wss://relay.example.com": [
+        productEvent({
+          id: hex("1"),
+          tags: [
+            ["d", "visible-item"],
+            ["title", "Visible Product"],
+            ["price", "10", "USD"],
+            ["t", "Electronics"],
+          ],
+        }),
+        productEvent({
+          id: hex("2"),
+          tags: [
+            ["d", "hidden-item"],
+            ["title", "Hidden Product"],
+            ["price", "20", "USD"],
+            ["t", "Electronics"],
+            ["visibility", "hidden"],
+          ],
+        }),
+      ],
+    })
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.count, 1);
+  assert.equal(body.products[0].title, "Visible Product");
+});

--- a/packages/shopstr-mcp/test/server.node.mjs
+++ b/packages/shopstr-mcp/test/server.node.mjs
@@ -7,11 +7,46 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { loadConfig } from "../dist/config.js";
 import { createMcpServer } from "../dist/server.js";
 
-test("exposes valid empty MCP discovery handlers for the setup package", async () => {
+const hex = (char) => char.repeat(64);
+
+function productEvent() {
+  return {
+    id: hex("a"),
+    pubkey: hex("b"),
+    created_at: 100,
+    kind: 30402,
+    tags: [
+      ["d", "shirt"],
+      ["title", "Linen Shirt"],
+      ["summary", "A nice shirt"],
+      ["price", "10", "USD"],
+    ],
+    content: "",
+    sig: "c".repeat(128),
+  };
+}
+
+test("registers and calls PR3 core read tools", async () => {
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "shopstr-mcp-test", version: "0.0.0" });
-  const server = createMcpServer(loadConfig({}));
+  let closeCount = 0;
+  const server = createMcpServer(
+    loadConfig({ SHOPSTR_MCP_RELAYS: "wss://relay.example.com" }),
+    {
+      nostr: {
+        async fetch() {
+          return [productEvent()];
+        },
+        async close() {
+          closeCount += 1;
+        },
+      },
+      logger: {
+        warn() {},
+      },
+    }
+  );
 
   try {
     await server.connect(serverTransport);
@@ -22,9 +57,26 @@ test("exposes valid empty MCP discovery handlers for the setup package", async (
     assert.ok(capabilities?.resources);
     assert.ok(capabilities?.prompts);
 
-    assert.deepEqual(await client.listTools(), { tools: [] });
+    const tools = await client.listTools();
+    assert.deepEqual(tools.tools.map((tool) => tool.name).sort(), [
+      "get_product_details",
+      "get_reviews",
+      "search_products",
+    ]);
     assert.deepEqual(await client.listResources(), { resources: [] });
     assert.deepEqual(await client.listPrompts(), { prompts: [] });
+
+    const result = await client.callTool({
+      name: "search_products",
+      arguments: { keyword: "shirt" },
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    assert.equal(body.count, 1);
+    assert.equal(body.products[0].title, "Linen Shirt");
+
+    await server.close();
+    assert.equal(closeCount, 1);
   } finally {
     await client.close();
     await server.close();

--- a/packages/shopstr-mcp/test/smoke-live.mjs
+++ b/packages/shopstr-mcp/test/smoke-live.mjs
@@ -1,0 +1,94 @@
+/**
+ * Live smoke test — calls real Nostr relays.
+ * Run:  node packages/shopstr-mcp/test/smoke-live.mjs
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { loadConfig } from "../dist/config.js";
+import { createMcpServer } from "../dist/server.js";
+
+const config = loadConfig({
+  SHOPSTR_MCP_RELAYS:
+    "wss://nos.lol,wss://relay.damus.io,wss://relay.nostr.band",
+  SHOPSTR_MCP_TOOL_TIMEOUT_MS: "15000",
+});
+
+const server = createMcpServer(config);
+const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+const client = new Client({ name: "smoke-test", version: "0.0.1" });
+
+await server.connect(serverTransport);
+await client.connect(clientTransport);
+
+console.log("=== Tools registered ===");
+const tools = await client.listTools();
+console.log(tools.tools.map((t) => t.name));
+
+// 1. search_products
+console.log("\n=== search_products (keyword: shirt) ===");
+const searchResult = await client.callTool({
+  name: "search_products",
+  arguments: { keyword: "shirt", limit: 3 },
+});
+const searchBody = JSON.parse(searchResult.content[0].text);
+console.log(`Found ${searchBody.count} of ${searchBody.totalMatches} matches`);
+console.log("Relay meta:", {
+  degraded: searchBody._meta?.degraded,
+  coverage: searchBody._meta?.coverage,
+  succeeded: searchBody._meta?.relaysSucceeded,
+  failed: searchBody._meta?.relaysFailed?.map((f) => f.url),
+});
+if (searchBody.products?.length > 0) {
+  const p = searchBody.products[0];
+  console.log("First product:", {
+    id: p.id?.slice(0, 12) + "...",
+    title: p.title,
+    price: p.price,
+    currency: p.currency,
+    priceStatus: p.priceStatus,
+  });
+
+  // 2. get_product_details using the first product's ID
+  console.log("\n=== get_product_details ===");
+  const detailResult = await client.callTool({
+    name: "get_product_details",
+    arguments: { productId: p.id },
+  });
+  const detailBody = JSON.parse(detailResult.content[0].text);
+  if (detailBody.product) {
+    console.log("Product title:", detailBody.product.title);
+    console.log("Categories:", detailBody.product.categories);
+  } else {
+    console.log("Detail response:", detailBody);
+  }
+
+  // 3. get_reviews for the seller
+  console.log("\n=== get_reviews (by seller) ===");
+  const reviewResult = await client.callTool({
+    name: "get_reviews",
+    arguments: { sellerPubkey: p.pubkey },
+  });
+  const reviewBody = JSON.parse(reviewResult.content[0].text);
+  console.log(`Found ${reviewBody.count ?? 0} reviews`);
+  if (reviewBody.reviews?.length > 0) {
+    console.log("First review:", {
+      ratings: reviewBody.reviews[0].ratings,
+      content: reviewBody.reviews[0].content?.slice(0, 80),
+    });
+  }
+} else {
+  console.log("No products found — try a broader search.");
+}
+
+// 4. Validation error test
+console.log("\n=== Validation error (price without currency) ===");
+const errResult = await client.callTool({
+  name: "search_products",
+  arguments: { maxPrice: 50 },
+});
+const errBody = JSON.parse(errResult.content[0].text);
+console.log("Error:", errBody.errorCode, "-", errBody.error);
+
+await server.close();
+await client.close();
+console.log("\n✅ Smoke test complete");


### PR DESCRIPTION
### Description

- Adds relay-backed MCP read tools: search_products, get_product_details, and get_reviews.
- Implements latest-by-coordinate product lookup to avoid returning stale replaceable product events.
- Adds productAddress support for product detail and review lookup flows.
- Gamma Spec based product review fetching using #d address targets.
- Adds standard Nostr #a review lookup fallback.
- Keeps legacy #e and #p review fallbacks for legacy clients
- seller review lookup by deriving seller product addresses before fetching reviews.
- Adds category tag to search product filter 
- Keeps broad relay fallback when category-tagged relay results do not match.
- Adds future timestamp guard to product/review deduplication.
- Adds Gamma product parsing for visibility, stock, product type/format, image metadata, shipping options, and subscriptions.
- Excludes hidden listings from search results.
- Adds response budgeting for product/review results.
- Preserves relay degradation metadata in tool responses
- Adds regression tests for product detail lookup, review lookup, search behavior, deduplication, and parsing.


### Video  
https://drive.google.com/file/d/13Ngyv9tm4GZQjKN6Z5AbgqUZe_agzDqa/view?usp=sharing
### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
