### PR TITLE
Potential fix for code scanning alert no. 42: Incomplete URL substring sanitization

### DIFF
--- a/utils/nostr/__tests__/nostr-helper-functions.test.ts
+++ b/utils/nostr/__tests__/nostr-helper-functions.test.ts
@@ -298,9 +298,13 @@ describe("withBlastr", () => {
   it("does not duplicate the blastr relay when it is already present", () => {
     const input = ["wss://relay.damus.io", "wss://sendit.nosflare.com"];
     const result = withBlastr(input);
-    const count = result.filter((r) =>
-      r.includes("sendit.nosflare.com")
-    ).length;
+    const count = result.filter((r) => {
+      try {
+        return new URL(r).hostname === "sendit.nosflare.com";
+      } catch {
+        return false;
+      }
+    }).length;
     expect(count).toBe(1);
   });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/shopstr-eng/shopstr/security/code-scanning/42](https://github.com/shopstr-eng/shopstr/security/code-scanning/42)

Use URL parsing and compare the hostname exactly, instead of substring matching.

Best fix in this file: in the `withBlastr` test (`describe("withBlastr")`, second test), replace:

- `r.includes("sendit.nosflare.com")`

with host-based matching via `new URL(r).hostname === "sendit.nosflare.com"` (safely guarded for invalid URLs). This preserves test intent (“count exact blastr relay host occurrences”) without changing functionality.

No new imports or dependencies are required; `URL` is global in the test runtime.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
