### PR TITLE
Fix MCP completed order status mismatch

### DIFF
--- a/mcp/tools/__tests__/order-status-auth.test.ts
+++ b/mcp/tools/__tests__/order-status-auth.test.ts
@@ -9,7 +9,7 @@ const order = {
 };
 
 describe("order status auth helpers", () => {
-  it.each(["confirmed", "shipped", "delivered", "completed"])(
+  it.each(["confirmed", "shipped", "delivered"])(
     "allows the seller to set %s",
     (status) => {
       expect(
@@ -18,7 +18,7 @@ describe("order status auth helpers", () => {
     }
   );
 
-  it.each(["confirmed", "shipped", "delivered", "completed"])(
+  it.each(["confirmed", "shipped", "delivered"])(
     "blocks the buyer from setting %s",
     (status) => {
       expect(
@@ -26,6 +26,15 @@ describe("order status auth helpers", () => {
       ).toBe(false);
     }
   );
+
+  it("blocks completed because delivered is the database-backed terminal state", () => {
+    expect(
+      canActorUpdateMcpOrderStatus(order, "completed", order.seller_pubkey)
+    ).toBe(false);
+    expect(
+      canActorUpdateMcpOrderStatus(order, "completed", order.buyer_pubkey)
+    ).toBe(false);
+  });
 
   it("allows the buyer to cancel", () => {
     expect(

--- a/mcp/tools/order-status-auth.ts
+++ b/mcp/tools/order-status-auth.ts
@@ -4,7 +4,6 @@ const SELLER_MANAGED_ORDER_STATUSES = new Set([
   "confirmed",
   "shipped",
   "delivered",
-  "completed",
 ]);
 
 const BUYER_MANAGED_ORDER_STATUSES = new Set(["cancelled"]);

--- a/mcp/tools/write-tools.ts
+++ b/mcp/tools/write-tools.ts
@@ -1908,11 +1908,11 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
 
   reg(
     "update_order_status",
-    "Update the status of an order and optionally notify the buyer via encrypted DM. Sellers can confirm, ship, or complete orders. Buyers can cancel orders.",
+    "Update the status of an order and optionally notify the buyer via encrypted DM. Sellers can confirm, ship, or mark orders delivered. Buyers can cancel orders.",
     {
       orderId: z.string().describe("The order ID to update"),
       status: z
-        .enum(["confirmed", "shipped", "delivered", "completed", "cancelled"])
+        .enum(["confirmed", "shipped", "delivered", "cancelled"])
         .describe("New order status"),
       buyerPubkey: z
         .string()
@@ -2005,7 +2005,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
               confirmed: "order-info",
               shipped: "shipping-info",
               delivered: "order-completed",
-              completed: "order-completed",
               cancelled: "order-info",
             };
 


### PR DESCRIPTION
Addresses #473.

This removes the redundant completed status from MCP seller authorization and `update_order_status` validation so the tool only accepts statuses the `mcp_orders` DB constraint can store. Sellers should use delivered for the terminal state, which still maps to the order completed notification subject.