### PR TITLE
Implement Read Tools - List Companies , Get Company Details, Get Storefront, Get Seller Reputation 

### DIFF
--- a/packages/shopstr-mcp/README.md
+++ b/packages/shopstr-mcp/README.md
@@ -3,9 +3,9 @@
 Standalone read-only MCP server package for Shopstr marketplace data.
 
 This package currently contains the standalone MCP shell, shared read-only
-infrastructure, and the first relay-backed read tools for public Shopstr
-marketplace data. Seller, storefront, reputation, prompt, and resource features
-will be added in follow-up PRs.
+infrastructure, relay-backed product/review tools, and relay-backed
+seller/storefront/reputation tools for public Shopstr marketplace data. Prompt
+and resource features will be added in follow-up PRs.
 
 ## Current Scope
 
@@ -13,8 +13,10 @@ will be added in follow-up PRs.
 - Reads relay, timeout, cache, and log-level settings from environment
   variables.
 - Starts an MCP server over stdio for local MCP-compatible clients.
-- Registers relay-backed core read tools:
-  `search_products`, `get_product_details`, and `get_reviews`.
+- Registers relay-backed read tools:
+  `search_products`, `get_product_details`, `get_reviews`,
+  `list_companies`, `get_company_details`, `get_storefront`,
+  and `get_seller_reputation`.
 - Registers disabled resource and prompt placeholders so `resources/list` and
   `prompts/list` return valid empty lists until those features are added.
 - Provides reusable infrastructure modules for upcoming tools:
@@ -41,6 +43,16 @@ will be added in follow-up PRs.
   product address when possible and keeps a legacy `#e` fallback. Seller review
   lookups first derive the seller's product addresses, query Gamma/standard
   product review targets, and keep legacy `#p` as a fallback.
+- `list_companies`: list public seller shop profiles from kind `30019` shop
+  metadata. Responses are capped at 50 sellers and cache returned shop profiles
+  for follow-up seller detail calls.
+- `get_company_details`: fetch a seller's kind `0` profile, kind `30019` shop
+  metadata, public products, reviews, and payment summary by pubkey or npub.
+- `get_storefront`: fetch pubkey-based storefront configuration, seller
+  profiles, products, and payment summary. Slug lookup is not supported since this is relay based MCP.
+- `get_seller_reputation`: summarize public kind `31555` seller/product reviews
+  into review counts, rating breakdowns, recent reviews, and a transparent
+  trust-level snapshot.
 
 Product responses expose Gamma-compatible fields where available, including
 structured image objects, `productType`, `productFormat`, `visibility`
@@ -52,10 +64,10 @@ Tool responses include relay degradation metadata in `_meta`, including queried
 relays, successful relays, failed relays, coverage, response time, hints, and
 truncation flags when response budgeting applies.
 
-Upcoming seller/profile tools receive a process-local in-memory profile cache
-through the shared tool context. The cache stores parsed public profile/shop
-responses by pubkey and event kind, expires entries by TTL, and is intended to
-surface `_meta.cached: true` when a future profile response is served from cache.
+Seller/profile tools receive a process-local in-memory profile cache through
+the shared tool context. The cache stores parsed public profile/shop responses
+by pubkey and event kind, expires entries by TTL, and surfaces per-kind cache
+hits in `_meta.cached`.
 
 ## Usage
 

--- a/packages/shopstr-mcp/src/dedup.ts
+++ b/packages/shopstr-mcp/src/dedup.ts
@@ -83,6 +83,24 @@ export function mergeAndDeduplicateReviews(
   return Array.from(byId.values()).sort((a, b) => b.created_at - a.created_at);
 }
 
