### PR TITLE
Validate cart mint quotes server-side

### DIFF
--- a/__tests__/pages/api/cart/mint-quote.test.ts
+++ b/__tests__/pages/api/cart/mint-quote.test.ts
@@ -1,0 +1,290 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const fetchProductByIdFromDbMock = jest.fn();
+const fetchProductByDTagAndPubkeyMock = jest.fn();
+const fetchAllProfilesFromDbMock = jest.fn();
+const validateDiscountCodeMock = jest.fn();
+const createMintQuoteBolt11Mock = jest.fn();
+const loadMintMock = jest.fn();
+const getSatoshiValueMock = jest.fn();
+var mockCashuMint: jest.Mock;
+
+jest.mock("@/utils/db/db-service", () => ({
+  fetchProductByDTagAndPubkey: (...args: unknown[]) =>
+    fetchProductByDTagAndPubkeyMock(...args),
+  fetchProductByIdFromDb: (...args: unknown[]) =>
+    fetchProductByIdFromDbMock(...args),
+  fetchAllProfilesFromDb: (...args: unknown[]) =>
+    fetchAllProfilesFromDbMock(...args),
+  validateDiscountCode: (...args: unknown[]) =>
+    validateDiscountCodeMock(...args),
+}));
+
+jest.mock("@getalby/lightning-tools", () => ({
+  getSatoshiValue: (...args: unknown[]) => getSatoshiValueMock(...args),
+}));
+
+jest.mock("@cashu/cashu-ts", () => {
+  mockCashuMint = jest.fn().mockImplementation((url: string) => ({ url }));
+  return {
+    Mint: mockCashuMint,
+    Wallet: jest.fn().mockImplementation(() => ({
+      loadMint: (...args: unknown[]) => loadMintMock(...args),
+      createMintQuoteBolt11: (...args: unknown[]) =>
+        createMintQuoteBolt11Mock(...args),
+    })),
+  };
+});
+
+import handler from "@/pages/api/cart/mint-quote";
+import { __resetRateLimitBuckets } from "@/utils/rate-limit";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+      return this;
+    },
+  };
+}
+
+function createRequest(body: unknown): NextApiRequest {
+  return {
+    method: "POST",
+    headers: {},
+    socket: { remoteAddress: "8.8.4.4" },
+    body,
+  } as NextApiRequest;
+}
+
+function productEvent(overrides: Partial<{ tags: string[][] }> = {}) {
+  return {
+    id: "product-1",
+    pubkey: "seller-pubkey",
+    created_at: 1,
+    kind: 30402,
+    content: "",
+    sig: "sig",
+    tags: overrides.tags ?? [
+      ["title", "Cart listing"],
+      ["d", "cart-listing"],
+      ["price", "100", "sats"],
+      ["shipping", "Added Cost", "10", "sats"],
+    ],
+  };
+}
+
+describe("/api/cart/mint-quote", () => {
+  beforeEach(() => {
+    fetchProductByIdFromDbMock.mockReset();
+    fetchProductByDTagAndPubkeyMock.mockReset();
+    fetchAllProfilesFromDbMock.mockReset();
+    validateDiscountCodeMock.mockReset();
+    createMintQuoteBolt11Mock.mockReset();
+    loadMintMock.mockReset();
+    getSatoshiValueMock.mockReset();
+    mockCashuMint.mockClear();
+    __resetRateLimitBuckets();
+
+    fetchProductByIdFromDbMock.mockResolvedValue(productEvent());
+    fetchProductByDTagAndPubkeyMock.mockResolvedValue(productEvent());
+    fetchAllProfilesFromDbMock.mockResolvedValue([]);
+    validateDiscountCodeMock.mockResolvedValue({
+      valid: true,
+      discount_percentage: 10,
+    });
+    createMintQuoteBolt11Mock.mockResolvedValue({
+      request: "lnbc200",
+      quote: "quote-200",
+    });
+    loadMintMock.mockResolvedValue(undefined);
+  });
+
+  it("recomputes cart totals server-side before creating a mint quote", async () => {
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        items: [{ productId: "product-1", quantity: 2 }],
+        formType: "shipping",
+        discountCodes: { "seller-pubkey": "SAVE10" },
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(validateDiscountCodeMock).toHaveBeenCalledWith(
+      "SAVE10",
+      "seller-pubkey"
+    );
+    expect(createMintQuoteBolt11Mock).toHaveBeenCalledWith(200);
+    expect(mockCashuMint).toHaveBeenCalledWith(
+      "https://mint.minibits.cash/Bitcoin"
+    );
+    expect(res.jsonBody).toMatchObject({
+      request: "lnbc200",
+      quote: "quote-200",
+      amount: 200,
+      mintUrl: "https://mint.minibits.cash/Bitcoin",
+      pricing: {
+        total: 200,
+        productTotalsInSats: { "product-1": 200 },
+      },
+    });
+  });
+
+  it("waives shipping when the server-side seller threshold is met", async () => {
+    fetchAllProfilesFromDbMock.mockResolvedValue([
+      {
+        id: "shop-profile",
+        pubkey: "seller-pubkey",
+        created_at: 2,
+        kind: 30019,
+        tags: [],
+        content: JSON.stringify({
+          name: "Seller",
+          freeShippingThreshold: 150,
+        }),
+        sig: "sig",
+      },
+    ]);
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        items: [{ productId: "product-1", quantity: 2 }],
+        formType: "shipping",
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(createMintQuoteBolt11Mock).toHaveBeenCalledWith(200);
+    expect(res.jsonBody).toMatchObject({
+      pricing: {
+        shippingCost: 0,
+        total: 200,
+      },
+    });
+  });
+
+  it("converts non-sat cart prices and shipping before quote creation", async () => {
+    fetchProductByIdFromDbMock.mockResolvedValue(
+      productEvent({
+        tags: [
+          ["title", "USD cart listing"],
+          ["d", "usd-cart-listing"],
+          ["price", "5", "USD"],
+          ["shipping", "Added Cost", "1", "USD"],
+        ],
+      })
+    );
+    fetchProductByDTagAndPubkeyMock.mockResolvedValue(
+      productEvent({
+        tags: [
+          ["title", "USD cart listing"],
+          ["d", "usd-cart-listing"],
+          ["price", "5", "USD"],
+          ["shipping", "Added Cost", "1", "USD"],
+        ],
+      })
+    );
+    getSatoshiValueMock.mockImplementation(({ amount }) => amount * 100);
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        items: [{ productId: "product-1", quantity: 1 }],
+        formType: "shipping",
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(createMintQuoteBolt11Mock).toHaveBeenCalledWith(600);
+  });
+
+  it("rejects invalid cart selections before quote creation", async () => {
+    fetchProductByIdFromDbMock.mockResolvedValue(
+      productEvent({
+        tags: [
+          ["title", "Sized cart listing"],
+          ["d", "sized-cart-listing"],
+          ["price", "100", "sats"],
+          ["size", "M", "1"],
+        ],
+      })
+    );
+    fetchProductByDTagAndPubkeyMock.mockResolvedValue(
+      productEvent({
+        tags: [
+          ["title", "Sized cart listing"],
+          ["d", "sized-cart-listing"],
+          ["price", "100", "sats"],
+          ["size", "M", "1"],
+        ],
+      })
+    );
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        items: [{ productId: "product-1", quantity: 1, selectedSize: "XL" }],
+        formType: "contact",
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(createMintQuoteBolt11Mock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid cart order types before fetching products", async () => {
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        items: [{ productId: "product-1", quantity: 1 }],
+        formType: "not-a-real-order-type",
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonBody).toMatchObject({
+      error: "Invalid cart order type",
+    });
+    expect(fetchProductByIdFromDbMock).not.toHaveBeenCalled();
+    expect(createMintQuoteBolt11Mock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed discount code maps before quote creation", async () => {
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        items: [{ productId: "product-1", quantity: 1 }],
+        formType: "shipping",
+        discountCodes: { "seller-pubkey": 123 },
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonBody).toMatchObject({
+      error: "Discount codes are invalid",
+    });
+    expect(createMintQuoteBolt11Mock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/pages/api/mcp/create-order.test.ts
+++ b/__tests__/pages/api/mcp/create-order.test.ts
@@ -1,0 +1,226 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const authenticateRequestMock = jest.fn();
+const initializeApiKeysTableMock = jest.fn();
+const fetchAllProductsFromDbMock = jest.fn();
+const fetchAllProfilesFromDbMock = jest.fn();
+const validateDiscountCodeMock = jest.fn();
+const recordRequestMock = jest.fn();
+const createMcpOrderMock = jest.fn();
+const getMcpOrderMock = jest.fn();
+const listMcpOrdersMock = jest.fn();
+const updateMcpOrderPaymentMock = jest.fn();
+const createMintQuoteBolt11Mock = jest.fn();
+const receiveMock = jest.fn();
+const loadMintMock = jest.fn();
+const getDecodedTokenMock = jest.fn();
+const getSatoshiValueMock = jest.fn();
+var mockCashuMint: jest.Mock;
+
+jest.mock("@/utils/mcp/auth", () => ({
+  authenticateRequest: (...args: unknown[]) => authenticateRequestMock(...args),
+  initializeApiKeysTable: (...args: unknown[]) =>
+    initializeApiKeysTableMock(...args),
+}));
+
+jest.mock("@/utils/db/db-service", () => ({
+  fetchAllProductsFromDb: (...args: unknown[]) =>
+    fetchAllProductsFromDbMock(...args),
+  fetchAllProfilesFromDb: (...args: unknown[]) =>
+    fetchAllProfilesFromDbMock(...args),
+  validateDiscountCode: (...args: unknown[]) =>
+    validateDiscountCodeMock(...args),
+}));
+
+jest.mock("@/utils/mcp/metrics", () => ({
+  recordRequest: (...args: unknown[]) => recordRequestMock(...args),
+}));
+
+jest.mock("@/mcp/tools/purchase-tools", () => ({
+  createMcpOrder: (...args: unknown[]) => createMcpOrderMock(...args),
+  getMcpOrder: (...args: unknown[]) => getMcpOrderMock(...args),
+  listMcpOrders: (...args: unknown[]) => listMcpOrdersMock(...args),
+  updateMcpOrderPayment: (...args: unknown[]) =>
+    updateMcpOrderPaymentMock(...args),
+  formatOrderForResponse: (order: { order_id: string }) => ({
+    orderId: order.order_id,
+  }),
+}));
+
+jest.mock("@getalby/lightning-tools", () => ({
+  getSatoshiValue: (...args: unknown[]) => getSatoshiValueMock(...args),
+}));
+
+jest.mock("@cashu/cashu-ts", () => {
+  mockCashuMint = jest.fn().mockImplementation((url: string) => ({ url }));
+  return {
+    Mint: mockCashuMint,
+    Wallet: jest.fn().mockImplementation(() => ({
+      loadMint: (...args: unknown[]) => loadMintMock(...args),
+      createMintQuoteBolt11: (...args: unknown[]) =>
+        createMintQuoteBolt11Mock(...args),
+      receive: (...args: unknown[]) => receiveMock(...args),
+    })),
+    getDecodedToken: (...args: unknown[]) => getDecodedTokenMock(...args),
+  };
+});
+
+import handler from "@/pages/api/mcp/create-order";
+import { __resetRateLimitBuckets } from "@/utils/rate-limit";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      this.end();
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+      return this;
+    },
+    end: jest.fn(),
+  };
+}
+
+function createRequest(body: unknown): NextApiRequest {
+  return {
+    method: "POST",
+    headers: {},
+    socket: { remoteAddress: "8.8.8.8" },
+    body,
+    query: {},
+  } as NextApiRequest;
+}
+
+function productEvent() {
+  return {
+    id: "product-1",
+    pubkey: "seller-pubkey",
+    created_at: 1,
+    kind: 30402,
+    content: "",
+    sig: "sig",
+    tags: [
+      ["title", "MCP USD listing"],
+      ["d", "mcp-usd-listing"],
+      ["price", "5", "USD"],
+      ["shipping", "Added Cost", "1", "USD"],
+    ],
+  };
+}
+
+function mcpOrder() {
+  return {
+    order_id: "mcp_test_order",
+    product_id: "product-1",
+    product_title: "MCP USD listing",
+    quantity: 1,
+    amount_total: 6,
+    currency: "USD",
+    shipping_address: null,
+    payment_ref: "ln_quote-600",
+    payment_status: "pending",
+    order_status: "pending",
+    created_at: "2026-06-10T00:00:00.000Z",
+  };
+}
+
+describe("/api/mcp/create-order", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetRateLimitBuckets();
+
+    authenticateRequestMock.mockResolvedValue({
+      id: 42,
+      pubkey: "buyer-pubkey",
+    });
+    initializeApiKeysTableMock.mockResolvedValue(undefined);
+    fetchAllProductsFromDbMock.mockResolvedValue([productEvent()]);
+    fetchAllProfilesFromDbMock.mockResolvedValue([]);
+    validateDiscountCodeMock.mockResolvedValue({
+      valid: false,
+      discount_percentage: 0,
+    });
+    createMcpOrderMock.mockResolvedValue(mcpOrder());
+    updateMcpOrderPaymentMock.mockResolvedValue(mcpOrder());
+    loadMintMock.mockResolvedValue(undefined);
+    createMintQuoteBolt11Mock.mockResolvedValue({
+      request: "lnbc600",
+      quote: "quote-600",
+    });
+    receiveMock.mockResolvedValue([]);
+    getDecodedTokenMock.mockReturnValue({
+      mint: "https://mint.minibits.cash/Bitcoin",
+      proofs: [{ amount: 600 }],
+    });
+    getSatoshiValueMock.mockImplementation(({ amount }) => amount * 100);
+  });
+
+  it("creates Lightning mint quotes in sats after converting non-sat listing totals", async () => {
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        productId: "product-1",
+        quantity: 1,
+        paymentMethod: "lightning",
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(402);
+    expect(getSatoshiValueMock).toHaveBeenCalledWith({
+      amount: 6,
+      currency: "USD",
+    });
+    expect(createMintQuoteBolt11Mock).toHaveBeenCalledWith(600);
+    expect(res.jsonBody).toMatchObject({
+      status: "payment_required",
+      payment: {
+        amount: 600,
+        currency: "sats",
+      },
+      pricing: {
+        total: 6,
+        currency: "USD",
+      },
+    });
+  });
+
+  it("checks Cashu tokens against the converted sat amount for non-sat listings", async () => {
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        productId: "product-1",
+        quantity: 1,
+        paymentMethod: "cashu",
+        cashuToken: "cashu-token",
+      }),
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(getSatoshiValueMock).toHaveBeenCalledWith({
+      amount: 6,
+      currency: "USD",
+    });
+    expect(receiveMock).toHaveBeenCalledWith("cashu-token");
+    expect(res.jsonBody).toMatchObject({
+      success: true,
+      payment: {
+        amount: 600,
+        required: 600,
+        status: "paid",
+      },
+    });
+  });
+});

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -42,6 +42,7 @@ import {
 import { safeMeltProofs } from "@/utils/cashu/melt-retry-service";
 import { safeSwap } from "@/utils/cashu/swap-retry-service";
 import { withMintRetry } from "@/utils/cashu/mint-retry-service";
+import { toCashuMintAmountSats } from "@/utils/cashu/payment-amount";
 import {
   recordPendingMintQuote,
   markMintQuoteClaimed,
@@ -94,6 +95,15 @@ import {
   ProductTotalsInSats,
   sumProductTotalsInSats,
 } from "@/utils/cart-totals";
+import type { CartPricingResult } from "@/utils/payments/cart-pricing";
+
+type CartMintQuoteResponse = {
+  request: string;
+  quote: string;
+  amount: number;
+  mintUrl: string;
+  pricing: CartPricingResult;
+};
 
 export default function CartInvoiceCard({
   products,
@@ -200,6 +210,7 @@ export default function CartInvoiceCard({
     selectedWeight?: string;
     selectedBulkOption?: string;
   } | null>(null);
+  const serverProductTotalsRef = useRef<ProductTotalsInSats | null>(null);
 
   useEffect(() => {
     if (paymentConfirmed && pendingOrderRef.current) {
@@ -485,6 +496,7 @@ export default function CartInvoiceCard({
   );
 
   useEffect(() => {
+    serverProductTotalsRef.current = null;
     setCurrentProductTotalsInSats(productTotalsInSats);
     setTotalCost(subtotalCost);
   }, [productTotalsInSats, subtotalCost]);
@@ -891,6 +903,56 @@ export default function CartInvoiceCard({
     }
   };
 
+  const createCartMintQuote = async (): Promise<CartMintQuoteResponse> => {
+    const response = await fetch("/api/cart/mint-quote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: products.map((product) => ({
+          productId: product.id,
+          quantity: quantities[product.id] || 1,
+          selectedSize: product.selectedSize,
+          selectedVolume: product.selectedVolume,
+          selectedWeight: product.selectedWeight,
+          selectedBulkOption: product.selectedBulkOption,
+        })),
+        formType,
+        shippingPickupPreference,
+        discountCodes,
+      }),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(
+        typeof payload.error === "string"
+          ? payload.error
+          : "Failed to create cart invoice"
+      );
+    }
+
+    const quote = payload as CartMintQuoteResponse;
+    if (!quote.pricing?.productTotalsInSats) {
+      throw new Error("Cart quote did not include validated cart totals");
+    }
+
+    return quote;
+  };
+
+  const applyServerCartQuote = (quote: CartMintQuoteResponse) => {
+    const amount = toCashuMintAmountSats(quote.amount);
+    serverProductTotalsRef.current = quote.pricing.productTotalsInSats;
+    setCurrentProductTotalsInSats(quote.pricing.productTotalsInSats);
+    setTotalCost(amount);
+
+    if (pendingOrderRef.current) {
+      pendingOrderRef.current.amount = String(amount);
+      pendingOrderRef.current.currency = "sats";
+    }
+
+    return amount;
+  };
+
   const onFormSubmit = async (
     data: { [x: string]: string },
     paymentType?: "lightning" | "cashu" | "nwc"
@@ -1003,6 +1065,7 @@ export default function CartInvoiceCard({
   };
 
   const resetCurrentProductTotals = () => {
+    serverProductTotalsRef.current = null;
     setCurrentProductTotalsInSats(productTotalsInSats);
     setTotalCost(subtotalCost);
   };
@@ -1032,6 +1095,7 @@ export default function CartInvoiceCard({
         shouldAddShipping,
       });
 
+      serverProductTotalsRef.current = null;
       setCurrentProductTotalsInSats(updatedProductTotalsInSats);
       setTotalCost(sumProductTotalsInSats(updatedProductTotalsInSats));
 
@@ -1105,18 +1169,17 @@ export default function CartInvoiceCard({
     let nwc: NostrWebLNProvider | null = null;
 
     try {
-      validatePaymentData(convertedPrice, data);
+      validatePaymentData(toCashuMintAmountSats(convertedPrice), data);
 
-      const wallet = new CashuWallet(new CashuMint(mints[0]!));
+      const cartQuote = await createCartMintQuote();
+      const invoiceAmount = applyServerCartQuote(cartQuote);
+      const { request: pr, quote: hash, mintUrl } = cartQuote;
+      const wallet = new CashuWallet(new CashuMint(mintUrl));
       await wallet.loadMint();
-      const { request: pr, quote: hash } = await withMintRetry(
-        () => wallet.createMintQuoteBolt11(convertedPrice),
-        { maxAttempts: 4, perAttemptTimeoutMs: 15000, totalTimeoutMs: 60000 }
-      );
       recordPendingMintQuote({
         quoteId: hash,
-        mintUrl: mints[0]!,
-        amount: convertedPrice,
+        mintUrl,
+        amount: invoiceAmount,
         invoice: pr,
       });
       invoicePollRef.current = { cancelled: false, activeQuoteId: hash };
@@ -1128,7 +1191,7 @@ export default function CartInvoiceCard({
       await nwc.enable();
 
       await nwc.sendPayment(pr);
-      await invoiceHasBeenPaid(wallet, totalCost, hash, data);
+      await invoiceHasBeenPaid(wallet, invoiceAmount, hash, data, mintUrl);
     } catch (error: any) {
       handleNWCError(error);
     } finally {
@@ -1139,20 +1202,18 @@ export default function CartInvoiceCard({
 
   const handleLightningPayment = async (convertedPrice: number, data: any) => {
     try {
-      validatePaymentData(convertedPrice, data);
+      validatePaymentData(toCashuMintAmountSats(convertedPrice), data);
 
       setShowInvoiceCard(true);
-      const wallet = new CashuWallet(new CashuMint(mints[0]!));
+      const cartQuote = await createCartMintQuote();
+      const invoiceAmount = applyServerCartQuote(cartQuote);
+      const { request: pr, quote: hash, mintUrl } = cartQuote;
+      const wallet = new CashuWallet(new CashuMint(mintUrl));
       await wallet.loadMint();
-
-      const { request: pr, quote: hash } = await withMintRetry(
-        () => wallet.createMintQuoteBolt11(convertedPrice),
-        { maxAttempts: 4, perAttemptTimeoutMs: 15000, totalTimeoutMs: 60000 }
-      );
       recordPendingMintQuote({
         quoteId: hash,
-        mintUrl: mints[0]!,
-        amount: convertedPrice,
+        mintUrl,
+        amount: invoiceAmount,
         invoice: pr,
       });
       invoicePollRef.current = { cancelled: false, activeQuoteId: hash };
@@ -1186,7 +1247,7 @@ export default function CartInvoiceCard({
           console.error(e);
         }
       }
-      await invoiceHasBeenPaid(wallet, totalCost, hash, data);
+      await invoiceHasBeenPaid(wallet, invoiceAmount, hash, data, mintUrl);
     } catch {
       if (setInvoiceGenerationFailed) {
         setInvoiceGenerationFailed(true);
@@ -1205,7 +1266,8 @@ export default function CartInvoiceCard({
     wallet: CashuWallet,
     convertedPrice: number,
     hash: string,
-    data: any
+    data: any,
+    mintUrl: string
   ) {
     let retryCount = 0;
     const maxRetries = 30; // Maximum 30 retries (about 1 minute)
@@ -1237,7 +1299,7 @@ export default function CartInvoiceCard({
           );
           recordPendingMintQuote({
             quoteId: hash,
-            mintUrl: mints[0]!,
+            mintUrl,
             amount: convertedPrice,
             invoice: existing?.invoice ?? "",
             status: "paid_unclaimed",
@@ -1274,7 +1336,7 @@ export default function CartInvoiceCard({
                 await recoverProofsToBuyerWallet(
                   nostr,
                   signer,
-                  mints[0]!,
+                  mintUrl,
                   proofs,
                   convertedPrice
                 );
@@ -1294,7 +1356,7 @@ export default function CartInvoiceCard({
               // wallet so they keep their sats and can retry.
               try {
                 await withDeadline(
-                  () => sendTokens(wallet, proofs, data),
+                  () => sendTokens(wallet, proofs, data, mintUrl),
                   45000,
                   "seller payment hand-off"
                 );
@@ -1310,7 +1372,7 @@ export default function CartInvoiceCard({
                 await recoverProofsToBuyerWallet(
                   nostr!,
                   signer!,
-                  mints[0]!,
+                  mintUrl,
                   proofs,
                   convertedPrice
                 );
@@ -1419,9 +1481,12 @@ export default function CartInvoiceCard({
   const sendTokens = async (
     wallet: CashuWallet,
     proofs: Proof[],
-    data: any
+    data: any,
+    tokenMintUrl = mints[0]!
   ) => {
     let remainingProofs = proofs;
+    const paymentProductTotals =
+      serverProductTotalsRef.current ?? currentProductTotalsInSats;
 
     // Construct address tag early so it can be passed to all messages
     // Handle both form field naming conventions
@@ -1440,7 +1505,7 @@ export default function CartInvoiceCard({
       const title = product.title;
       const pubkey = product.pubkey;
       const required = product.required;
-      const tokenAmount = currentProductTotalsInSats[product.id] || 0;
+      const tokenAmount = paymentProductTotals[product.id] || 0;
       if (tokenAmount < 1) {
         setFailureText("Failed to calculate cart totals for payment.");
         setShowFailureModal(true);
@@ -1553,7 +1618,7 @@ export default function CartInvoiceCard({
         const { keep, send } = swapOutcome;
         sellerProofs = send;
         sellerToken = getEncodedToken({
-          mint: mints[0]!,
+          mint: tokenMintUrl,
           proofs: send,
         });
         remainingProofs = keep;
@@ -1600,7 +1665,7 @@ export default function CartInvoiceCard({
         }
         const { keep, send } = swapOutcome;
         donationToken = getEncodedToken({
-          mint: mints[0]!,
+          mint: tokenMintUrl,
           proofs: send,
         });
         remainingProofs = keep;
@@ -1751,7 +1816,7 @@ export default function CartInvoiceCard({
               await new Promise((resolve) => setTimeout(resolve, 500));
 
               const encodedChange = getEncodedToken({
-                mint: mints[0]!,
+                mint: tokenMintUrl,
                 proofs: changeProofs,
               });
               const changeMessage = "Overpaid fee change: " + encodedChange;
@@ -1790,7 +1855,7 @@ export default function CartInvoiceCard({
                   )
                 : 0;
             const unusedToken = getEncodedToken({
-              mint: mints[0]!,
+              mint: tokenMintUrl,
               proofs: unusedProofs,
             });
             let productDetails = "";

--- a/pages/api/cart/mint-quote.ts
+++ b/pages/api/cart/mint-quote.ts
@@ -1,0 +1,300 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Mint as CashuMint, Wallet as CashuWallet } from "@cashu/cashu-ts";
+import {
+  fetchAllProfilesFromDb,
+  fetchProductByDTagAndPubkey,
+  fetchProductByIdFromDb,
+  validateDiscountCode,
+} from "@/utils/db/db-service";
+import { parseTags } from "@/utils/parsers/product-parser-functions";
+import { withMintRetry } from "@/utils/cashu/mint-retry-service";
+import { toCashuMintAmountSats } from "@/utils/cashu/payment-amount";
+import { getTrustedMintUrl } from "@/utils/cashu/trusted-mints";
+import { applyRateLimit } from "@/utils/rate-limit";
+import {
+  CartOrderFormType,
+  CartPricingItemInput,
+  CartPricingProductInput,
+  CartShippingPickupPreference,
+  computeCartPricing,
+} from "@/utils/payments/cart-pricing";
+import type { NostrEvent } from "@/utils/types/types";
+
+const RATE_LIMIT = { limit: 30, windowMs: 60 * 1000 };
+
+type CartMintQuoteRequest = {
+  items?: CartPricingItemInput[];
+  formType?: CartOrderFormType;
+  shippingPickupPreference?: CartShippingPickupPreference;
+  discountCodes?: Record<string, string>;
+};
+
+type ValidatedCartPricingItemInput = CartPricingItemInput & {
+  productId: string;
+};
+
+const CART_FORM_TYPES = new Set(["shipping", "contact", "combined"]);
+
+function parseFormType(value: unknown): CartOrderFormType {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value === "string" && CART_FORM_TYPES.has(value)) {
+    return value as CartOrderFormType;
+  }
+
+  throw new Error("Invalid cart order type");
+}
+
+function parseShippingPickupPreference(
+  value: unknown
+): CartShippingPickupPreference {
+  if (value === undefined || value === null) {
+    return "shipping";
+  }
+
+  if (value === "shipping" || value === "contact") {
+    return value;
+  }
+
+  throw new Error("Invalid shipping pickup preference");
+}
+
+function parseDiscountCodes(value: unknown): Record<string, string> {
+  if (value === undefined || value === null) {
+    return {};
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Discount codes are invalid");
+  }
+
+  const discountCodes: Record<string, string> = {};
+  for (const [pubkey, code] of Object.entries(value)) {
+    if (typeof code !== "string") {
+      throw new Error("Discount codes are invalid");
+    }
+    discountCodes[pubkey] = code;
+  }
+
+  return discountCodes;
+}
+
+function parseSelectedBulkOption(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "" || value === 1) {
+    return undefined;
+  }
+
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error("Invalid bulk tier");
+  }
+
+  return parsed;
+}
+
+function parseOptionalString(
+  value: unknown,
+  label: string
+): string | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw new Error(`${label} is invalid`);
+  }
+
+  return value;
+}
+
+function parseCartItems(value: unknown): ValidatedCartPricingItemInput[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("Cart items are required");
+  }
+
+  if (value.length > 50) {
+    throw new Error("Cart has too many items");
+  }
+
+  return value.map((rawItem) => {
+    if (
+      typeof rawItem !== "object" ||
+      rawItem === null ||
+      Array.isArray(rawItem)
+    ) {
+      throw new Error("Cart item is invalid");
+    }
+
+    const item = rawItem as Record<string, unknown>;
+    const productId = item.productId;
+    if (typeof productId !== "string" || !productId.trim()) {
+      throw new Error("productId is required");
+    }
+
+    const quantity = item.quantity;
+    if (
+      quantity !== undefined &&
+      (typeof quantity !== "number" ||
+        !Number.isInteger(quantity) ||
+        quantity < 1)
+    ) {
+      throw new Error("Cart item quantity must be a positive integer");
+    }
+
+    return {
+      productId,
+      quantity,
+      selectedSize: parseOptionalString(item.selectedSize, "Selected size"),
+      selectedVolume: parseOptionalString(
+        item.selectedVolume,
+        "Selected volume"
+      ),
+      selectedWeight: parseOptionalString(
+        item.selectedWeight,
+        "Selected weight"
+      ),
+      selectedBulkOption: parseSelectedBulkOption(item.selectedBulkOption),
+    };
+  });
+}
+
+async function fetchLatestProduct(productId: string) {
+  let productEvent = await fetchProductByIdFromDb(productId);
+  if (!productEvent) {
+    return null;
+  }
+
+  const requestedProduct = parseTags(productEvent);
+  if (!requestedProduct) {
+    throw new Error("Failed to parse product data");
+  }
+
+  if (requestedProduct.d) {
+    productEvent =
+      (await fetchProductByDTagAndPubkey(
+        requestedProduct.d,
+        requestedProduct.pubkey
+      )) ?? productEvent;
+  }
+
+  const product = parseTags(productEvent);
+  if (!product) {
+    throw new Error("Failed to parse product data");
+  }
+
+  return product;
+}
+
+function buildShopProfileMap(profileEvents: NostrEvent[]) {
+  const profiles = new Map<
+    string,
+    { content?: { freeShippingThreshold?: number; name?: string } }
+  >();
+
+  for (const event of profileEvents) {
+    if (event.kind !== 30019 || profiles.has(event.pubkey)) {
+      continue;
+    }
+
+    try {
+      profiles.set(event.pubkey, { content: JSON.parse(event.content) });
+    } catch {
+      profiles.set(event.pubkey, {});
+    }
+  }
+
+  return profiles;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.setHeader("Cache-Control", "no-store");
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  if (!applyRateLimit(req, res, "cart-mint-quote", RATE_LIMIT)) {
+    return;
+  }
+
+  try {
+    const body =
+      typeof req.body === "object" && req.body !== null
+        ? (req.body as CartMintQuoteRequest)
+        : {};
+    const items = parseCartItems(body.items);
+    const formType = parseFormType(body.formType);
+    const shippingPickupPreference = parseShippingPickupPreference(
+      body.shippingPickupPreference
+    );
+    const discountCodes = parseDiscountCodes(body.discountCodes);
+
+    const productInputs: CartPricingProductInput[] = [];
+
+    for (const item of items) {
+      const product = await fetchLatestProduct(item.productId!);
+      if (!product) {
+        return res.status(404).json({ error: "Product not found" });
+      }
+
+      const discountCode = discountCodes[product.pubkey]?.trim();
+      let discountPercentage = 0;
+
+      if (discountCode) {
+        const discountResult = await validateDiscountCode(
+          discountCode,
+          product.pubkey
+        );
+
+        if (!discountResult.valid || !discountResult.discount_percentage) {
+          return res.status(400).json({
+            error: `Invalid discount code for ${product.title}`,
+          });
+        }
+
+        discountPercentage = discountResult.discount_percentage;
+      }
+
+      productInputs.push({
+        product: { ...product, id: item.productId },
+        item,
+        discountPercentage,
+      });
+    }
+
+    const profileEvents = await fetchAllProfilesFromDb();
+    const pricing = await computeCartPricing({
+      products: productInputs,
+      formType,
+      shippingPickupPreference,
+      shopProfiles: buildShopProfileMap(profileEvents),
+    });
+    const amount = toCashuMintAmountSats(pricing.total);
+    const mint = getTrustedMintUrl();
+
+    const wallet = new CashuWallet(new CashuMint(mint));
+    await wallet.loadMint();
+
+    const mintQuote = await withMintRetry(
+      () => wallet.createMintQuoteBolt11(amount),
+      { maxAttempts: 4, perAttemptTimeoutMs: 15000, totalTimeoutMs: 60000 }
+    );
+
+    return res.status(200).json({
+      request: mintQuote.request,
+      quote: mintQuote.quote,
+      amount,
+      mintUrl: mint,
+      pricing,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to create cart invoice";
+    return res.status(400).json({ error: message });
+  }
+}

--- a/pages/api/mcp/create-order.ts
+++ b/pages/api/mcp/create-order.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { randomBytes } from "crypto";
 import { Mint as CashuMint, Wallet as CashuWallet } from "@cashu/cashu-ts";
 import { withMintRetry } from "@/utils/cashu/mint-retry-service";
+import { convertCurrencyAmountToSats } from "@/utils/cashu/currency-conversion";
+import { getTrustedMintUrl } from "@/utils/cashu/trusted-mints";
 import { authenticateRequest, initializeApiKeysTable } from "@/utils/mcp/auth";
 import {
   fetchAllProductsFromDb,
@@ -26,7 +28,7 @@ import { applyRateLimit } from "@/utils/rate-limit";
 const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
 const PER_KEY_LIMIT = { limit: 30, windowMs: 60 * 1000 };
 
-const DEFAULT_MINT_URL = "https://mint.minibits.cash/Bitcoin";
+const DEFAULT_MINT_URL = getTrustedMintUrl();
 
 // Server-controlled allowlist of Cashu mints the backend will trust for both
 // Lightning invoice creation and Cashu token redemption.  Buyer-supplied mint
@@ -389,14 +391,7 @@ async function handleLightningPayment(
   }
   const mint = DEFAULT_MINT_URL;
 
-  let amountInSats: number;
-  if (currency.toLowerCase() === "sats" || currency.toLowerCase() === "sat") {
-    amountInSats = Math.round(totalAmount);
-  } else {
-    amountInSats = Math.round(totalAmount);
-  }
-
-  if (amountInSats < 1) amountInSats = 1;
+  const amountInSats = await convertCurrencyAmountToSats(totalAmount, currency);
 
   try {
     const cashuMint = new CashuMint(mint);
@@ -496,12 +491,10 @@ async function handleCashuPayment(
       0
     );
 
-    let requiredAmount: number;
-    if (currency.toLowerCase() === "sats" || currency.toLowerCase() === "sat") {
-      requiredAmount = Math.round(totalAmount);
-    } else {
-      requiredAmount = Math.round(totalAmount);
-    }
+    const requiredAmount = await convertCurrencyAmountToSats(
+      totalAmount,
+      currency
+    );
 
     if (tokenAmount < requiredAmount) {
       return res.status(400).json({

--- a/utils/cashu/__tests__/currency-conversion.test.ts
+++ b/utils/cashu/__tests__/currency-conversion.test.ts
@@ -1,0 +1,43 @@
+const getSatoshiValueMock = jest.fn();
+
+jest.mock("@getalby/lightning-tools", () => ({
+  getSatoshiValue: (...args: unknown[]) => getSatoshiValueMock(...args),
+}));
+
+import { convertCurrencyAmountToSats } from "@/utils/cashu/currency-conversion";
+
+describe("convertCurrencyAmountToSats", () => {
+  beforeEach(() => {
+    getSatoshiValueMock.mockReset();
+  });
+
+  it("keeps sat-denominated amounts as sats", async () => {
+    await expect(convertCurrencyAmountToSats(12, "sats")).resolves.toBe(12);
+    expect(getSatoshiValueMock).not.toHaveBeenCalled();
+  });
+
+  it("converts bitcoin amounts to sats without an external rate lookup", async () => {
+    await expect(convertCurrencyAmountToSats(0.00000012, "btc")).resolves.toBe(
+      12
+    );
+    expect(getSatoshiValueMock).not.toHaveBeenCalled();
+  });
+
+  it("rounds fiat conversions up through the exchange-rate helper", async () => {
+    getSatoshiValueMock.mockResolvedValue(123.4);
+
+    await expect(convertCurrencyAmountToSats(5, "USD")).resolves.toBe(124);
+    expect(getSatoshiValueMock).toHaveBeenCalledWith({
+      amount: 5,
+      currency: "USD",
+    });
+  });
+
+  it("rejects fiat conversions that round to zero sats", async () => {
+    getSatoshiValueMock.mockResolvedValue(0.4);
+
+    await expect(convertCurrencyAmountToSats(0.01, "USD")).rejects.toThrow(
+      "Payment amount must be greater than 0 sats"
+    );
+  });
+});

--- a/utils/cashu/__tests__/payment-amount.test.ts
+++ b/utils/cashu/__tests__/payment-amount.test.ts
@@ -1,0 +1,20 @@
+import { toCashuMintAmountSats } from "@/utils/cashu/payment-amount";
+
+describe("toCashuMintAmountSats", () => {
+  it("rounds fractional positive sat amounts up", () => {
+    expect(toCashuMintAmountSats(1.1)).toBe(2);
+    expect(toCashuMintAmountSats("10")).toBe(10);
+  });
+
+  it("rejects zero, non-finite, and unsafe amounts", () => {
+    expect(() => toCashuMintAmountSats(0)).toThrow(
+      "Payment amount must be greater than 0 sats"
+    );
+    expect(() => toCashuMintAmountSats(Number.NaN)).toThrow(
+      "Payment amount must be a finite number of sats"
+    );
+    expect(() => toCashuMintAmountSats(Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      "Payment amount is too large to invoice safely"
+    );
+  });
+});

--- a/utils/cashu/currency-conversion.ts
+++ b/utils/cashu/currency-conversion.ts
@@ -1,0 +1,28 @@
+import { getSatoshiValue } from "@getalby/lightning-tools";
+import { toCashuMintAmountSats } from "@/utils/cashu/payment-amount";
+
+export async function convertCurrencyAmountToSats(
+  amount: number,
+  currency: string
+): Promise<number> {
+  if (!Number.isFinite(amount)) {
+    throw new Error("Payment amount must be finite");
+  }
+
+  const normalizedCurrency = currency.toLowerCase();
+
+  if (normalizedCurrency === "sats" || normalizedCurrency === "sat") {
+    return toCashuMintAmountSats(amount);
+  }
+
+  if (normalizedCurrency === "btc") {
+    return toCashuMintAmountSats(amount * 100_000_000);
+  }
+
+  const sats = await getSatoshiValue({
+    amount,
+    currency,
+  });
+
+  return toCashuMintAmountSats(sats);
+}

--- a/utils/cashu/payment-amount.ts
+++ b/utils/cashu/payment-amount.ts
@@ -1,0 +1,30 @@
+const MAX_SAFE_SATS_AMOUNT = Number.MAX_SAFE_INTEGER;
+
+export function toCashuMintAmountSats(amount: unknown): number {
+  const numericAmount =
+    typeof amount === "number"
+      ? amount
+      : typeof amount === "string" && amount.trim() !== ""
+        ? Number(amount)
+        : NaN;
+
+  if (!Number.isFinite(numericAmount)) {
+    throw new Error("Payment amount must be a finite number of sats");
+  }
+
+  if (numericAmount < 1) {
+    throw new Error("Payment amount must be greater than 0 sats");
+  }
+
+  const satsAmount = Math.ceil(numericAmount);
+
+  if (!Number.isSafeInteger(satsAmount)) {
+    throw new Error("Payment amount is too large to invoice safely");
+  }
+
+  if (satsAmount > MAX_SAFE_SATS_AMOUNT) {
+    throw new Error("Payment amount is too large to invoice safely");
+  }
+
+  return satsAmount;
+}

--- a/utils/cashu/trusted-mints.ts
+++ b/utils/cashu/trusted-mints.ts
@@ -1,0 +1,16 @@
+const DEFAULT_TRUSTED_MINT_URL = "https://mint.minibits.cash/Bitcoin";
+
+function normalizeMintUrl(mintUrl: string): string {
+  const parsed = new URL(mintUrl);
+
+  if (parsed.protocol !== "https:") {
+    throw new Error("Trusted mint URLs must use HTTPS");
+  }
+
+  return parsed.toString().replace(/\/$/, "");
+}
+
+export function getTrustedMintUrl(): string {
+  const configuredMint = process.env.SHOPSTR_TRUSTED_MINT_URL?.trim();
+  return normalizeMintUrl(configuredMint || DEFAULT_TRUSTED_MINT_URL);
+}

--- a/utils/payments/cart-pricing.ts
+++ b/utils/payments/cart-pricing.ts
@@ -1,0 +1,334 @@
+import { convertCurrencyAmountToSats } from "@/utils/cashu/currency-conversion";
+import { ProductData } from "@/utils/parsers/product-parser-functions";
+
+export type CartOrderFormType = "shipping" | "contact" | "combined" | null;
+export type CartShippingPickupPreference = "shipping" | "contact";
+
+export type CartPricingItemInput = {
+  productId?: string;
+  quantity?: number;
+  selectedSize?: string;
+  selectedVolume?: string;
+  selectedWeight?: string;
+  selectedBulkOption?: number;
+};
+
+export type CartPricingProductInput = {
+  product: ProductData;
+  item: CartPricingItemInput;
+  discountPercentage?: number;
+};
+
+export type CartShopProfile = {
+  content?: {
+    freeShippingThreshold?: number;
+    name?: string;
+  };
+};
+
+export type CartPricingItemResult = {
+  productId: string;
+  pubkey: string;
+  title: string;
+  unitPrice: number;
+  unitPriceSats: number;
+  quantity: number;
+  subtotal: number;
+  shippingCost: number;
+  total: number;
+  currency: string;
+  discountPercentage?: number;
+  selectedSize?: string;
+  selectedVolume?: string;
+  selectedWeight?: string;
+  selectedBulkOption?: number;
+};
+
+export type CartPricingResult = {
+  items: CartPricingItemResult[];
+  productTotalsInSats: Record<string, number>;
+  subtotal: number;
+  shippingCost: number;
+  total: number;
+  currency: "sats";
+};
+
+function requireFiniteAmount(amount: number, label: string) {
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error(`${label} is invalid`);
+  }
+}
+
+function requireQuantity(quantity: number | undefined): number {
+  const parsed = quantity ?? 1;
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error("Cart item quantity must be a positive integer");
+  }
+  return parsed;
+}
+
+function hasPurchasableSizes(product: ProductData): boolean {
+  return Boolean(
+    product.sizes?.some((size) => (product.sizeQuantities?.get(size) ?? 0) > 0)
+  );
+}
+
+function requireAvailableProduct(product: ProductData, quantity: number) {
+  if (product.status?.toLowerCase() === "sold") {
+    throw new Error(`Listing "${product.title}" is sold out`);
+  }
+
+  if (product.expiration && Date.now() / 1000 > product.expiration) {
+    throw new Error(`Listing "${product.title}" has expired`);
+  }
+
+  if (product.quantity !== undefined && product.quantity < quantity) {
+    throw new Error(`Insufficient stock for "${product.title}"`);
+  }
+
+  if (
+    product.sizes &&
+    product.sizes.length > 0 &&
+    !hasPurchasableSizes(product)
+  ) {
+    throw new Error(`Listing "${product.title}" is sold out`);
+  }
+}
+
+function selectUnitPrice(
+  product: ProductData,
+  item: CartPricingItemInput,
+  quantity: number
+) {
+  const requiresSize = hasPurchasableSizes(product);
+  const requiresVolume = Boolean(product.volumes?.length);
+  const requiresWeight = Boolean(product.weights?.length);
+
+  if (requiresSize && !item.selectedSize) {
+    throw new Error(`Size selection is required for "${product.title}"`);
+  }
+
+  if (requiresVolume && !item.selectedVolume) {
+    throw new Error(`Volume selection is required for "${product.title}"`);
+  }
+
+  if (requiresWeight && !item.selectedWeight) {
+    throw new Error(`Weight selection is required for "${product.title}"`);
+  }
+
+  if (item.selectedSize) {
+    if (!product.sizes || !product.sizes.includes(item.selectedSize)) {
+      throw new Error(`Invalid size selection for "${product.title}"`);
+    }
+
+    const sizeStock = product.sizeQuantities?.get(item.selectedSize);
+    if (sizeStock !== undefined && sizeStock < quantity) {
+      throw new Error(`Insufficient stock for "${product.title}"`);
+    }
+  }
+
+  let unitPrice = product.price;
+
+  if (item.selectedBulkOption && item.selectedBulkOption !== 1) {
+    if (
+      !Number.isInteger(item.selectedBulkOption) ||
+      !product.bulkPrices?.has(item.selectedBulkOption)
+    ) {
+      throw new Error(`Invalid bulk tier for "${product.title}"`);
+    }
+    unitPrice = product.bulkPrices.get(item.selectedBulkOption)!;
+  } else if (item.selectedVolume) {
+    if (!product.volumes || !product.volumes.includes(item.selectedVolume)) {
+      throw new Error(`Invalid volume selection for "${product.title}"`);
+    }
+    const volumePrice = product.volumePrices?.get(item.selectedVolume);
+    if (volumePrice !== undefined) {
+      unitPrice = volumePrice;
+    }
+  } else if (item.selectedWeight) {
+    if (!product.weights || !product.weights.includes(item.selectedWeight)) {
+      throw new Error(`Invalid weight selection for "${product.title}"`);
+    }
+    const weightPrice = product.weightPrices?.get(item.selectedWeight);
+    if (weightPrice !== undefined) {
+      unitPrice = weightPrice;
+    }
+  }
+
+  requireFiniteAmount(unitPrice, "Cart item price");
+  return unitPrice;
+}
+
+function shouldAddShipping(
+  formType: CartOrderFormType,
+  shippingPickupPreference: CartShippingPickupPreference,
+  shippingType?: string
+) {
+  if (formType === "shipping") {
+    return true;
+  }
+
+  if (formType === "contact" || !formType) {
+    return false;
+  }
+
+  if (shippingPickupPreference === "contact") {
+    return shippingType === "Added Cost" || shippingType === "Free";
+  }
+
+  return (
+    shippingType === "Added Cost" ||
+    shippingType === "Free" ||
+    shippingType === "Free/Pickup" ||
+    shippingType === "Added Cost/Pickup"
+  );
+}
+
+export async function computeCartPricing({
+  products,
+  formType,
+  shippingPickupPreference = "shipping",
+  shopProfiles = new Map<string, CartShopProfile>(),
+}: {
+  products: CartPricingProductInput[];
+  formType: CartOrderFormType;
+  shippingPickupPreference?: CartShippingPickupPreference;
+  shopProfiles?: Map<string, CartShopProfile>;
+}): Promise<CartPricingResult> {
+  if (!formType) {
+    throw new Error("Cart order type is required");
+  }
+
+  if (products.length === 0) {
+    throw new Error("Cart is empty");
+  }
+
+  const prepared = await Promise.all(
+    products.map(async ({ product, item, discountPercentage = 0 }) => {
+      const quantity = requireQuantity(item.quantity);
+      requireAvailableProduct(product, quantity);
+
+      const unitPrice = selectUnitPrice(product, item, quantity);
+      const unitPriceSats = await convertCurrencyAmountToSats(
+        unitPrice,
+        product.currency || "sats"
+      );
+
+      if (
+        !Number.isFinite(discountPercentage) ||
+        discountPercentage < 0 ||
+        discountPercentage > 100
+      ) {
+        throw new Error("Discount percentage is invalid");
+      }
+
+      const discountedUnitPrice =
+        discountPercentage > 0
+          ? unitPrice * (1 - discountPercentage / 100)
+          : unitPrice;
+      const discountedUnitPriceSats =
+        discountPercentage > 0
+          ? Math.ceil(unitPriceSats * (1 - discountPercentage / 100))
+          : unitPriceSats;
+      const subtotal = Math.ceil(discountedUnitPriceSats * quantity);
+
+      return {
+        product,
+        item,
+        quantity,
+        unitPrice,
+        unitPriceSats,
+        discountedUnitPrice,
+        subtotal,
+        discountPercentage,
+      };
+    })
+  );
+
+  const sellerSubtotals = new Map<string, number>();
+  for (const preparedItem of prepared) {
+    const previous = sellerSubtotals.get(preparedItem.product.pubkey) ?? 0;
+    sellerSubtotals.set(
+      preparedItem.product.pubkey,
+      previous + preparedItem.discountedUnitPrice * preparedItem.quantity
+    );
+  }
+
+  const resultItems: CartPricingItemResult[] = [];
+
+  for (const preparedItem of prepared) {
+    const { product, item, quantity } = preparedItem;
+    const shopProfile = shopProfiles.get(product.pubkey);
+    const freeShippingThreshold =
+      shopProfile?.content?.freeShippingThreshold ?? 0;
+    const sellerSubtotal = sellerSubtotals.get(product.pubkey) ?? 0;
+    const qualifiesForFreeShipping =
+      freeShippingThreshold > 0 && sellerSubtotal >= freeShippingThreshold;
+
+    let shippingCost = 0;
+    if (
+      !qualifiesForFreeShipping &&
+      shouldAddShipping(
+        formType,
+        shippingPickupPreference,
+        product.shippingType
+      )
+    ) {
+      const shippingCostSats = await convertCurrencyAmountToSats(
+        product.shippingCost ?? 0,
+        product.currency || "sats"
+      ).catch((error) => {
+        if ((product.shippingCost ?? 0) === 0) {
+          return 0;
+        }
+        throw error;
+      });
+      shippingCost = Math.ceil(shippingCostSats * quantity);
+    }
+
+    const total = preparedItem.subtotal + shippingCost;
+
+    resultItems.push({
+      productId: product.id,
+      pubkey: product.pubkey,
+      title: product.title,
+      unitPrice: preparedItem.unitPrice,
+      unitPriceSats: preparedItem.unitPriceSats,
+      quantity,
+      subtotal: preparedItem.subtotal,
+      shippingCost,
+      total,
+      currency: "sats",
+      discountPercentage:
+        preparedItem.discountPercentage > 0
+          ? preparedItem.discountPercentage
+          : undefined,
+      selectedSize: item.selectedSize || undefined,
+      selectedVolume: item.selectedVolume || undefined,
+      selectedWeight: item.selectedWeight || undefined,
+      selectedBulkOption:
+        item.selectedBulkOption && item.selectedBulkOption !== 1
+          ? item.selectedBulkOption
+          : undefined,
+    });
+  }
+
+  const productTotalsInSats = Object.fromEntries(
+    resultItems.map((item) => [item.productId, item.total])
+  );
+  const subtotal = resultItems.reduce((sum, item) => sum + item.subtotal, 0);
+  const shippingCost = resultItems.reduce(
+    (sum, item) => sum + item.shippingCost,
+    0
+  );
+  const total = resultItems.reduce((sum, item) => sum + item.total, 0);
+
+  return {
+    items: resultItems,
+    productTotalsInSats,
+    subtotal,
+    shippingCost,
+    total,
+    currency: "sats",
+  };
+}


### PR DESCRIPTION
## Summary

This PR closes the remaining payment validation gaps around cart checkout and MCP order creation.

- Adds a server-side cart mint quote endpoint that fetches the latest listing events, validates cart item selections, validates discount codes, recomputes totals, and creates the Cashu mint quote using the server-controlled trusted mint.
- Updates cart Lightning and NWC checkout to use the server-returned quote amount and product totals before polling, minting proofs, and splitting seller/donation/change tokens.
- Fixes MCP `create-order` so non-sat listing totals are converted to sats before creating Lightning quotes or checking Cashu token amounts.
- Adds shared helpers for Cashu-safe sat amounts, currency conversion, and trusted mint selection.

## Note

The new `/api/cart/mint-quote` route treats the request body as untrusted runtime input. It validates cart order type, pickup preference, item shape, selected variants, discount-code map shape, listing availability, stock, expiration, and quantity before calling the mint.

This PR intentionally does not change direct browser Cashu-token checkout; that path does not create a mint quote. It should still get a separate server-validated amount/totals follow-up, but it is separate from the Lightning/NWC quote-manipulation issue.

## Coordination

This complements #449, which validates single-listing Lightning/NWC mint quotes server-side. So ideally should merge after that.

