### PR TITLE
Tighten NIP-99 listing tests

### DIFF
--- a/utils/__tests__/listing-identifiers.test.ts
+++ b/utils/__tests__/listing-identifiers.test.ts
@@ -1,6 +1,7 @@
 import { nip19 } from "nostr-tools";
 
 import {
+  decodeListingNaddr,
   eventMatchesListingIdentifier,
   getListingRouteIdentifier,
 } from "../listing-identifiers";
@@ -39,6 +40,21 @@ describe("listing-identifiers", () => {
     expect(eventMatchesListingIdentifier(baseEvent, relayHintedNaddr)).toBe(
       true
     );
+  });
+
+  test("decodes relay-hinted NIP-99 naddr values to listing identity only", () => {
+    const relayHintedNaddr = nip19.naddrEncode({
+      identifier: "listing-d-tag",
+      pubkey: baseEvent.pubkey,
+      kind: 30402,
+      relays: ["wss://relay.shopstr.example"],
+    });
+
+    expect(decodeListingNaddr(relayHintedNaddr)).toEqual({
+      identifier: "listing-d-tag",
+      pubkey: baseEvent.pubkey,
+      kind: 30402,
+    });
   });
 
   test("matches a canonical naddr without relay hints", () => {

--- a/utils/nostr/__tests__/fetch-all-posts-abortable.test.ts
+++ b/utils/nostr/__tests__/fetch-all-posts-abortable.test.ts
@@ -196,4 +196,95 @@ describe("fetchAllPostsAbortable", () => {
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([relayProduct]);
     expect(sub.close).toHaveBeenCalledTimes(1);
   });
+
+  it("merges NIP-99 listings by pubkey and d tag across DB and relay events", async () => {
+    const cacheEventsToDatabase = jest.fn().mockResolvedValue(undefined);
+
+    jest.doMock("@/utils/db/db-client", () => ({
+      cacheEventsToDatabase,
+    }));
+
+    const { fetchAllPostsAbortable } =
+      await import("../fetch-all-posts-abortable");
+
+    let params:
+      | {
+          onevent: (event: any) => void;
+          oneose: () => void;
+        }
+      | undefined;
+    const sub = {
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    const nostr = {
+      subscribe: jest.fn((_filters, subscribeParams) => {
+        params = subscribeParams;
+        return Promise.resolve(sub);
+      }),
+    } as any;
+
+    const cachedOlderListing = makeProductEvent({
+      id: "cached-old",
+      pubkey: "seller",
+      created_at: 10,
+      tags: [["d", "shared-listing"]],
+      sig: "sig-cached-old",
+    });
+    const cachedSeparateListing = makeProductEvent({
+      id: "cached-separate",
+      pubkey: "seller",
+      created_at: 11,
+      tags: [["d", "separate-listing"]],
+      sig: "sig-cached-separate",
+    });
+    const relayUpdatedListing = makeProductEvent({
+      id: "relay-updated",
+      pubkey: "seller",
+      created_at: 20,
+      tags: [["d", "shared-listing"]],
+      sig: "sig-relay-updated",
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        makeDbPayload([cachedOlderListing, cachedSeparateListing])
+      ) as typeof global.fetch;
+
+    const editProductContext = jest.fn();
+    const promise = fetchAllPostsAbortable(
+      nostr,
+      ["wss://relay.example"],
+      editProductContext
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    params!.onevent(relayUpdatedListing);
+    params!.oneose();
+
+    await expect(promise).resolves.toEqual({
+      productEvents: [relayUpdatedListing, cachedSeparateListing],
+      profileSetFromProducts: new Set(["seller"]),
+    });
+    expect(nostr.subscribe).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kinds: [30402],
+        }),
+      ]),
+      expect.any(Object),
+      ["wss://relay.example"]
+    );
+    expect(editProductContext).toHaveBeenNthCalledWith(
+      1,
+      [cachedOlderListing, cachedSeparateListing],
+      true
+    );
+    expect(editProductContext).toHaveBeenLastCalledWith(
+      [relayUpdatedListing, cachedSeparateListing],
+      false
+    );
+    expect(cacheEventsToDatabase).toHaveBeenCalledWith([relayUpdatedListing]);
+    expect(sub.close).toHaveBeenCalledTimes(1);
+  });
 });

--- a/utils/parsers/__tests__/product-parser-functions.test.ts
+++ b/utils/parsers/__tests__/product-parser-functions.test.ts
@@ -20,7 +20,7 @@ describe("parseTags", () => {
     id: "test-id",
     pubkey: "test-pubkey",
     created_at: 1672531200,
-    kind: 30023,
+    kind: 30402,
     tags: [],
     content: "Product description",
     sig: "test-sig",
@@ -50,6 +50,65 @@ describe("parseTags", () => {
     expect(result.location).toBe("Online");
   });
 
+  it("should parse a NIP-99 classified listing event", () => {
+    const event = {
+      ...baseEvent,
+      id: "listing-event-id",
+      pubkey: "seller-pubkey",
+      created_at: 1710000000,
+      content: "NIP-99 listing description from event content",
+      tags: [
+        ["d", "seller-listing-1"],
+        ["title", "Handmade Wallet"],
+        ["summary", "Legacy summary should not replace content"],
+        ["published_at", "1710000000"],
+        ["image", "https://example.com/front.jpg"],
+        ["image", "https://example.com/back.jpg"],
+        ["t", "accessories"],
+        ["t", "nostr"],
+        ["location", "Austin, TX"],
+        ["price", "25", "USD"],
+        ["shipping", "Added Cost", "5", "USD"],
+        ["quantity", "3"],
+      ],
+    };
+
+    const result = parseTags(event)!;
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: "listing-event-id",
+        pubkey: "seller-pubkey",
+        createdAt: 1710000000,
+        d: "seller-listing-1",
+        title: "Handmade Wallet",
+        summary: "NIP-99 listing description from event content",
+        publishedAt: "1710000000",
+        images: [
+          "https://example.com/front.jpg",
+          "https://example.com/back.jpg",
+        ],
+        categories: ["accessories", "nostr"],
+        location: "Austin, TX",
+        price: 25,
+        currency: "USD",
+        shippingType: "Added Cost",
+        shippingCost: 5,
+        quantity: 3,
+        totalCost: 999,
+        rawEvent: event,
+      })
+    );
+    expect(mockedCalculateTotalCost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        d: "seller-listing-1",
+        price: 25,
+        currency: "USD",
+        shippingCost: 5,
+      })
+    );
+  });
+
   it("should fallback to summary tag when content is empty", () => {
     const event = {
       ...baseEvent,
@@ -65,10 +124,14 @@ describe("parseTags", () => {
     const event = {
       ...baseEvent,
       content: "   ",
-      tags: [["summary", "Whitespace fallback summary"]],
+      tags: [
+        ["d", "listing-with-blank-content"],
+        ["summary", "Whitespace fallback summary"],
+      ],
     };
     const result = parseTags(event)!;
 
+    expect(result.d).toBe("listing-with-blank-content");
     expect(result.summary).toBe("Whitespace fallback summary");
   });
 


### PR DESCRIPTION
This tightens the NIP-99 listing tests so the coverage now proves the behavior Shopstr depends on instead of relying on looser product fixtures.

The parser tests now use kind 30402 directly and cover a full classified listing shape, including content as the description, d tags, images, categories, price, shipping, quantity, and raw event handoff. I also added coverage for relay-hinted naddr decoding and the abortable fetch path that merges cached and relay listings by pubkey plus d tag.