+export function mergeAndDeduplicateProfiles(
+  events: readonly NostrEvent[]
+): NostrEvent[] {
+  const byKindAndAuthor = new Map<string, NostrEvent>();
+
+  for (const event of events) {
+    const key = `${event.kind}:${event.pubkey}`;
+    const existing = byKindAndAuthor.get(key);
+    if (!existing || isBetterEvent(event, existing)) {
+      byKindAndAuthor.set(key, event);
+    }
+  }
+
+  return Array.from(byKindAndAuthor.values()).sort(
+    (a, b) => b.created_at - a.created_at
+  );
+}
+
 function getReviewTarget(event: NostrEvent): string | undefined {
   const aTag = getTagValue(event, "a");
   if (aTag) return `a:${aTag}`;

--- a/packages/shopstr-mcp/src/parse-tags.ts
+++ b/packages/shopstr-mcp/src/parse-tags.ts
@@ -393,6 +393,8 @@ export function parseProfileEvent(event: NostrEvent): ProfileResponse {
     pubkey: event.pubkey,
     kind: event.kind,
     name: typeof content.name === "string" ? content.name : "",
+    displayName:
+      typeof content.display_name === "string" ? content.display_name : "",
     about: typeof content.about === "string" ? content.about : "",
     picture: typeof content.picture === "string" ? content.picture : "",
     banner: typeof content.banner === "string" ? content.banner : "",

--- a/packages/shopstr-mcp/src/tools/get-company-details.ts
+++ b/packages/shopstr-mcp/src/tools/get-company-details.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+
+import { createSuccessResponse, type ToolTextResponse } from "../errors.js";
+import { companyDetailsInputSchema } from "../validation.js";
+import {
+  buildToolMeta,
+  combineRelayMetas,
+  createValidationErrorResponse,
+  getDataFreshness,
+} from "./utils/common.js";
+import type { CoreToolContext } from "./utils/context.js";
+import {
+  buildPaymentInfo,
+  fetchSellerProducts,
+  fetchSellerProfiles,
+  fetchSellerReviews,
+  guardSellerNotFound,
+} from "./utils/seller.js";
+
+export const getCompanyDetailsInputSchema = {
+  pubkey: z.string().describe("Seller public key as hex or npub"),
+};
+
+export async function handleGetCompanyDetails(
+  args: Record<string, unknown>,
+  context: CoreToolContext
+): Promise<ToolTextResponse> {
+  const parsed = companyDetailsInputSchema.safeParse(args);
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const startedAt = Date.now();
+  const { pubkey } = parsed.data;
+  const [profiles, products] = await Promise.all([
+    fetchSellerProfiles(pubkey, context),
+    fetchSellerProducts(pubkey, context),
+  ]);
+  const reviews = await fetchSellerReviews(pubkey, products.events, context);
+  const relayMeta = combineRelayMetas(
+    [profiles.meta, products.meta, reviews.meta],
+    Date.now() - startedAt
+  );
+
+  const guardError = guardSellerNotFound(
+    relayMeta,
+    profiles,
+    products,
+    reviews,
+    "Use list_companies to discover seller pubkeys before calling get_company_details."
+  );
+  if (guardError) return guardError;
+
+  const truncated = products.truncated || reviews.truncated;
+  const hints: string[] = [];
+  if (products.truncated) {
+    hints.push(
+      "Seller has more products than returned; use search_products with the seller's categories or product keywords to narrow further."
+    );
+  }
+  if (reviews.truncated) {
+    hints.push(
+      "Seller has more reviews than returned; use get_reviews with sellerPubkey for review-only inspection."
+    );
+  }
+  const resultCount =
+    Number(Boolean(profiles.userProfile)) +
+    Number(Boolean(profiles.shopProfile)) +
+    products.returnedProducts.length +
+    reviews.returnedReviews.length;
+
+  const dataFreshness = getDataFreshness([
+    ...[profiles.userProfile, profiles.shopProfile].filter(
+      (profile): profile is NonNullable<typeof profile> => profile !== null
+    ),
+    ...products.returnedProducts,
+    ...reviews.returnedReviews,
+  ]);
+  const meta = {
+    ...buildToolMeta(relayMeta, {
+      resultCount,
+      totalMatches: products.products.length + reviews.reviews.length,
+      truncated,
+      dataFreshness,
+      hints,
+    }),
+    cached: profiles.cache,
+  };
+
+  return createSuccessResponse(
+    {
+      pubkey,
+      shopProfile: profiles.shopProfile,
+      userProfile: profiles.userProfile,
+      products: {
+        count: products.returnedProducts.length,
+        totalMatches: products.products.length,
+        items: products.returnedProducts,
+      },
+      reviews: {
+        count: reviews.returnedReviews.length,
+        totalMatches: reviews.reviews.length,
+        items: reviews.returnedReviews,
+      },
+      paymentInfo: buildPaymentInfo(products.products),
+    },
+    meta,
+    resultCount
+  );
+}

--- a/packages/shopstr-mcp/src/tools/get-company-details.ts
+++ b/packages/shopstr-mcp/src/tools/get-company-details.ts
@@ -61,6 +61,11 @@ export async function handleGetCompanyDetails(
       "Seller has more reviews than returned; use get_reviews with sellerPubkey for review-only inspection."
     );
   }
+  if (reviews.reviewLookupPartial) {
+    hints.push(
+      "Review lookup was partial: seller has too many products for complete review scanning."
+    );
+  }
   const resultCount =
     Number(Boolean(profiles.userProfile)) +
     Number(Boolean(profiles.shopProfile)) +

--- a/packages/shopstr-mcp/src/tools/get-reviews.ts
+++ b/packages/shopstr-mcp/src/tools/get-reviews.ts
@@ -12,7 +12,6 @@ import type { NostrEvent, NostrFilter } from "../types.js";
 import { reviewsInputSchema } from "../validation.js";
 import {
   PRODUCT_KIND,
-  REVIEW_KIND,
   REVIEW_RESPONSE_BUDGET,
   allRelaysFailed,
   buildToolMeta,
@@ -21,6 +20,12 @@ import {
   getDataFreshness,
 } from "./utils/common.js";
 import type { CoreToolContext } from "./utils/context.js";
+import {
+  createReviewFilter,
+  eventReferencesSeller,
+  hasProductAddress,
+  hasTag,
+} from "./utils/review-helpers.js";
 
 export const getReviewsInputSchema = {
   productId: z
@@ -36,10 +41,6 @@ export const getReviewsInputSchema = {
     .optional()
     .describe("Seller public key as hex or npub"),
 };
-
-function hasTag(event: NostrEvent, key: string, value: string): boolean {
-  return event.tags.some((tag) => tag[0] === key && tag[1] === value);
-}
 
 function reviewMatchesTarget(
   event: NostrEvent,
@@ -74,36 +75,6 @@ function reviewMatchesTarget(
     return false;
   }
   return true;
-}
-
-function hasProductAddress(event: NostrEvent, productAddress: string): boolean {
-  return (
-    hasTag(event, "d", `a:${productAddress}`) ||
-    hasTag(event, "d", productAddress) ||
-    hasTag(event, "a", productAddress)
-  );
-}
-
-function eventReferencesSeller(
-  event: NostrEvent,
-  sellerPubkey: string
-): boolean {
-  return event.tags.some((tag) => {
-    const [key, value] = tag;
-    return (
-      typeof value === "string" &&
-      (key === "d" || key === "a") &&
-      value.includes(sellerPubkey)
-    );
-  });
-}
-
-function createReviewFilter(fields: Partial<NostrFilter>): NostrFilter {
-  return {
-    kinds: [REVIEW_KIND],
-    limit: 500,
-    ...fields,
-  };
 }
 
 function buildReviewFilters(

--- a/packages/shopstr-mcp/src/tools/get-seller-reputation.ts
+++ b/packages/shopstr-mcp/src/tools/get-seller-reputation.ts
@@ -62,6 +62,17 @@ export async function handleGetSellerReputation(
 
   const stats = calculateReputationStats(reviews.reviews);
   const recentReviews = reviews.reviews.slice(0, RECENT_REVIEW_BUDGET);
+  const reputationHints: string[] = [];
+  if (reviews.reviews.length === 0) {
+    reputationHints.push(
+      "No public reviews were found for this seller; inspect product freshness and profile details before recommending purchases."
+    );
+  }
+  if (reviews.reviewLookupPartial) {
+    reputationHints.push(
+      "Review lookup was partial: seller has too many products for complete review scanning."
+    );
+  }
   const meta = {
     ...buildToolMeta(relayMeta, {
       resultCount: recentReviews.length,
@@ -71,12 +82,7 @@ export async function handleGetSellerReputation(
         ...recentReviews,
         ...products.returnedProducts,
       ]),
-      hints:
-        reviews.reviews.length === 0
-          ? [
-              "No public reviews were found for this seller; inspect product freshness and profile details before recommending purchases.",
-            ]
-          : [],
+      hints: reputationHints,
     }),
     cached: profiles.cache,
   };

--- a/packages/shopstr-mcp/src/tools/get-seller-reputation.ts
+++ b/packages/shopstr-mcp/src/tools/get-seller-reputation.ts
@@ -1,0 +1,228 @@
+import { z } from "zod";
+
+import type { ReviewResponse } from "../types.js";
+import { sellerReputationInputSchema } from "../validation.js";
+import { createSuccessResponse, type ToolTextResponse } from "../errors.js";
+import {
+  buildToolMeta,
+  combineRelayMetas,
+  createValidationErrorResponse,
+  getDataFreshness,
+} from "./utils/common.js";
+import type { CoreToolContext } from "./utils/context.js";
+import {
+  fetchSellerProducts,
+  fetchSellerProfiles,
+  fetchSellerReviews,
+  guardSellerNotFound,
+} from "./utils/seller.js";
+
+const RECENT_REVIEW_BUDGET = 10;
+
+export const getSellerReputationInputSchema = {
+  sellerPubkey: z.string().describe("Seller public key as hex or npub"),
+};
+
+type ReviewScore = {
+  score: number | null;
+  ratings: Record<string, number>;
+};
+
+export async function handleGetSellerReputation(
+  args: Record<string, unknown>,
+  context: CoreToolContext
+): Promise<ToolTextResponse> {
+  const parsed = sellerReputationInputSchema.safeParse(args);
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const startedAt = Date.now();
+  const { sellerPubkey } = parsed.data;
+  const [profiles, products] = await Promise.all([
+    fetchSellerProfiles(sellerPubkey, context),
+    fetchSellerProducts(sellerPubkey, context),
+  ]);
+  const reviews = await fetchSellerReviews(
+    sellerPubkey,
+    products.events,
+    context
+  );
+  const relayMeta = combineRelayMetas(
+    [profiles.meta, products.meta, reviews.meta],
+    Date.now() - startedAt
+  );
+
+  const guardError = guardSellerNotFound(
+    relayMeta,
+    profiles,
+    products,
+    reviews,
+    "Use list_companies to discover seller pubkeys before checking reputation."
+  );
+  if (guardError) return guardError;
+
+  const stats = calculateReputationStats(reviews.reviews);
+  const recentReviews = reviews.reviews.slice(0, RECENT_REVIEW_BUDGET);
+  const meta = {
+    ...buildToolMeta(relayMeta, {
+      resultCount: recentReviews.length,
+      totalMatches: reviews.reviews.length,
+      truncated: recentReviews.length < reviews.reviews.length,
+      dataFreshness: getDataFreshness([
+        ...recentReviews,
+        ...products.returnedProducts,
+      ]),
+      hints:
+        reviews.reviews.length === 0
+          ? [
+              "No public reviews were found for this seller; inspect product freshness and profile details before recommending purchases.",
+            ]
+          : [],
+    }),
+    cached: profiles.cache,
+  };
+
+  const oldestListingTimestamp = products.products.reduce(
+    (oldest, product) =>
+      product.createdAt > 0 && (oldest === 0 || product.createdAt < oldest)
+        ? product.createdAt
+        : oldest,
+    0
+  );
+
+  return createSuccessResponse(
+    {
+      sellerPubkey,
+      seller: {
+        shopProfile: profiles.shopProfile,
+        userProfile: profiles.userProfile,
+      },
+      productCount: products.products.length,
+      reviewCount: reviews.reviews.length,
+      oldestListingDate: oldestListingTimestamp
+        ? new Date(oldestListingTimestamp * 1000).toISOString()
+        : null,
+      reputation: stats,
+      recentReviews,
+    },
+    meta,
+    recentReviews.length
+  );
+}
+
+function calculateReputationStats(reviews: readonly ReviewResponse[]): {
+  averageScore: number | null;
+  averagePercent: number | null;
+  ratingBreakdown: Record<string, { average: number; count: number }>;
+  positiveReviewCount: number;
+  neutralReviewCount: number;
+  negativeReviewCount: number;
+  trustLevel: "unknown" | "low" | "medium" | "high";
+  formula: string;
+} {
+  const scores = reviews.map(scoreReview);
+  const numericScores = scores
+    .map((entry) => entry.score)
+    .filter((score): score is number => score !== null);
+  const averageScore =
+    numericScores.length > 0
+      ? round(
+          numericScores.reduce((sum, score) => sum + score, 0) /
+            numericScores.length
+        )
+      : null;
+  const ratingBreakdown = buildRatingBreakdown(scores);
+  const positiveReviewCount = numericScores.filter(
+    (score) => score >= 0.75
+  ).length;
+  const negativeReviewCount = numericScores.filter(
+    (score) => score <= 0.4
+  ).length;
+  const neutralReviewCount =
+    numericScores.length - positiveReviewCount - negativeReviewCount;
+
+  return {
+    averageScore,
+    averagePercent:
+      averageScore === null ? null : Math.round(averageScore * 100),
+    ratingBreakdown,
+    positiveReviewCount,
+    neutralReviewCount,
+    negativeReviewCount,
+    trustLevel: determineTrustLevel(averageScore, reviews.length),
+    formula:
+      "Scores use kind 31555 rating tags. When thumb is present it contributes 50%; other rating categories split the remaining 50%. Scores are normalized from 0 to 1.",
+  };
+}
+
+function scoreReview(review: ReviewResponse): ReviewScore {
+  const entries = Object.entries(review.ratings)
+    .filter(([, value]) => Number.isFinite(value))
+    .map(([key, value]) => [key, clamp01(value)] as const);
+  if (entries.length === 0) return { score: null, ratings: {} };
+
+  const ratings = Object.fromEntries(entries);
+  const thumb = ratings.thumb;
+  const otherRatings = entries.filter(([key]) => key !== "thumb");
+  if (thumb !== undefined) {
+    const otherAverage =
+      otherRatings.length > 0
+        ? otherRatings.reduce((sum, [, value]) => sum + value, 0) /
+          otherRatings.length
+        : thumb;
+    return {
+      score: round(thumb * 0.5 + otherAverage * 0.5),
+      ratings,
+    };
+  }
+
+  return {
+    score: round(
+      entries.reduce((sum, [, value]) => sum + value, 0) / entries.length
+    ),
+    ratings,
+  };
+}
+
+function buildRatingBreakdown(
+  scores: readonly ReviewScore[]
+): Record<string, { average: number; count: number }> {
+  const buckets = new Map<string, number[]>();
+
+  for (const score of scores) {
+    for (const [key, value] of Object.entries(score.ratings)) {
+      const bucket = buckets.get(key) ?? [];
+      bucket.push(value);
+      buckets.set(key, bucket);
+    }
+  }
+
+  return Object.fromEntries(
+    Array.from(buckets.entries()).map(([key, values]) => [
+      key,
+      {
+        average: round(
+          values.reduce((sum, value) => sum + value, 0) / values.length
+        ),
+        count: values.length,
+      },
+    ])
+  );
+}
+
+function determineTrustLevel(
+  averageScore: number | null,
+  reviewCount: number
+): "unknown" | "low" | "medium" | "high" {
+  if (averageScore === null || reviewCount === 0) return "unknown";
+  if (reviewCount >= 5 && averageScore >= 0.8) return "high";
+  if (reviewCount >= 2 && averageScore >= 0.6) return "medium";
+  return "low";
+}
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/packages/shopstr-mcp/src/tools/get-storefront.ts
+++ b/packages/shopstr-mcp/src/tools/get-storefront.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+import { createSuccessResponse, type ToolTextResponse } from "../errors.js";
+import { storefrontInputSchema } from "../validation.js";
+import {
+  buildToolMeta,
+  combineRelayMetas,
+  createValidationErrorResponse,
+  getDataFreshness,
+} from "./utils/common.js";
+import type { CoreToolContext } from "./utils/context.js";
+import {
+  buildPaymentInfo,
+  fetchSellerProducts,
+  fetchSellerProfiles,
+  guardSellerNotFound,
+} from "./utils/seller.js";
+
+export const getStorefrontInputSchema = {
+  pubkey: z.string().describe("Seller public key as hex or npub"),
+};
+
+export async function handleGetStorefront(
+  args: Record<string, unknown>,
+  context: CoreToolContext
+): Promise<ToolTextResponse> {
+  const parsed = storefrontInputSchema.safeParse(args);
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const pubkey = parsed.data.pubkey;
+  const startedAt = Date.now();
+  const [profiles, products] = await Promise.all([
+    fetchSellerProfiles(pubkey, context),
+    fetchSellerProducts(pubkey, context),
+  ]);
+  const relayMeta = combineRelayMetas(
+    [profiles.meta, products.meta],
+    Date.now() - startedAt
+  );
+
+  const guardError = guardSellerNotFound(
+    relayMeta,
+    profiles,
+    products,
+    undefined,
+    "Use list_companies to discover sellers that have public storefront metadata."
+  );
+  if (guardError) return guardError;
+
+  const storefront =
+    profiles.shopProfile?.storefront &&
+    typeof profiles.shopProfile.storefront === "object" &&
+    !Array.isArray(profiles.shopProfile.storefront)
+      ? profiles.shopProfile.storefront
+      : {};
+  const resultCount =
+    Number(Boolean(profiles.userProfile)) +
+    Number(Boolean(profiles.shopProfile)) +
+    products.returnedProducts.length;
+  const meta = {
+    ...buildToolMeta(relayMeta, {
+      resultCount,
+      totalMatches: products.products.length,
+      truncated: products.truncated,
+      dataFreshness: getDataFreshness([
+        ...[profiles.userProfile, profiles.shopProfile].filter(
+          (profile): profile is NonNullable<typeof profile> => profile !== null
+        ),
+        ...products.returnedProducts,
+      ]),
+      hints: products.truncated
+        ? [
+            "Storefront has more products than returned; use get_company_details or search_products to inspect more.",
+          ]
+        : [],
+    }),
+    cached: profiles.cache,
+  };
+
+  return createSuccessResponse(
+    {
+      pubkey,
+      shopProfile: profiles.shopProfile,
+      userProfile: profiles.userProfile,
+      storefront: {
+        ...storefront,
+        storefrontUrl: profiles.shopProfile?.storefrontUrl ?? null,
+        customDomain: null,
+      },
+      products: {
+        count: products.returnedProducts.length,
+        totalMatches: products.products.length,
+        items: products.returnedProducts,
+      },
+      paymentInfo: buildPaymentInfo(products.products),
+    },
+    meta,
+    resultCount
+  );
+}

--- a/packages/shopstr-mcp/src/tools/index.ts
+++ b/packages/shopstr-mcp/src/tools/index.ts
@@ -1,3 +1,15 @@
+/**
+  Each tool uses a two-layer validation pattern:
+    1. MCP inputSchema  is a plain Zod object
+       that the MCP SDK converts to JSON Schema for LLM tool listings. These are
+       intentionally kept loose.
+    2. Zod validation schema is the actual
+       schema used in handlers via safeParse(). These add transforms (e.g.
+       canonicalizePubkey), refines (e.g. isHex64), and defaults.
+ 
+  The MCP schema tells the LLM what shape of args to send; the Zod schema
+  validates and normalizes the actual input at runtime.
+**/
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { wrapWithAudit } from "../audit-log.js";
@@ -7,6 +19,23 @@ import {
   handleGetProductDetails,
 } from "./get-product-details.js";
 import { getReviewsInputSchema, handleGetReviews } from "./get-reviews.js";
+import {
+  getCompanyDetailsInputSchema,
+  handleGetCompanyDetails,
+} from "./get-company-details.js";
+import {
+  getSellerReputationInputSchema,
+  handleGetSellerReputation,
+} from "./get-seller-reputation.js";
+import {
+  getStorefrontInputSchema,
+  handleGetStorefront,
+} from "./get-storefront.js";
+import {
+  handleListCompanies,
+  listCompaniesInputSchema,
+} from "./list-companies.js";
+
 import {
   handleSearchProducts,
   searchProductsInputSchema,
@@ -40,6 +69,29 @@ export function registerCoreTools(
   );
 
   server.registerTool(
+    "list_companies",
+    {
+      description: "List public Shopstr seller/shop profiles.",
+      inputSchema: listCompaniesInputSchema,
+    },
+    wrapWithAudit("list_companies", (args, _extra) =>
+      handleListCompanies(args, context)
+    )
+  );
+
+  server.registerTool(
+    "get_company_details",
+    {
+      description:
+        "Get a public Shopstr seller profile, shop metadata, products, and reviews. Accepts hex pubkey or npub1... address.",
+      inputSchema: getCompanyDetailsInputSchema,
+    },
+    wrapWithAudit("get_company_details", (args, _extra) =>
+      handleGetCompanyDetails(args, context)
+    )
+  );
+
+  server.registerTool(
     "get_reviews",
     {
       description: "Get public reviews for a Shopstr product or seller.",
@@ -47,6 +99,30 @@ export function registerCoreTools(
     },
     wrapWithAudit("get_reviews", (args, _extra) =>
       handleGetReviews(args, context)
+    )
+  );
+
+  server.registerTool(
+    "get_storefront",
+    {
+      description:
+        "Get public storefront configuration and products for a seller pubkey. Slug lookup is not supported in standalone MCP.",
+      inputSchema: getStorefrontInputSchema,
+    },
+    wrapWithAudit("get_storefront", (args, _extra) =>
+      handleGetStorefront(args, context)
+    )
+  );
+
+  server.registerTool(
+    "get_seller_reputation",
+    {
+      description:
+        "Summarize public Shopstr reviews into a seller reputation snapshot.",
+      inputSchema: getSellerReputationInputSchema,
+    },
+    wrapWithAudit("get_seller_reputation", (args, _extra) =>
+      handleGetSellerReputation(args, context)
     )
   );
 }

--- a/packages/shopstr-mcp/src/tools/index.ts
+++ b/packages/shopstr-mcp/src/tools/index.ts
@@ -6,7 +6,7 @@
     2. Zod validation schema is the actual
        schema used in handlers via safeParse(). These add transforms (e.g.
        canonicalizePubkey), refines (e.g. isHex64), and defaults.
- 
+
   The MCP schema tells the LLM what shape of args to send; the Zod schema
   validates and normalizes the actual input at runtime.
 **/

--- a/packages/shopstr-mcp/src/tools/list-companies.ts
+++ b/packages/shopstr-mcp/src/tools/list-companies.ts
@@ -49,7 +49,10 @@ export async function handleListCompanies(
     [
       {
         kinds: [SHOP_PROFILE_KIND],
-        limit: 500,
+        limit: Math.min(
+          500,
+          Math.min(parsed.data.limit, SELLER_LIST_RESPONSE_BUDGET) * 5
+        ),
         ...(parsed.data.until !== undefined && { until: parsed.data.until }),
       },
     ],

--- a/packages/shopstr-mcp/src/tools/list-companies.ts
+++ b/packages/shopstr-mcp/src/tools/list-companies.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+import { mergeAndDeduplicateProfiles } from "../dedup.js";
+import { createSuccessResponse, type ToolTextResponse } from "../errors.js";
+import { parseProfileEvent } from "../parse-tags.js";
+import { fetchFromRelays } from "../relay-fetch.js";
+import { listCompaniesSchema } from "../validation.js";
+import {
+  SELLER_LIST_RESPONSE_BUDGET,
+  SHOP_PROFILE_KIND,
+  allRelaysFailed,
+  buildToolMeta,
+  createRelayUnavailableResponse,
+  createValidationErrorResponse,
+  getDataFreshness,
+} from "./utils/common.js";
+import type { CoreToolContext } from "./utils/context.js";
+
+export const listCompaniesInputSchema = {
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      `Requested seller count. Responses are capped at ${SELLER_LIST_RESPONSE_BUDGET} sellers for MCP token budgeting.`
+    ),
+  until: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe(
+      "Unix timestamp. Only return profiles created at or before this time. Use for pagination by passing the oldest createdAt from the previous response."
+    ),
+};
+
+export async function handleListCompanies(
+  args: Record<string, unknown>,
+  context: CoreToolContext
+): Promise<ToolTextResponse> {
+  const parsed = listCompaniesSchema.safeParse(args);
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [
+      {
+        kinds: [SHOP_PROFILE_KIND],
+        limit: 500,
+        ...(parsed.data.until !== undefined && { until: parsed.data.until }),
+      },
+    ],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  if (allRelaysFailed(relayResult.meta)) {
+    return createRelayUnavailableResponse(relayResult.meta);
+  }
+
+  const companies = mergeAndDeduplicateProfiles(relayResult.events).map(
+    parseProfileEvent
+  );
+  for (const company of companies) {
+    context.cache.set(
+      { pubkey: company.pubkey, kind: SHOP_PROFILE_KIND },
+      company
+    );
+  }
+
+  const requestedLimit = parsed.data.limit;
+  const responseLimit = Math.min(requestedLimit, SELLER_LIST_RESPONSE_BUDGET);
+  const returnedCompanies = companies.slice(0, responseLimit);
+  const truncated = returnedCompanies.length < companies.length;
+  const hints = truncated
+    ? [
+        "Too many seller profiles matched; use get_company_details with a specific pubkey to inspect one seller.",
+      ]
+    : [];
+  const meta = buildToolMeta(relayResult.meta, {
+    resultCount: returnedCompanies.length,
+    totalMatches: companies.length,
+    truncated,
+    dataFreshness: getDataFreshness(returnedCompanies),
+    hints,
+  });
+
+  return createSuccessResponse(
+    {
+      count: returnedCompanies.length,
+      totalMatches: companies.length,
+      companies: returnedCompanies,
+      _pagination: {
+        oldestCreatedAt:
+          returnedCompanies.length > 0
+            ? returnedCompanies[returnedCompanies.length - 1]!.createdAt
+            : null,
+      },
+    },
+    meta,
+    returnedCompanies.length
+  );
+}

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -127,8 +127,9 @@ function buildSearchFilters(filters: SearchProductsInput): {
   primary: NostrFilter;
   fallback: NostrFilter | undefined;
 } {
-  const base: NostrFilter = { kinds: [PRODUCT_KIND], limit: 500 };
-
+  const effectiveLimit = Math.min(filters.limit, PRODUCT_RESPONSE_BUDGET);
+  const relayLimit = Math.min(500, effectiveLimit * 5);
+  const base: NostrFilter = { kinds: [PRODUCT_KIND], limit: relayLimit };
   if (filters.category) {
     const variants = new Set([
       filters.category,
@@ -186,7 +187,7 @@ export async function handleSearchProducts(
     }
   }
 
-  const requestedLimit = filters.limit ?? PRODUCT_RESPONSE_BUDGET;
+  const requestedLimit = filters.limit;
   const responseLimit = Math.min(requestedLimit, PRODUCT_RESPONSE_BUDGET);
   const returnedProducts = products.slice(0, responseLimit);
   const truncated = returnedProducts.length < products.length;

--- a/packages/shopstr-mcp/src/tools/utils/common.ts
+++ b/packages/shopstr-mcp/src/tools/utils/common.ts
@@ -10,8 +10,11 @@ import type { RelayFetchMeta } from "../../types.js";
 
 export const PRODUCT_KIND = 30402;
 export const REVIEW_KIND = 31555;
+export const PROFILE_KIND = 0;
+export const SHOP_PROFILE_KIND = 30019;
 export const PRODUCT_RESPONSE_BUDGET = 37;
 export const REVIEW_RESPONSE_BUDGET = 50;
+export const SELLER_LIST_RESPONSE_BUDGET = 50;
 export const RELAY_RETRY_AFTER_MS = 2_000;
 
 export function formatValidationError(error: ZodError): string {
@@ -61,6 +64,48 @@ export function buildToolMeta(
     }),
     ...(fields.truncated !== undefined && { _truncated: fields.truncated }),
     _hints: fields.hints ?? [],
+  };
+}
+
+export function emptyRelayMeta(responseTimeMs = 0): RelayFetchMeta {
+  return {
+    relaysQueried: [],
+    relaysSucceeded: [],
+    relaysFailed: [],
+    degraded: false,
+    coverage: 1,
+    responseTimeMs,
+    eventCount: 0,
+  };
+}
+
+export function combineRelayMetas(
+  metas: readonly RelayFetchMeta[],
+  responseTimeMs: number
+): RelayFetchMeta {
+  const relaysQueried = new Set<string>();
+  const relaysSucceeded = new Set<string>();
+  const relaysFailed = new Map<string, { url: string; error: string }>();
+  let eventCount = 0;
+
+  for (const meta of metas) {
+    meta.relaysQueried.forEach((relay) => relaysQueried.add(relay));
+    meta.relaysSucceeded.forEach((relay) => relaysSucceeded.add(relay));
+    for (const failure of meta.relaysFailed) {
+      relaysFailed.set(`${failure.url}:${failure.error}`, failure);
+    }
+    eventCount += meta.eventCount;
+  }
+
+  return {
+    relaysQueried: Array.from(relaysQueried),
+    relaysSucceeded: Array.from(relaysSucceeded),
+    relaysFailed: Array.from(relaysFailed.values()),
+    degraded: Array.from(relaysFailed.values()).length > 0,
+    coverage:
+      relaysQueried.size === 0 ? 1 : relaysSucceeded.size / relaysQueried.size,
+    responseTimeMs,
+    eventCount,
   };
 }
 

--- a/packages/shopstr-mcp/src/tools/utils/common.ts
+++ b/packages/shopstr-mcp/src/tools/utils/common.ts
@@ -15,6 +15,7 @@ export const SHOP_PROFILE_KIND = 30019;
 export const PRODUCT_RESPONSE_BUDGET = 37;
 export const REVIEW_RESPONSE_BUDGET = 50;
 export const SELLER_LIST_RESPONSE_BUDGET = 50;
+export const REVIEW_PRODUCT_FILTER_LIMIT = 20;
 export const RELAY_RETRY_AFTER_MS = 2_000;
 
 export function formatValidationError(error: ZodError): string {

--- a/packages/shopstr-mcp/src/tools/utils/review-helpers.ts
+++ b/packages/shopstr-mcp/src/tools/utils/review-helpers.ts
@@ -1,0 +1,39 @@
+import type { NostrEvent, NostrFilter } from "../../types.js";
+import { REVIEW_KIND } from "./common.js";
+
+export function hasTag(event: NostrEvent, key: string, value: string): boolean {
+  return event.tags.some((tag) => tag[0] === key && tag[1] === value);
+}
+
+export function hasProductAddress(
+  event: NostrEvent,
+  productAddress: string
+): boolean {
+  return (
+    hasTag(event, "d", `a:${productAddress}`) ||
+    hasTag(event, "d", productAddress) ||
+    hasTag(event, "a", productAddress)
+  );
+}
+
+export function eventReferencesSeller(
+  event: NostrEvent,
+  sellerPubkey: string
+): boolean {
+  return event.tags.some((tag) => {
+    const [key, value] = tag;
+    return (
+      typeof value === "string" &&
+      (key === "d" || key === "a") &&
+      value.includes(sellerPubkey)
+    );
+  });
+}
+
+export function createReviewFilter(fields: Partial<NostrFilter>): NostrFilter {
+  return {
+    kinds: [REVIEW_KIND],
+    limit: 500,
+    ...fields,
+  };
+}

--- a/packages/shopstr-mcp/src/tools/utils/seller.ts
+++ b/packages/shopstr-mcp/src/tools/utils/seller.ts
@@ -27,6 +27,7 @@ import {
   PRODUCT_KIND,
   PRODUCT_RESPONSE_BUDGET,
   PROFILE_KIND,
+  REVIEW_PRODUCT_FILTER_LIMIT,
   REVIEW_RESPONSE_BUDGET,
   SHOP_PROFILE_KIND,
   allRelaysFailed,
@@ -64,6 +65,7 @@ export type SellerReviewsResult = {
   reviews: ReviewResponse[];
   returnedReviews: ReviewResponse[];
   truncated: boolean;
+  reviewLookupPartial: boolean;
   meta: RelayFetchMeta;
 };
 
@@ -176,12 +178,16 @@ export async function fetchSellerReviews(
   productEvents: readonly NostrEvent[],
   context: CoreToolContext
 ): Promise<SellerReviewsResult> {
-  const productAddresses = Array.from(
+  const allProductAddresses = Array.from(
     new Set(
       productEvents
         .map(getParameterizedReplaceableCoordinate)
         .filter((value): value is string => value !== undefined)
     )
+  );
+  const productAddresses = allProductAddresses.slice(
+    0,
+    REVIEW_PRODUCT_FILTER_LIMIT
   );
   const relayFilters = buildSellerReviewFilters(productAddresses, sellerPubkey);
   const relayResult = await fetchFromRelays(
@@ -193,15 +199,19 @@ export async function fetchSellerReviews(
 
   const reviews = mergeAndDeduplicateReviews(relayResult.events)
     .filter((event) =>
-      reviewMatchesSeller(event, sellerPubkey, productAddresses)
+      reviewMatchesSeller(event, sellerPubkey, allProductAddresses)
     )
     .map(parseReviewEvent);
   const returnedReviews = reviews.slice(0, REVIEW_RESPONSE_BUDGET);
+
+  const reviewLookupPartial =
+    allProductAddresses.length > REVIEW_PRODUCT_FILTER_LIMIT;
 
   return {
     reviews,
     returnedReviews,
     truncated: returnedReviews.length < reviews.length,
+    reviewLookupPartial,
     meta: relayResult.meta,
   };
 }

--- a/packages/shopstr-mcp/src/tools/utils/seller.ts
+++ b/packages/shopstr-mcp/src/tools/utils/seller.ts
@@ -1,0 +1,329 @@
+import {
+  getParameterizedReplaceableCoordinate,
+  mergeAndDeduplicateProducts,
+  mergeAndDeduplicateProfiles,
+  mergeAndDeduplicateReviews,
+} from "../../dedup.js";
+import {
+  parseProductEvent,
+  parseProfileEvent,
+  parseReviewEvent,
+} from "../../parse-tags.js";
+import { fetchFromRelays } from "../../relay-fetch.js";
+import type {
+  NostrEvent,
+  NostrFilter,
+  ProductResponse,
+  ProfileResponse,
+  RelayFetchMeta,
+  ReviewResponse,
+} from "../../types.js";
+import {
+  MCP_ERROR_CODES,
+  createErrorResponse,
+  type ToolTextResponse,
+} from "../../errors.js";
+import {
+  PRODUCT_KIND,
+  PRODUCT_RESPONSE_BUDGET,
+  PROFILE_KIND,
+  REVIEW_RESPONSE_BUDGET,
+  SHOP_PROFILE_KIND,
+  allRelaysFailed,
+  buildToolMeta,
+  createRelayUnavailableResponse,
+  emptyRelayMeta,
+} from "./common.js";
+import type { CoreToolContext } from "./context.js";
+import {
+  createReviewFilter,
+  eventReferencesSeller,
+  hasProductAddress,
+  hasTag,
+} from "./review-helpers.js";
+
+export type SellerProfilesResult = {
+  userProfile: ProfileResponse | null;
+  shopProfile: ProfileResponse | null;
+  meta: RelayFetchMeta;
+  cache: {
+    userProfile: boolean;
+    shopProfile: boolean;
+  };
+};
+
+export type SellerProductsResult = {
+  events: NostrEvent[];
+  products: ProductResponse[];
+  returnedProducts: ProductResponse[];
+  truncated: boolean;
+  meta: RelayFetchMeta;
+};
+
+export type SellerReviewsResult = {
+  reviews: ReviewResponse[];
+  returnedReviews: ReviewResponse[];
+  truncated: boolean;
+  meta: RelayFetchMeta;
+};
+
+export function isPublicProduct(product: ProductResponse): boolean {
+  return product.visibility !== "hidden";
+}
+
+export async function fetchSellerProfiles(
+  pubkey: string,
+  context: CoreToolContext
+): Promise<SellerProfilesResult> {
+  const cachedUserProfile = context.cache.get<ProfileResponse>({
+    pubkey,
+    kind: PROFILE_KIND,
+  });
+  const cachedShopProfile = context.cache.get<ProfileResponse>({
+    pubkey,
+    kind: SHOP_PROFILE_KIND,
+  });
+
+  let userProfile = cachedUserProfile?.value ?? null;
+  let shopProfile = cachedShopProfile?.value ?? null;
+  const missingKinds: number[] = [];
+  if (!userProfile) missingKinds.push(PROFILE_KIND);
+  if (!shopProfile) missingKinds.push(SHOP_PROFILE_KIND);
+
+  if (missingKinds.length === 0) {
+    return {
+      userProfile,
+      shopProfile,
+      meta: emptyRelayMeta(),
+      cache: {
+        userProfile: true,
+        shopProfile: true,
+      },
+    };
+  }
+
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [
+      {
+        kinds: missingKinds,
+        authors: [pubkey],
+        limit: 10,
+      },
+    ],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  const profiles = mergeAndDeduplicateProfiles(relayResult.events).map(
+    parseProfileEvent
+  );
+
+  for (const profile of profiles) {
+    if (profile.kind === PROFILE_KIND) {
+      userProfile = profile;
+      context.cache.set({ pubkey, kind: PROFILE_KIND }, profile);
+    }
+    if (profile.kind === SHOP_PROFILE_KIND) {
+      shopProfile = profile;
+      context.cache.set({ pubkey, kind: SHOP_PROFILE_KIND }, profile);
+    }
+  }
+
+  return {
+    userProfile,
+    shopProfile,
+    meta: relayResult.meta,
+    cache: {
+      userProfile: cachedUserProfile?.cached ?? false,
+      shopProfile: cachedShopProfile?.cached ?? false,
+    },
+  };
+}
+
+export async function fetchSellerProducts(
+  pubkey: string,
+  context: CoreToolContext
+): Promise<SellerProductsResult> {
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [
+      {
+        kinds: [PRODUCT_KIND],
+        authors: [pubkey],
+        limit: 500,
+      },
+    ],
+    { timeoutMs: context.timeoutMs }
+  );
+
+  const events = mergeAndDeduplicateProducts(relayResult.events);
+  const products = events.map(parseProductEvent).filter(isPublicProduct);
+  const returnedProducts = products.slice(0, PRODUCT_RESPONSE_BUDGET);
+
+  return {
+    events,
+    products,
+    returnedProducts,
+    truncated: returnedProducts.length < products.length,
+    meta: relayResult.meta,
+  };
+}
+
+export async function fetchSellerReviews(
+  sellerPubkey: string,
+  productEvents: readonly NostrEvent[],
+  context: CoreToolContext
+): Promise<SellerReviewsResult> {
+  const productAddresses = Array.from(
+    new Set(
+      productEvents
+        .map(getParameterizedReplaceableCoordinate)
+        .filter((value): value is string => value !== undefined)
+    )
+  );
+  const relayFilters = buildSellerReviewFilters(productAddresses, sellerPubkey);
+  const relayResult = await fetchFromRelays(
+    context.nostr,
+    context.relays,
+    relayFilters,
+    { timeoutMs: context.timeoutMs }
+  );
+
+  const reviews = mergeAndDeduplicateReviews(relayResult.events)
+    .filter((event) =>
+      reviewMatchesSeller(event, sellerPubkey, productAddresses)
+    )
+    .map(parseReviewEvent);
+  const returnedReviews = reviews.slice(0, REVIEW_RESPONSE_BUDGET);
+
+  return {
+    reviews,
+    returnedReviews,
+    truncated: returnedReviews.length < reviews.length,
+    meta: relayResult.meta,
+  };
+}
+
+export function buildPaymentInfo(products: readonly ProductResponse[]): {
+  acceptedPaymentMethods: string[];
+  hasStripeConnect: boolean;
+  freeShippingAvailable: boolean;
+  freeShippingProductCount: number;
+  priceRanges: Array<{
+    currency: string;
+    min: number;
+    max: number;
+    count: number;
+  }>;
+  priceRange: { min: number; max: number; currency: string } | null;
+} {
+  const priceBuckets = new Map<string, number[]>();
+  for (const product of products) {
+    if (product.priceStatus !== "known" || product.price === undefined) {
+      continue;
+    }
+    const currency = product.currency ?? "sats";
+    const bucket = priceBuckets.get(currency) ?? [];
+    bucket.push(product.price);
+    priceBuckets.set(currency, bucket);
+  }
+
+  const priceRanges = Array.from(priceBuckets.entries()).map(
+    ([currency, prices]) => ({
+      currency,
+      min: Math.min(...prices),
+      max: Math.max(...prices),
+      count: prices.length,
+    })
+  );
+  const freeShippingProductCount = products.filter(
+    (product) =>
+      product.shippingType === "Free" || product.shippingType === "Free/Pickup"
+  ).length;
+
+  return {
+    acceptedPaymentMethods: ["lightning", "cashu"],
+    hasStripeConnect: false,
+    freeShippingAvailable: freeShippingProductCount > 0,
+    freeShippingProductCount,
+    priceRanges,
+    priceRange:
+      priceRanges.length === 1
+        ? {
+            min: priceRanges[0]!.min,
+            max: priceRanges[0]!.max,
+            currency: priceRanges[0]!.currency,
+          }
+        : null,
+  };
+}
+
+function buildSellerReviewFilters(
+  productAddresses: readonly string[],
+  sellerPubkey: string
+): NostrFilter[] {
+  const filters: NostrFilter[] = [];
+
+  for (const productAddress of productAddresses) {
+    filters.push(
+      createReviewFilter({ "#d": [`a:${productAddress}`, productAddress] }),
+      createReviewFilter({ "#a": [productAddress] })
+    );
+  }
+
+  filters.push(createReviewFilter({ "#p": [sellerPubkey] }));
+  return filters;
+}
+
+function reviewMatchesSeller(
+  event: NostrEvent,
+  sellerPubkey: string,
+  productAddresses: readonly string[]
+): boolean {
+  if (hasTag(event, "p", sellerPubkey)) return true;
+  if (eventReferencesSeller(event, sellerPubkey)) return true;
+  return productAddresses.some((address) => hasProductAddress(event, address));
+}
+
+/**
+  Shared guard: returns an error response if the seller has no data at all,
+  either because all relays failed or because the pubkey doesn't exist.
+**/
+export function guardSellerNotFound(
+  relayMeta: RelayFetchMeta,
+  profiles: SellerProfilesResult,
+  products: SellerProductsResult,
+  reviews?: SellerReviewsResult,
+  discoveryHint = "Use list_companies to discover seller pubkeys."
+): ToolTextResponse | undefined {
+  const hasAnyData =
+    Boolean(profiles.userProfile) ||
+    Boolean(profiles.shopProfile) ||
+    products.products.length > 0 ||
+    (reviews?.reviews.length ?? 0) > 0;
+
+  if (allRelaysFailed(relayMeta) && !hasAnyData) {
+    return createRelayUnavailableResponse(relayMeta);
+  }
+
+  if (
+    !profiles.userProfile &&
+    !profiles.shopProfile &&
+    products.products.length === 0 &&
+    (reviews?.reviews.length ?? 0) === 0
+  ) {
+    return createErrorResponse(
+      "Seller not found.",
+      MCP_ERROR_CODES.NOT_FOUND,
+      false,
+      undefined,
+      buildToolMeta(relayMeta, {
+        hints: [discoveryHint],
+      })
+    );
+  }
+
+  return undefined;
+}

--- a/packages/shopstr-mcp/src/types.ts
+++ b/packages/shopstr-mcp/src/types.ts
@@ -79,6 +79,7 @@ export type ProfileResponse = {
   pubkey: string;
   kind: number;
   name: string;
+  displayName: string;
   about: string;
   picture: string;
   banner: string;

--- a/packages/shopstr-mcp/src/validation.ts
+++ b/packages/shopstr-mcp/src/validation.ts
@@ -171,3 +171,20 @@ export const reviewsInputSchema = z
       message: "Either productId, productAddress, or sellerPubkey is required",
     }
   );
+
+export const listCompaniesSchema = z.object({
+  limit: limitSchema.default(50),
+  until: z.coerce.number().int().min(0).optional(),
+});
+
+export const companyDetailsInputSchema = z.object({
+  pubkey: pubkeySchema,
+});
+
+export const storefrontInputSchema = z.object({
+  pubkey: pubkeySchema,
+});
+
+export const sellerReputationInputSchema = z.object({
+  sellerPubkey: pubkeySchema,
+});

--- a/packages/shopstr-mcp/test/dedup.node.mjs
+++ b/packages/shopstr-mcp/test/dedup.node.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getParameterizedReplaceableCoordinate,
   mergeAndDeduplicateProducts,
+  mergeAndDeduplicateProfiles,
   mergeAndDeduplicateReviews,
 } from "../dist/dedup.js";
 
@@ -142,4 +143,60 @@ test("far-future review does not beat a current valid review for the same target
 
   assert.equal(deduped.length, 1);
   assert.equal(deduped[0].id, hex("e"), "should prefer the non-future event");
+});
+
+test("deduplicates profiles by pubkey+kind keeping latest", () => {
+  const older = event({
+    id: hex("a"),
+    kind: 0,
+    created_at: 10,
+    content: JSON.stringify({ name: "Old Name" }),
+  });
+  const newer = event({
+    id: hex("b"),
+    kind: 0,
+    created_at: 20,
+    content: JSON.stringify({ name: "New Name" }),
+  });
+
+  const deduped = mergeAndDeduplicateProfiles([older, newer]);
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].id, hex("b"));
+});
+
+test("deduplicates profiles across mixed kinds (0 and 30019)", () => {
+  const userProfile = event({
+    id: hex("a"),
+    kind: 0,
+    created_at: 10,
+    content: JSON.stringify({ name: "User" }),
+  });
+  const shopProfile = event({
+    id: hex("b"),
+    kind: 30019,
+    created_at: 20,
+    content: JSON.stringify({ name: "Shop" }),
+  });
+  const olderShop = event({
+    id: hex("c"),
+    kind: 30019,
+    created_at: 15,
+    content: JSON.stringify({ name: "Old Shop" }),
+  });
+
+  const deduped = mergeAndDeduplicateProfiles([
+    userProfile,
+    shopProfile,
+    olderShop,
+  ]);
+  assert.equal(deduped.length, 2);
+  assert.deepEqual(deduped.map((p) => p.kind).sort(), [0, 30019]);
+  // Shop should be the newer one
+  const shop = deduped.find((p) => p.kind === 30019);
+  assert.equal(shop.id, hex("b"));
+});
+
+test("mergeAndDeduplicateProfiles returns empty array for empty input", () => {
+  const deduped = mergeAndDeduplicateProfiles([]);
+  assert.deepEqual(deduped, []);
 });

--- a/packages/shopstr-mcp/test/parse-tags.node.mjs
+++ b/packages/shopstr-mcp/test/parse-tags.node.mjs
@@ -307,3 +307,30 @@ test("parses Gamma stock tag with fallback to legacy quantity", () => {
   assert.equal(legacyProduct.stock, 15);
   assert.equal(legacyProduct.quantity, 15);
 });
+
+test("parses display_name from NIP-24 profile metadata", () => {
+  const profile = parseProfileEvent(
+    event({
+      kind: 0,
+      content: JSON.stringify({
+        name: "alice",
+        display_name: "Alice ✨",
+        about: "Nostr user",
+      }),
+    })
+  );
+
+  assert.equal(profile.name, "alice");
+  assert.equal(profile.displayName, "Alice ✨");
+});
+
+test("defaults displayName to empty string when missing", () => {
+  const profile = parseProfileEvent(
+    event({
+      kind: 0,
+      content: JSON.stringify({ name: "bob" }),
+    })
+  );
+
+  assert.equal(profile.displayName, "");
+});

--- a/packages/shopstr-mcp/test/server.node.mjs
+++ b/packages/shopstr-mcp/test/server.node.mjs
@@ -26,7 +26,7 @@ function productEvent() {
   };
 }
 
-test("registers and calls PR3 core read tools", async () => {
+test("registers and calls PR4 read tools", async () => {
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "shopstr-mcp-test", version: "0.0.0" });
@@ -59,8 +59,12 @@ test("registers and calls PR3 core read tools", async () => {
 
     const tools = await client.listTools();
     assert.deepEqual(tools.tools.map((tool) => tool.name).sort(), [
+      "get_company_details",
       "get_product_details",
       "get_reviews",
+      "get_seller_reputation",
+      "get_storefront",
+      "list_companies",
       "search_products",
     ]);
     assert.deepEqual(await client.listResources(), { resources: [] });

--- a/packages/shopstr-mcp/test/tools/seller-tools.node.mjs
+++ b/packages/shopstr-mcp/test/tools/seller-tools.node.mjs
@@ -233,6 +233,47 @@ test("get_company_details merges profiles, products, reviews, and cache metadata
   });
 });
 
+test("get_company_details hints when review lookup is partial", async () => {
+  const products = Array.from({ length: 21 }, (_, index) =>
+    productEvent({
+      id: (index + 1).toString(16).padStart(64, "0"),
+      created_at: 130 + index,
+      tags: [
+        ["d", `item-${index}`],
+        ["title", `Product ${index}`],
+        ["summary", "Product beyond review scan cap"],
+        ["price", "25", "USD"],
+      ],
+    })
+  );
+  const response = await handleGetCompanyDetails(
+    { pubkey: sellerPubkey },
+    context((filters) => {
+      if (
+        filters.some((filter) =>
+          filter.kinds?.some((kind) => kind === 0 || kind === 30019)
+        )
+      ) {
+        return [profileEvent(), shopEvent()];
+      }
+      if (filters.some((filter) => filter.kinds?.includes(30402))) {
+        return products;
+      }
+      if (filters.some((filter) => filter.kinds?.includes(31555))) {
+        return [];
+      }
+      return [];
+    })
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(body.products.totalMatches, 21);
+  assert.ok(
+    body._meta._hints.some((hint) => hint.includes("Review lookup was partial"))
+  );
+});
+
 test("get_company_details accepts npub input via pubkeySchema", async () => {
   const npub = nip19.npubEncode(sellerPubkey);
   const response = await handleGetCompanyDetails(

--- a/packages/shopstr-mcp/test/tools/seller-tools.node.mjs
+++ b/packages/shopstr-mcp/test/tools/seller-tools.node.mjs
@@ -1,0 +1,376 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nip19 } from "nostr-tools";
+
+import { MemoryCache } from "../../dist/cache.js";
+import { handleGetCompanyDetails } from "../../dist/tools/get-company-details.js";
+import { handleGetSellerReputation } from "../../dist/tools/get-seller-reputation.js";
+import { handleGetStorefront } from "../../dist/tools/get-storefront.js";
+import { handleListCompanies } from "../../dist/tools/list-companies.js";
+
+const hex = (char) => char.repeat(64);
+const sellerPubkey = hex("8");
+const reviewerPubkey = hex("7");
+const productAddress = `30402:${sellerPubkey}:coffee`;
+
+function profileEvent(overrides = {}) {
+  return {
+    id: hex("1"),
+    pubkey: sellerPubkey,
+    created_at: 100,
+    kind: 0,
+    tags: [],
+    content: JSON.stringify({
+      name: "Fresh Seller",
+      display_name: "Fresh Seller",
+      about: "Public seller profile",
+      website: "https://example.com",
+    }),
+    sig: "a".repeat(128),
+    ...overrides,
+  };
+}
+
+function shopEvent(overrides = {}) {
+  return {
+    id: hex("2"),
+    pubkey: sellerPubkey,
+    created_at: 120,
+    kind: 30019,
+    tags: [],
+    content: JSON.stringify({
+      name: "Fresh Shop",
+      about: "Relay-native storefront",
+      storefront: {
+        shopSlug: "fresh-shop",
+        productLayout: "grid",
+      },
+      freeShippingThreshold: 100,
+      freeShippingCurrency: "USD",
+    }),
+    sig: "b".repeat(128),
+    ...overrides,
+  };
+}
+
+function productEvent(overrides = {}) {
+  return {
+    id: hex("3"),
+    pubkey: sellerPubkey,
+    created_at: 130,
+    kind: 30402,
+    tags: [
+      ["d", "coffee"],
+      ["title", "Coffee Beans"],
+      ["summary", "Washed process coffee"],
+      ["price", "25", "USD"],
+      ["shipping", "Free", "0", "USD"],
+      ["t", "Coffee"],
+    ],
+    content: "",
+    sig: "c".repeat(128),
+    ...overrides,
+  };
+}
+
+function reviewEvent(overrides = {}) {
+  return {
+    id: hex("4"),
+    pubkey: reviewerPubkey,
+    created_at: 140,
+    kind: 31555,
+    tags: [
+      ["d", `a:${productAddress}`],
+      ["rating", "1", "thumb"],
+      ["rating", "0.8", "quality"],
+    ],
+    content: "Fast shipping and good product.",
+    sig: "d".repeat(128),
+    ...overrides,
+  };
+}
+
+function context(fetchImpl, cache = new MemoryCache(60_000)) {
+  const calls = [];
+  return {
+    calls,
+    relays: ["wss://relay.example.com"],
+    timeoutMs: 100,
+    cache,
+    nostr: {
+      async fetch(filters) {
+        calls.push(filters);
+        return fetchImpl(filters);
+      },
+    },
+  };
+}
+
+function sellerFetch(filters) {
+  if (
+    filters.some((filter) =>
+      filter.kinds?.some((kind) => kind === 0 || kind === 30019)
+    )
+  ) {
+    return [profileEvent(), shopEvent()];
+  }
+  if (filters.some((filter) => filter.kinds?.includes(30402))) {
+    return [productEvent()];
+  }
+  if (filters.some((filter) => filter.kinds?.includes(31555))) {
+    return [reviewEvent()];
+  }
+  return [];
+}
+
+// ─── list_companies ──────────────────────────────────────────────────
+
+test("list_companies fetches latest public shop profiles and budgets results", async () => {
+  const response = await handleListCompanies(
+    { limit: 1 },
+    context(() => [
+      shopEvent({
+        id: hex("5"),
+        created_at: 80,
+        content: JSON.stringify({ name: "Old Shop" }),
+      }),
+      shopEvent(),
+      shopEvent({
+        id: hex("6"),
+        pubkey: hex("9"),
+        created_at: 110,
+        content: JSON.stringify({ name: "Second Shop" }),
+      }),
+    ])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(body.count, 1);
+  assert.equal(body.totalMatches, 2);
+  assert.equal(body.companies[0].name, "Fresh Shop");
+  assert.equal(body._meta._truncated, true);
+});
+
+test("list_companies passes until to relay filter and includes _pagination", async () => {
+  const ctx = context((filters) => {
+    // Verify the until parameter is passed to relay filter
+    assert.ok(filters.some((f) => f.until === 100));
+    return [
+      shopEvent({ created_at: 90 }),
+      shopEvent({
+        id: hex("6"),
+        pubkey: hex("9"),
+        created_at: 80,
+        content: JSON.stringify({ name: "Older Shop" }),
+      }),
+    ];
+  });
+  const response = await handleListCompanies({ limit: 10, until: 100 }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.count, 2);
+  assert.ok(body._pagination);
+  assert.equal(body._pagination.oldestCreatedAt, 80);
+});
+
+test("list_companies returns null oldestCreatedAt when empty", async () => {
+  const response = await handleListCompanies(
+    { limit: 10 },
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.count, 0);
+  assert.equal(body._pagination.oldestCreatedAt, null);
+});
+
+// ─── get_company_details ─────────────────────────────────────────────
+
+test("get_company_details merges profiles, products, reviews, and cache metadata", async () => {
+  const cache = new MemoryCache(60_000);
+  const ctx = context(sellerFetch, cache);
+
+  const first = await handleGetCompanyDetails({ pubkey: sellerPubkey }, ctx);
+  const firstBody = JSON.parse(first.content[0].text);
+
+  assert.equal(firstBody.pubkey, sellerPubkey);
+  assert.equal(firstBody.shopProfile.name, "Fresh Shop");
+  assert.equal(firstBody.shopProfile.storefrontUrl, "/shop/fresh-shop");
+  assert.equal(firstBody.userProfile.name, "Fresh Seller");
+  assert.equal(firstBody.userProfile.displayName, "Fresh Seller");
+  assert.equal(firstBody.products.count, 1);
+  assert.equal(firstBody.products.items[0].title, "Coffee Beans");
+  assert.equal(firstBody.reviews.count, 1);
+  assert.deepEqual(firstBody.paymentInfo.acceptedPaymentMethods, [
+    "lightning",
+    "cashu",
+  ]);
+  assert.equal(firstBody.paymentInfo.freeShippingAvailable, true);
+  assert.deepEqual(firstBody._meta.cached, {
+    userProfile: false,
+    shopProfile: false,
+  });
+
+  const profileFetchesBefore = ctx.calls.filter((filters) =>
+    filters.some((filter) =>
+      filter.kinds?.some((kind) => kind === 0 || kind === 30019)
+    )
+  ).length;
+  const second = await handleGetCompanyDetails({ pubkey: sellerPubkey }, ctx);
+  const secondBody = JSON.parse(second.content[0].text);
+  const profileFetchesAfter = ctx.calls.filter((filters) =>
+    filters.some((filter) =>
+      filter.kinds?.some((kind) => kind === 0 || kind === 30019)
+    )
+  ).length;
+
+  assert.equal(profileFetchesAfter, profileFetchesBefore);
+  assert.deepEqual(secondBody._meta.cached, {
+    userProfile: true,
+    shopProfile: true,
+  });
+});
+
+test("get_company_details accepts npub input via pubkeySchema", async () => {
+  const npub = nip19.npubEncode(sellerPubkey);
+  const response = await handleGetCompanyDetails(
+    { pubkey: npub },
+    context(sellerFetch)
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.pubkey, sellerPubkey);
+  assert.equal(body.shopProfile.name, "Fresh Shop");
+});
+
+test("get_company_details returns NOT_FOUND for unknown pubkey", async () => {
+  const response = await handleGetCompanyDetails(
+    { pubkey: hex("f") },
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "NOT_FOUND");
+});
+
+test("get_company_details rejects invalid pubkey", async () => {
+  const response = await handleGetCompanyDetails(
+    { pubkey: "not-a-valid-key" },
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "VALIDATION_ERROR");
+});
+
+// ─── get_storefront ──────────────────────────────────────────────────
+
+test("get_storefront requires pubkey and returns storefront data", async () => {
+  const response = await handleGetStorefront(
+    { pubkey: sellerPubkey },
+    context(sellerFetch)
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.pubkey, sellerPubkey);
+  assert.equal(body.storefront.shopSlug, "fresh-shop");
+  assert.equal(body.storefront.storefrontUrl, "/shop/fresh-shop");
+  assert.equal(body.storefront.customDomain, null);
+  assert.equal(body.products.count, 1);
+});
+
+test("get_storefront rejects missing pubkey", async () => {
+  const response = await handleGetStorefront({}, context(sellerFetch));
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "VALIDATION_ERROR");
+});
+
+test("get_storefront returns NOT_FOUND for unknown pubkey", async () => {
+  const response = await handleGetStorefront(
+    { pubkey: hex("f") },
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "NOT_FOUND");
+});
+
+// ─── get_seller_reputation ───────────────────────────────────────────
+
+test("get_seller_reputation summarizes public review scores", async () => {
+  const response = await handleGetSellerReputation(
+    { sellerPubkey },
+    context((filters) => {
+      if (
+        filters.some((filter) =>
+          filter.kinds?.some((kind) => kind === 0 || kind === 30019)
+        )
+      ) {
+        return [profileEvent(), shopEvent()];
+      }
+      if (filters.some((filter) => filter.kinds?.includes(30402))) {
+        return [productEvent()];
+      }
+      if (filters.some((filter) => filter.kinds?.includes(31555))) {
+        return [
+          reviewEvent(),
+          reviewEvent({
+            id: hex("5"),
+            pubkey: hex("6"),
+            created_at: 150,
+            tags: [
+              ["d", `a:${productAddress}`],
+              ["rating", "0", "thumb"],
+              ["rating", "0.2", "quality"],
+            ],
+            content: "Poor communication.",
+          }),
+        ];
+      }
+      return [];
+    })
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.reviewCount, 2);
+  assert.equal(body.productCount, 1);
+  assert.equal(body.reputation.averageScore, 0.5);
+  assert.equal(body.reputation.averagePercent, 50);
+  assert.equal(body.reputation.positiveReviewCount, 1);
+  assert.equal(body.reputation.negativeReviewCount, 1);
+  assert.equal(body.reputation.trustLevel, "low");
+  assert.deepEqual(body.reputation.ratingBreakdown.thumb, {
+    average: 0.5,
+    count: 2,
+  });
+  assert.equal(body.recentReviews.length, 2);
+});
+
+test("get_seller_reputation includes oldestListingDate", async () => {
+  const response = await handleGetSellerReputation(
+    { sellerPubkey },
+    context(sellerFetch)
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.ok(body.oldestListingDate);
+  assert.equal(body.oldestListingDate, new Date(130 * 1000).toISOString());
+});
+
+test("get_seller_reputation returns NOT_FOUND for unknown seller", async () => {
+  const response = await handleGetSellerReputation(
+    { sellerPubkey: hex("f") },
+    context(() => [])
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "NOT_FOUND");
+});

--- a/packages/shopstr-mcp/test/validation.node.mjs
+++ b/packages/shopstr-mcp/test/validation.node.mjs
@@ -5,11 +5,15 @@ import { nip19 } from "nostr-tools";
 
 import {
   canonicalizePubkey,
+  companyDetailsInputSchema,
   eventIdSchema,
+  listCompaniesSchema,
   pubkeySchema,
   reviewsInputSchema,
   searchProductsSchema,
   searchSchema,
+  sellerReputationInputSchema,
+  storefrontInputSchema,
 } from "../dist/validation.js";
 
 const pubkey = "a".repeat(64);
@@ -51,4 +55,58 @@ test("requires at least one reviews lookup identifier", () => {
       .success,
     true
   );
+});
+
+// ─── PR4 schema tests ───────────────────────────────────────────────
+
+test("listCompaniesSchema defaults limit to 50 and accepts until", () => {
+  const result = listCompaniesSchema.parse({});
+  assert.equal(result.limit, 50);
+  assert.equal(result.until, undefined);
+
+  const withUntil = listCompaniesSchema.parse({ until: 1700000000 });
+  assert.equal(withUntil.until, 1700000000);
+  assert.equal(withUntil.limit, 50);
+});
+
+test("listCompaniesSchema rejects negative until", () => {
+  assert.equal(listCompaniesSchema.safeParse({ until: -1 }).success, false);
+});
+
+test("companyDetailsInputSchema canonicalizes npub to hex", () => {
+  const npub = nip19.npubEncode(pubkey);
+  const result = companyDetailsInputSchema.parse({ pubkey: npub });
+  assert.equal(result.pubkey, pubkey);
+});
+
+test("companyDetailsInputSchema rejects invalid pubkey", () => {
+  assert.equal(
+    companyDetailsInputSchema.safeParse({ pubkey: "not-a-key" }).success,
+    false
+  );
+});
+
+test("storefrontInputSchema requires pubkey", () => {
+  assert.equal(storefrontInputSchema.safeParse({}).success, false);
+  assert.equal(
+    storefrontInputSchema.safeParse({ pubkey: pubkey }).success,
+    true
+  );
+});
+
+test("storefrontInputSchema canonicalizes npub pubkey", () => {
+  const npub = nip19.npubEncode(pubkey);
+  const result = storefrontInputSchema.parse({ pubkey: npub });
+  assert.equal(result.pubkey, pubkey);
+});
+
+test("sellerReputationInputSchema canonicalizes pubkey", () => {
+  const result = sellerReputationInputSchema.parse({
+    sellerPubkey: pubkey.toUpperCase(),
+  });
+  assert.equal(result.sellerPubkey, pubkey);
+});
+
+test("sellerReputationInputSchema rejects missing sellerPubkey", () => {
+  assert.equal(sellerReputationInputSchema.safeParse({}).success, false);
 });


### PR DESCRIPTION
### Description

- Adds relay-backed MCP seller/profile tools: get_company_details, get_storefront, list_companies and get_seller_reputation
- Registered and exported all 5 new tools so they are visible to the MCP client.
- get_company_details:  Fetches and deduplicates both kind: 0 (user profile) and kind: 30019 (shop profile), alongside the seller's products and reviews.
- get_storefront:  Returns shop configuration and products but omits the heavy customer reviews.
- list_companies: Discovers public Shopstr sellers (querying kind: 30019). Add until pagination support .
- get_seller_reputation: Calculates and normalizes seller trust scores using kind: 31555 review tags (50% thumb weight, 50% category averages) - Based on Gamma Market Spec. 
- Extract review helpers and common seller utilities into seperate modules
- Extract duplicated guard pattern
- Add deduplication for profiles 
- Add  test coverage for the newly added tools (some are left)

### Video
https://drive.google.com/file/d/1xot-BLDSwV1DnTd5aNkZiZh0OV40QfhC/view?usp=sharing
### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
