### PR TITLE
Potential fix for code scanning alert no. 41: Server-side request forgery

### DIFF
--- a/pages/api/og-preview.ts
+++ b/pages/api/og-preview.ts
@@ -12,10 +12,13 @@ const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
 const ALLOWED_PREVIEW_HOSTS = new Set<string>([
   "shopstr.store",
   "www.shopstr.store",
+  "shopstr.market",
+  "www.shopstr.market",
 ]);
 
 const ALLOWED_PREVIEW_HOST_SUFFIXES = [
   ".shopstr.store",
+  ".shopstr.market",
 ];
 
 function isAllowedPreviewHost(hostname: string): boolean {

--- a/pages/api/og-preview.ts
+++ b/pages/api/og-preview.ts
@@ -7,6 +7,23 @@ import { applyRateLimit } from "@/utils/rate-limit";
 // cap to prevent us from being used as an SSRF amplifier.
 const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
 
+// Server-controlled allowlist to prevent attacker-chosen outbound targets.
+// Replace entries with the domains your application is intended to preview.
+const ALLOWED_PREVIEW_HOSTS = new Set<string>([
+  "shopstr.store",
+  "www.shopstr.store",
+]);
+
+const ALLOWED_PREVIEW_HOST_SUFFIXES = [
+  ".shopstr.store",
+];
+
+function isAllowedPreviewHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (ALLOWED_PREVIEW_HOSTS.has(host)) return true;
+  return ALLOWED_PREVIEW_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
 type OGData = {
   title?: string;
   description?: string;
@@ -152,6 +169,10 @@ export default async function handler(
     }
   } catch {
     return res.status(400).json({ error: "Invalid URL" });
+  }
+
+  if (!isAllowedPreviewHost(parsedUrl.hostname)) {
+    return res.status(400).json({ error: "URL host is not allowed" });
   }
 
   const isSafeHost = await isSafePublicHostname(parsedUrl.hostname);


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/41](https://github.com/shopstr-eng/shopstr/security/code-scanning/41)

General fix: ensure outbound fetch destinations are selected from a **server-controlled allowlist** (exact hostnames or trusted suffixes), not arbitrary user input. Keep existing protocol/port/private-network defenses as defense-in-depth.

Best single fix without changing core functionality too much: add an explicit hostname allowlist check in `handler` after URL parsing and before `isSafePublicHostname`/`fetch`. This preserves existing OG-preview behavior for approved domains while preventing attacker-selected destinations.

In `pages/api/og-preview.ts`:
- Add a constant allowlist (e.g., exact hosts and/or approved suffixes).
- Add a helper `isAllowedPreviewHost(hostname: string): boolean`.
- In `handler`, reject URLs whose hostname is not on the allowlist with HTTP 400.
- Keep existing `isSafePublicHostname` check in place.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
