### PR TITLE
fix: cryptographically validate zap receipts instead of just polling relays

### DIFF
--- a/components/ZapsnagButton.tsx
+++ b/components/ZapsnagButton.tsx
@@ -25,7 +25,53 @@ import {
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
 import { ProductData } from "@/utils/parsers/product-parser-functions";
-import { validateZapReceipt, validateSingleReceipt } from "@/utils/nostr/zap-validator";
+import {
+  validateZapReceipt,
+  validateSingleReceipt,
+} from "@/utils/nostr/zap-validator";
+import type { NostrManager } from "@/utils/nostr/nostr-manager";
+
+type SellerZapContext = {
+  lightningAddress: LightningAddress;
+  zapRecipientPubkey: string;
+};
+
+async function resolveSellerZapContext(
+  nostrManager: NostrManager,
+  sellerPubkey: string
+): Promise<SellerZapContext> {
+  const profileFilter = { kinds: [0], authors: [sellerPubkey] };
+  const events = await nostrManager.fetch([profileFilter]);
+  let lud16 = "";
+
+  if (events.length > 0) {
+    const kind0 = [...events].sort((a, b) => b.created_at - a.created_at)[0];
+    if (kind0) {
+      try {
+        const content = JSON.parse(kind0.content || "{}");
+        lud16 = content.lud16 || content.lnurl || "";
+      } catch (e) {
+        console.warn("Failed to parse seller profile", e);
+      }
+    }
+  }
+
+  if (!lud16) {
+    throw new Error("Seller has not set up a Lightning Address (LUD16).");
+  }
+
+  const lightningAddress = new LightningAddress(lud16);
+  await lightningAddress.fetch();
+
+  if (!lightningAddress.nostrPubkey) {
+    throw new Error("Seller Lightning Address does not support NIP-57 zaps.");
+  }
+
+  return {
+    lightningAddress,
+    zapRecipientPubkey: lightningAddress.nostrPubkey,
+  };
+}
 
 export default function ZapsnagButton({ product }: { product: ProductData }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -74,18 +120,22 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
       }
 
       try {
+        const { zapRecipientPubkey } = await resolveSellerZapContext(
+          nostrManager,
+          product.pubkey
+        );
         const filter = { kinds: [9735], "#e": [product.id] };
         const events = await nostrManager.fetch([filter]);
         let count = 0;
         for (const event of events) {
-          const result = validateSingleReceipt(
-            event,
-            product.id,
-            product.pubkey,
-            product.price,
-            0,
-            { skipFreshnessCheck: true }
-          );
+          const result = validateSingleReceipt(event, {
+            productId: product.id,
+            expectedRecipientPubkey: zapRecipientPubkey,
+            expectedReceiptSignerPubkey: zapRecipientPubkey,
+            expectedAmountSats: product.price,
+            minTimestamp: 0,
+            skipFreshnessCheck: true,
+          });
           if (result.valid) count++;
         }
         setSoldCount(count);
@@ -96,7 +146,13 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
       }
     };
     checkInventory();
-  }, [nostrManager, product.id, product.quantity]);
+  }, [
+    nostrManager,
+    product.id,
+    product.price,
+    product.pubkey,
+    product.quantity,
+  ]);
 
   const handleBuy = async () => {
     let originalWebLN: any;
@@ -119,27 +175,8 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
     setLoading(true);
     setStatus("Finding seller address...");
     try {
-      const profileFilter = { kinds: [0], authors: [product.pubkey] };
-      const events = (await nostrManager?.fetch([profileFilter])) || [];
-      let lud16 = "";
-
-      if (events.length > 0) {
-        const kind0 = [...events].sort(
-          (a, b) => b.created_at - a.created_at
-        )[0];
-        if (kind0) {
-          try {
-            const content = JSON.parse(kind0.content || "{}");
-            lud16 = content.lud16 || content.lnurl || "";
-          } catch (e) {
-            console.warn("Failed to parse seller profile", e);
-          }
-        }
-      }
-
-      if (!lud16) {
-        throw new Error("Seller has not set up a Lightning Address (LUD16).");
-      }
+      const { lightningAddress: ln, zapRecipientPubkey } =
+        await resolveSellerZapContext(nostrManager, product.pubkey);
 
       originalWebLN = (window as any).webln;
       const { nwcString } = getLocalStorageData();
@@ -197,8 +234,6 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
       await sendGiftWrappedMessageEvent(nostrManager!, finalEvent, signer);
 
       setStatus("Paying via Lightning...");
-      const ln = new LightningAddress(lud16);
-      await ln.fetch();
 
       const { relays: userRelays } = getLocalStorageData();
       const targetRelays =
@@ -223,14 +258,14 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
         );
 
         setStatus("Verifying receipt...");
-        const receiptResult = await validateZapReceipt(
-          nostrManager,
-          product.id,
-          startTime,
-          product.pubkey,
-          product.price,
-          response.preimage
-        );
+        const receiptResult = await validateZapReceipt(nostrManager, {
+          productId: product.id,
+          expectedRecipientPubkey: zapRecipientPubkey,
+          expectedReceiptSignerPubkey: zapRecipientPubkey,
+          expectedAmountSats: product.price,
+          minTimestamp: startTime,
+          expectedPreimage: response.preimage,
+        });
 
         if (receiptResult.valid) {
           alert(

--- a/components/ZapsnagButton.tsx
+++ b/components/ZapsnagButton.tsx
@@ -25,7 +25,7 @@ import {
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { SHOPSTRBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
 import { ProductData } from "@/utils/parsers/product-parser-functions";
-import { validateZapReceipt } from "@/utils/nostr/zap-validator";
+import { validateZapReceipt, validateSingleReceipt } from "@/utils/nostr/zap-validator";
 
 export default function ZapsnagButton({ product }: { product: ProductData }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -63,7 +63,10 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
 
   useEffect(() => {
     const checkInventory = async () => {
-      if (!nostrManager || !product.id) return;
+      if (!nostrManager || !product.id) {
+        setIsCheckingInventory(false);
+        return;
+      }
 
       if (!product.quantity || product.quantity <= 0) {
         setIsCheckingInventory(false);
@@ -72,8 +75,20 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
 
       try {
         const filter = { kinds: [9735], "#e": [product.id] };
-        const zaps = await nostrManager.fetch([filter]);
-        setSoldCount(zaps.length);
+        const events = await nostrManager.fetch([filter]);
+        let count = 0;
+        for (const event of events) {
+          const result = validateSingleReceipt(
+            event,
+            product.id,
+            product.pubkey,
+            product.price,
+            0,
+            { skipFreshnessCheck: true }
+          );
+          if (result.valid) count++;
+        }
+        setSoldCount(count);
       } catch (e) {
         console.error("Failed to check inventory", e);
       } finally {
@@ -87,6 +102,12 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
     let originalWebLN: any;
     if (!signer || !isLoggedIn || !userPubkey) {
       alert("Please sign in to purchase.");
+      return;
+    }
+
+    if (!nostrManager) {
+      alert("Connection error: unable to verify payment.");
+      setLoading(false);
       return;
     }
 
@@ -202,13 +223,16 @@ export default function ZapsnagButton({ product }: { product: ProductData }) {
         );
 
         setStatus("Verifying receipt...");
-        const receiptFound = await validateZapReceipt(
-          nostrManager!,
+        const receiptResult = await validateZapReceipt(
+          nostrManager,
           product.id,
-          startTime
+          startTime,
+          product.pubkey,
+          product.price,
+          response.preimage
         );
 
-        if (receiptFound) {
+        if (receiptResult.valid) {
           alert(
             "Order Placed & Verified! Preimage: " +
               response.preimage.substring(0, 8) +

--- a/components/__tests__/ZapsnagButton.test.tsx
+++ b/components/__tests__/ZapsnagButton.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import ZapsnagButton from "../ZapsnagButton";
 import {
   NostrContext,
@@ -55,16 +61,26 @@ jest.mock("@heroicons/react/24/outline", () => ({
   BoltIcon: () => <span data-testid="bolt-icon">⚡</span>,
 }));
 
+const mockLightningAddressInstances: any[] = [];
+
 jest.mock("@getalby/lightning-tools", () => {
   return {
-    LightningAddress: jest.fn().mockImplementation(() => ({
-      fetch: jest.fn().mockResolvedValue(true),
-      zap: jest.fn().mockResolvedValue({ preimage: "test-preimage" }),
-    })),
+    LightningAddress: jest.fn().mockImplementation(() => {
+      const instance = {
+        nostrPubkey: "lnurl-provider-pubkey",
+        fetch: jest.fn().mockResolvedValue(true),
+        zap: jest.fn().mockResolvedValue({ preimage: "test-preimage" }),
+      };
+      mockLightningAddressInstances.push(instance);
+      return instance;
+    }),
   };
 });
 
 jest.mock("@getalby/sdk", () => ({
+  NostrWebLNProvider: jest.fn().mockImplementation(() => ({
+    enable: jest.fn().mockResolvedValue(true),
+  })),
   webln: {
     NostrWebLNProvider: jest.fn().mockImplementation(() => ({
       enable: jest.fn().mockResolvedValue(true),
@@ -87,7 +103,9 @@ jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
 
 jest.mock("@/utils/nostr/zap-validator", () => ({
   validateZapReceipt: jest.fn(),
-  validateSingleReceipt: jest.fn().mockReturnValue({ valid: true, amountSats: 100, errors: [] }),
+  validateSingleReceipt: jest
+    .fn()
+    .mockReturnValue({ valid: true, amountSats: 100, errors: [] }),
 }));
 
 Object.defineProperty(global, "crypto", {
@@ -112,10 +130,11 @@ const mockProduct = {
   totalCost: 100,
 };
 
+const LNURL_NOSTR_PUBKEY = "lnurl-provider-pubkey";
 const mockSigner = { signEvent: jest.fn() };
 const mockNostrManager = { fetch: jest.fn() };
 
-const renderComponent = (contextOverrides = {}) => {
+const renderComponent = (contextOverrides = {}, product = mockProduct) => {
   const defaultContext = {
     nostrContext: { nostr: mockNostrManager },
     signerContext: {
@@ -129,7 +148,7 @@ const renderComponent = (contextOverrides = {}) => {
   return render(
     <NostrContext.Provider value={defaultContext.nostrContext as any}>
       <SignerContext.Provider value={defaultContext.signerContext as any}>
-        <ZapsnagButton product={mockProduct} />
+        <ZapsnagButton product={product as any} />
       </SignerContext.Provider>
     </NostrContext.Provider>
   );
@@ -138,9 +157,20 @@ const renderComponent = (contextOverrides = {}) => {
 describe("ZapsnagButton Component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLightningAddressInstances.length = 0;
     mockNostrManager.fetch.mockReset();
     mockSigner.signEvent.mockReset();
     window.alert = jest.fn();
+
+    (LightningAddress as unknown as jest.Mock).mockImplementation(() => {
+      const instance = {
+        nostrPubkey: LNURL_NOSTR_PUBKEY,
+        fetch: jest.fn().mockResolvedValue(true),
+        zap: jest.fn().mockResolvedValue({ preimage: "test-preimage" }),
+      };
+      mockLightningAddressInstances.push(instance);
+      return instance;
+    });
 
     Storage.prototype.getItem = jest.fn(() => null);
     Storage.prototype.setItem = jest.fn();
@@ -396,11 +426,14 @@ describe("ZapsnagButton Component", () => {
     expect(zapValidator.validateZapReceipt).toHaveBeenCalled();
     expect(zapValidator.validateZapReceipt).toHaveBeenCalledWith(
       mockNostrManager,
-      mockProduct.id,
-      1700000000,
-      mockProduct.pubkey,
-      mockProduct.price,
-      "test-preimage"
+      expect.objectContaining({
+        productId: mockProduct.id,
+        minTimestamp: 1700000000,
+        expectedRecipientPubkey: LNURL_NOSTR_PUBKEY,
+        expectedReceiptSignerPubkey: LNURL_NOSTR_PUBKEY,
+        expectedAmountSats: mockProduct.price,
+        expectedPreimage: "test-preimage",
+      })
     );
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
@@ -427,15 +460,15 @@ describe("ZapsnagButton Component", () => {
     (nostrHelpers.constructGiftWrappedEvent as jest.Mock).mockResolvedValueOnce(
       { id: "gift-wrap" }
     );
-    (nostrHelpers.constructMessageSeal as jest.Mock).mockResolvedValueOnce(
-      { id: "seal" }
-    );
-    (nostrHelpers.constructMessageGiftWrap as jest.Mock).mockResolvedValueOnce(
-      { id: "final" }
-    );
-    (nostrHelpers.sendGiftWrappedMessageEvent as jest.Mock).mockResolvedValueOnce(
-      undefined
-    );
+    (nostrHelpers.constructMessageSeal as jest.Mock).mockResolvedValueOnce({
+      id: "seal",
+    });
+    (nostrHelpers.constructMessageGiftWrap as jest.Mock).mockResolvedValueOnce({
+      id: "final",
+    });
+    (
+      nostrHelpers.sendGiftWrappedMessageEvent as jest.Mock
+    ).mockResolvedValueOnce(undefined);
 
     (zapValidator.validateZapReceipt as jest.Mock).mockResolvedValue({
       valid: false,
@@ -504,6 +537,81 @@ describe("ZapsnagButton Component", () => {
     expect(window.alert).toHaveBeenCalledWith(
       expect.stringContaining("Seller has not set up a Lightning Address")
     );
+  });
+
+  test("shows alert if seller Lightning Address does not support NIP-57 zaps", async () => {
+    (LightningAddress as unknown as jest.Mock).mockImplementationOnce(() => ({
+      nostrPubkey: "",
+      fetch: jest.fn().mockResolvedValue(true),
+      zap: jest.fn(),
+    }));
+
+    mockNostrManager.fetch.mockResolvedValueOnce([
+      {
+        created_at: 100,
+        content: JSON.stringify({ lud16: "seller@alby.com" }),
+      },
+    ]);
+
+    renderComponent();
+    fireEvent.click(screen.getByText(/Zap to Buy/i));
+
+    fireEvent.change(screen.getByLabelText("Full Name"), {
+      target: { value: "Buyer" },
+    });
+    fireEvent.change(screen.getByLabelText("Street Address"), {
+      target: { value: "Road" },
+    });
+    fireEvent.change(screen.getByLabelText("City"), {
+      target: { value: "Town" },
+    });
+    fireEvent.change(screen.getByLabelText("Postal / Zip Code"), {
+      target: { value: "123" },
+    });
+    fireEvent.change(screen.getByLabelText("Country"), {
+      target: { value: "US" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Confirm & Zap"));
+    });
+
+    expect(window.alert).toHaveBeenCalledWith(
+      expect.stringContaining("does not support NIP-57 zaps")
+    );
+    expect(zapValidator.validateZapReceipt).not.toHaveBeenCalled();
+  });
+
+  test("uses LNURL provider pubkey when validating inventory receipts", async () => {
+    const quantityProduct = { ...mockProduct, quantity: 3 };
+    const receipt = { id: "receipt-id" };
+
+    mockNostrManager.fetch
+      .mockResolvedValueOnce([
+        {
+          created_at: 100,
+          content: JSON.stringify({ lud16: "seller@alby.com" }),
+        },
+      ])
+      .mockResolvedValueOnce([receipt]);
+
+    renderComponent({}, quantityProduct);
+
+    await waitFor(() => {
+      expect(zapValidator.validateSingleReceipt).toHaveBeenCalledWith(
+        receipt,
+        expect.objectContaining({
+          productId: quantityProduct.id,
+          expectedRecipientPubkey: LNURL_NOSTR_PUBKEY,
+          expectedReceiptSignerPubkey: LNURL_NOSTR_PUBKEY,
+          expectedAmountSats: quantityProduct.price,
+          minTimestamp: 0,
+          skipFreshnessCheck: true,
+        })
+      );
+    });
+
+    expect(screen.getByText(/Zap to Buy \(2 left\)/i)).toBeInTheDocument();
   });
 
   test("shows alert when nostrManager is not available", async () => {

--- a/components/__tests__/ZapsnagButton.test.tsx
+++ b/components/__tests__/ZapsnagButton.test.tsx
@@ -87,6 +87,7 @@ jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
 
 jest.mock("@/utils/nostr/zap-validator", () => ({
   validateZapReceipt: jest.fn(),
+  validateSingleReceipt: jest.fn().mockReturnValue({ valid: true, amountSats: 100, errors: [] }),
 }));
 
 Object.defineProperty(global, "crypto", {
@@ -284,7 +285,13 @@ describe("ZapsnagButton Component", () => {
       nostrHelpers.sendGiftWrappedMessageEvent as jest.Mock
     ).mockResolvedValueOnce(undefined);
 
-    (zapValidator.validateZapReceipt as jest.Mock).mockResolvedValue(true);
+    (zapValidator.validateZapReceipt as jest.Mock).mockResolvedValue({
+      valid: true,
+      amountSats: 100,
+      payerPubkey: "buyer-pubkey",
+      receiptId: "receipt-id",
+      errors: [],
+    });
 
     renderComponent();
 
@@ -390,7 +397,10 @@ describe("ZapsnagButton Component", () => {
     expect(zapValidator.validateZapReceipt).toHaveBeenCalledWith(
       mockNostrManager,
       mockProduct.id,
-      1700000000
+      1700000000,
+      mockProduct.pubkey,
+      mockProduct.price,
+      "test-preimage"
     );
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
@@ -399,6 +409,65 @@ describe("ZapsnagButton Component", () => {
     );
     expect(window.alert).toHaveBeenCalledWith(
       expect.stringContaining("Order Placed & Verified")
+    );
+
+    dateNowSpy.mockRestore();
+  });
+
+  test("shows fallback alert when zap receipt validation fails", async () => {
+    const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+    mockNostrManager.fetch.mockResolvedValueOnce([
+      {
+        created_at: 100,
+        content: JSON.stringify({ lud16: "seller@alby.com" }),
+      },
+    ]);
+
+    (nostrHelpers.constructGiftWrappedEvent as jest.Mock).mockResolvedValueOnce(
+      { id: "gift-wrap" }
+    );
+    (nostrHelpers.constructMessageSeal as jest.Mock).mockResolvedValueOnce(
+      { id: "seal" }
+    );
+    (nostrHelpers.constructMessageGiftWrap as jest.Mock).mockResolvedValueOnce(
+      { id: "final" }
+    );
+    (nostrHelpers.sendGiftWrappedMessageEvent as jest.Mock).mockResolvedValueOnce(
+      undefined
+    );
+
+    (zapValidator.validateZapReceipt as jest.Mock).mockResolvedValue({
+      valid: false,
+      amountSats: 0,
+      errors: ["No valid zap receipt found after all retries"],
+    });
+
+    renderComponent();
+    fireEvent.click(screen.getByText(/Zap to Buy/i));
+    fireEvent.change(screen.getByLabelText("Full Name"), {
+      target: { value: "Buyer" },
+    });
+    fireEvent.change(screen.getByLabelText("Street Address"), {
+      target: { value: "Road" },
+    });
+    fireEvent.change(screen.getByLabelText("City"), {
+      target: { value: "Town" },
+    });
+    fireEvent.change(screen.getByLabelText("Postal / Zip Code"), {
+      target: { value: "123" },
+    });
+    fireEvent.change(screen.getByLabelText("Country"), {
+      target: { value: "US" },
+    });
+
+    const confirmBtn = screen.getByText("Confirm & Zap");
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(window.alert).toHaveBeenCalledWith(
+      expect.stringContaining("Payment sent (Preimage received)")
     );
 
     dateNowSpy.mockRestore();
@@ -434,6 +503,42 @@ describe("ZapsnagButton Component", () => {
 
     expect(window.alert).toHaveBeenCalledWith(
       expect.stringContaining("Seller has not set up a Lightning Address")
+    );
+  });
+
+  test("shows alert when nostrManager is not available", async () => {
+    renderComponent({
+      nostrContext: { nostr: null },
+      signerContext: {
+        signer: mockSigner,
+        isLoggedIn: true,
+        pubkey: "buyer-pubkey",
+      },
+    });
+
+    fireEvent.click(screen.getByText(/Zap to Buy/i));
+    fireEvent.change(screen.getByLabelText("Full Name"), {
+      target: { value: "Buyer" },
+    });
+    fireEvent.change(screen.getByLabelText("Street Address"), {
+      target: { value: "Road" },
+    });
+    fireEvent.change(screen.getByLabelText("City"), {
+      target: { value: "Town" },
+    });
+    fireEvent.change(screen.getByLabelText("Postal / Zip Code"), {
+      target: { value: "123" },
+    });
+    fireEvent.change(screen.getByLabelText("Country"), {
+      target: { value: "US" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Confirm & Zap"));
+    });
+
+    expect(window.alert).toHaveBeenCalledWith(
+      "Connection error: unable to verify payment."
     );
   });
 

--- a/utils/nostr/__tests__/zap-validator.test.ts
+++ b/utils/nostr/__tests__/zap-validator.test.ts
@@ -1,12 +1,593 @@
-import { validateZapReceipt } from "@/utils/nostr/zap-validator";
+import { validateZapReceipt, validateSingleReceipt } from "@/utils/nostr/zap-validator";
 import { NostrManager } from "@/utils/nostr/nostr-manager";
 
-const mockFetch = jest.fn();
-const mockNostrManager = {
-  fetch: mockFetch,
-} as unknown as NostrManager;
+const mockVerifyEvent = jest.fn();
+jest.mock("nostr-tools", () => {
+  const actual = jest.requireActual("nostr-tools");
+  return {
+    ...actual,
+    verifyEvent: (...args: unknown[]) => mockVerifyEvent(...args),
+  };
+});
+
+const SELLER_PUBKEY = "seller-pubkey-hex";
+const BUYER_PUBKEY = "buyer-pubkey-hex";
+const PRODUCT_ID = "product-event-id";
+const AMOUNT_SATS = 100;
+const AMOUNT_MSAT = 100000;
+const MIN_TIMESTAMP = 2000;
+
+function defaultTags(): string[][] {
+  return [
+    ["p", SELLER_PUBKEY],
+    ["e", PRODUCT_ID],
+    ["amount", String(AMOUNT_MSAT)],
+    ["bolt11", "lnbc..."],
+    ["description", JSON.stringify({
+      id: "zap-req-id",
+      pubkey: BUYER_PUBKEY,
+      created_at: MIN_TIMESTAMP,
+      kind: 9734,
+      tags: [
+        ["p", SELLER_PUBKEY],
+        ["e", PRODUCT_ID],
+        ["amount", String(AMOUNT_MSAT)],
+        ["relays", "wss://relay.damus.io"],
+      ],
+      content: "Order #order-123",
+      sig: "zap-req-sig",
+    })],
+    ["preimage", "test-preimage"],
+  ];
+}
+
+function withReplacedTag(
+  tags: string[][],
+  tagName: string,
+  newValues: string[]
+): string[][] {
+  return tags.map((t) => (t[0] === tagName ? newValues : t));
+}
+
+function makeReceipt(overrides?: Partial<{
+  kind: number;
+  tags: string[][];
+  content: string;
+  pubkey: string;
+  created_at: number;
+  id: string;
+  sig: string;
+}>): Record<string, unknown> {
+  return {
+    id: "receipt-id",
+    pubkey: SELLER_PUBKEY,
+    created_at: MIN_TIMESTAMP + 10,
+    kind: 9735,
+    tags: defaultTags(),
+    content: "",
+    sig: "receipt-sig",
+    ...overrides,
+  };
+}
+
+function makeZapRequest(overrides?: Partial<{
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+  id: string;
+  sig: string;
+}>): Record<string, unknown> {
+  return {
+    id: "zap-req-id",
+    pubkey: BUYER_PUBKEY,
+    created_at: MIN_TIMESTAMP,
+    kind: 9734,
+    tags: [
+      ["p", SELLER_PUBKEY],
+      ["e", PRODUCT_ID],
+      ["amount", String(AMOUNT_MSAT)],
+      ["relays", "wss://relay.damus.io"],
+    ],
+    content: "Order #order-123",
+    sig: "zap-req-sig",
+    ...overrides,
+  };
+}
+
+describe("validateSingleReceipt", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("accepts a fully valid receipt", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt() as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.amountSats).toBe(AMOUNT_SATS);
+    expect(result.payerPubkey).toBe(BUYER_PUBKEY);
+    expect(result.receiptId).toBe("receipt-id");
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects receipt with invalid signature", () => {
+    mockVerifyEvent.mockReturnValue(false);
+
+    const result = validateSingleReceipt(
+      makeReceipt() as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Invalid signature on zap receipt");
+  });
+
+  it("verifies both receipt and zap request signatures", () => {
+    let callCount = 0;
+    mockVerifyEvent.mockImplementation(() => {
+      callCount++;
+      return callCount === 1;
+    });
+
+    const result = validateSingleReceipt(
+      makeReceipt() as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Invalid signature on embedded zap request");
+    expect(callCount).toBe(2);
+  });
+
+  it("rejects receipt with wrong kind", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt({ kind: 1 }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Expected kind 9735/);
+  });
+
+  it("rejects receipt with wrong seller pubkey", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt({
+        tags: withReplacedTag(defaultTags(), "p", ["p", "wrong-pubkey"]),
+      }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/does not match seller/);
+  });
+
+  it("rejects receipt with wrong product id", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt() as any,
+      "different-product",
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/does not match product/);
+  });
+
+  it("rejects receipt without amount tag", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const withoutAmount = makeReceipt() as any;
+    withoutAmount.tags = withoutAmount.tags.filter((t: string[]) => t[0] !== "amount");
+
+    const result = validateSingleReceipt(
+      withoutAmount,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Missing or invalid 'amount' tag/);
+  });
+
+  it("rejects receipt with non-numeric amount (e.g. scientific notation)", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt({
+        tags: withReplacedTag(defaultTags(), "amount", ["amount", "1e5"]),
+      }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Missing or invalid 'amount' tag/);
+  });
+
+  it("rejects receipt with zero amount", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt({
+        tags: withReplacedTag(defaultTags(), "amount", ["amount", "0"]),
+      }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Invalid amount/);
+  });
+
+  it("rejects receipt with amount mismatch", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt({
+        tags: withReplacedTag(defaultTags(), "amount", ["amount", "50000"]),
+      }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/does not match expected/);
+  });
+
+  it("accepts amount within rounding tolerance (1 sat difference)", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const oneSatOff = (AMOUNT_SATS - 1) * 1000;
+    const tags = defaultTags();
+    const descStr = tags.find((t) => t[0] === "description")?.[1];
+    const desc = JSON.parse(descStr ?? "{}");
+    desc.tags = (desc.tags as string[][]).map((t) =>
+      t[0] === "amount" ? ["amount", String(oneSatOff)] : t
+    );
+    const updatedTags = tags.map((t) =>
+      t[0] === "amount"
+        ? ["amount", String(oneSatOff)]
+        : t[0] === "description"
+          ? ["description", JSON.stringify(desc)]
+          : t
+    );
+
+    const result = validateSingleReceipt(
+      makeReceipt({ tags: updatedTags }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.amountSats).toBe(AMOUNT_SATS - 1);
+  });
+
+  it("rejects receipt without description tag", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const withoutDesc = makeReceipt() as any;
+    withoutDesc.tags = withoutDesc.tags.filter((t: string[]) => t[0] !== "description");
+
+    const result = validateSingleReceipt(
+      withoutDesc,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Missing 'description' tag/);
+  });
+
+  it("rejects receipt with non-JSON description", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const badDesc = makeReceipt() as any;
+    for (let i = 0; i < badDesc.tags.length; i++) {
+      const tag = badDesc.tags[i];
+      if (tag && tag[0] === "description") {
+        badDesc.tags[i] = ["description", "not-json"];
+      }
+    }
+
+    const result = validateSingleReceipt(
+      badDesc,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Failed to parse/);
+  });
+
+  it("rejects receipt where description is not a zap request (wrong kind)", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const badZapReq = makeReceipt() as any;
+    const wrongKindReq = { ...makeZapRequest(), kind: 1 };
+    for (let i = 0; i < badZapReq.tags.length; i++) {
+      const tag = badZapReq.tags[i];
+      if (tag && tag[0] === "description") {
+        badZapReq.tags[i] = ["description", JSON.stringify(wrongKindReq)];
+      }
+    }
+
+    const result = validateSingleReceipt(
+      badZapReq,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/expected 9734/);
+  });
+
+  it("rejects receipt where zap request has wrong 'p' tag", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const badPTag = makeReceipt() as any;
+    const wrongPReq = makeZapRequest({ tags: [["p", "wrong-pubkey"]] });
+    for (let i = 0; i < badPTag.tags.length; i++) {
+      const tag = badPTag.tags[i];
+      if (tag && tag[0] === "description") {
+        badPTag.tags[i] = ["description", JSON.stringify(wrongPReq)];
+      }
+    }
+
+    const result = validateSingleReceipt(
+      badPTag,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/does not match seller/);
+  });
+
+  it("rejects receipt where zap request has missing 'e' tag", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const badETag = makeReceipt() as any;
+    const noETagReq = makeZapRequest({ tags: [["p", SELLER_PUBKEY]] });
+    for (let i = 0; i < badETag.tags.length; i++) {
+      const tag = badETag.tags[i];
+      if (tag && tag[0] === "description") {
+        badETag.tags[i] = ["description", JSON.stringify(noETagReq)];
+      }
+    }
+
+    const result = validateSingleReceipt(
+      badETag,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/missing or does not match product/);
+  });
+
+  it("rejects receipt where zap request has wrong 'e' tag", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const badETag = makeReceipt() as any;
+    const wrongETagReq = makeZapRequest({
+      tags: [
+        ["p", SELLER_PUBKEY],
+        ["e", "wrong-product"],
+      ],
+    });
+    for (let i = 0; i < badETag.tags.length; i++) {
+      const tag = badETag.tags[i];
+      if (tag && tag[0] === "description") {
+        badETag.tags[i] = ["description", JSON.stringify(wrongETagReq)];
+      }
+    }
+
+    const result = validateSingleReceipt(
+      badETag,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/missing or does not match product/);
+  });
+
+  it("rejects receipt where zap request amount differs beyond tolerance", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const badAmount = makeReceipt() as any;
+    const amountDiffReq = makeZapRequest({
+      tags: [
+        ["p", SELLER_PUBKEY],
+        ["e", PRODUCT_ID],
+        ["amount", String(AMOUNT_MSAT + 2000)],
+      ],
+    });
+    for (let i = 0; i < badAmount.tags.length; i++) {
+      const tag = badAmount.tags[i];
+      if (tag && tag[0] === "description") {
+        badAmount.tags[i] = ["description", JSON.stringify(amountDiffReq)];
+      }
+    }
+
+    const result = validateSingleReceipt(
+      badAmount,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/does not match receipt amount/);
+  });
+
+  it("accepts receipt where zap request amount is within 1 sat tolerance", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const closeAmount = makeReceipt() as any;
+    const closeReq = makeZapRequest({
+      tags: [
+        ["p", SELLER_PUBKEY],
+        ["e", PRODUCT_ID],
+        ["amount", String(AMOUNT_MSAT + 500)],
+      ],
+    });
+    for (let i = 0; i < closeAmount.tags.length; i++) {
+      const tag = closeAmount.tags[i];
+      if (tag && tag[0] === "description") {
+        closeAmount.tags[i] = ["description", JSON.stringify(closeReq)];
+      }
+    }
+
+    const result = validateSingleReceipt(
+      closeAmount,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects receipt with timestamp outside the window", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt({ created_at: MIN_TIMESTAMP - 121 }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/outside acceptable window/);
+  });
+
+  it("skips freshness check when skipFreshnessCheck is true", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt({ created_at: 0 }) as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP,
+      { skipFreshnessCheck: true }
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects receipt when expectedPreimage is set but receipt has no preimage tag", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const noPreimage = makeReceipt() as any;
+    noPreimage.tags = noPreimage.tags.filter((t: string[]) => t[0] !== "preimage");
+
+    const result = validateSingleReceipt(
+      noPreimage,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP,
+      { expectedPreimage: "should-be-present" }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Missing 'preimage' tag/);
+  });
+
+  it("rejects receipt when expectedPreimage does not match", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt() as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP,
+      { expectedPreimage: "wrong-preimage" }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Preimage mismatch/);
+  });
+
+  it("accepts receipt when expectedPreimage matches", () => {
+    mockVerifyEvent.mockReturnValue(true);
+
+    const result = validateSingleReceipt(
+      makeReceipt() as any,
+      PRODUCT_ID,
+      SELLER_PUBKEY,
+      AMOUNT_SATS,
+      MIN_TIMESTAMP,
+      { expectedPreimage: "test-preimage" }
+    );
+
+    expect(result.valid).toBe(true);
+  });
+});
 
 describe("validateZapReceipt", () => {
+  const mockFetch = jest.fn();
+  const mockNostrManager = {
+    fetch: mockFetch,
+  } as unknown as NostrManager;
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
@@ -16,58 +597,86 @@ describe("validateZapReceipt", () => {
     jest.useRealTimers();
   });
 
-  it("returns true immediately if receipt is found on first try", async () => {
-    mockFetch.mockResolvedValue([{ id: "zap-receipt" }]);
+  it("returns valid result when receipt passes crypto checks", async () => {
+    mockVerifyEvent.mockReturnValue(true);
+    mockFetch.mockResolvedValue([makeReceipt()]);
 
-    const promise = validateZapReceipt(mockNostrManager, "item-123", 1000);
+    const result = await validateZapReceipt(
+      mockNostrManager,
+      PRODUCT_ID,
+      MIN_TIMESTAMP,
+      SELLER_PUBKEY,
+      AMOUNT_SATS
+    );
 
-    const result = await promise;
-
-    expect(result).toBe(true);
+    expect(result.valid).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("retries and returns true if receipt is found on the 3rd try", async () => {
+  it("retries when fetched receipts fail crypto validation", async () => {
+    mockVerifyEvent.mockReturnValue(true);
+    const badAmount = makeReceipt({
+      tags: withReplacedTag(defaultTags(), "amount", ["amount", "5000"]),
+    });
     mockFetch
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ id: "zap-receipt" }]);
+      .mockResolvedValueOnce([badAmount])
+      .mockResolvedValueOnce([badAmount])
+      .mockResolvedValueOnce([makeReceipt()]);
 
-    const promise = validateZapReceipt(mockNostrManager, "item-123", 1000);
+    const promise = validateZapReceipt(
+      mockNostrManager,
+      PRODUCT_ID,
+      MIN_TIMESTAMP,
+      SELLER_PUBKEY,
+      AMOUNT_SATS
+    );
 
     await jest.advanceTimersByTimeAsync(3000);
 
     const result = await promise;
 
-    expect(result).toBe(true);
+    expect(result.valid).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
-  it("returns false after max retries (5) if no receipt is found", async () => {
+  it("returns invalid after all retries if no receipt validates", async () => {
+    mockVerifyEvent.mockReturnValue(true);
     mockFetch.mockResolvedValue([]);
 
-    const promise = validateZapReceipt(mockNostrManager, "item-123", 1000);
+    const promise = validateZapReceipt(
+      mockNostrManager,
+      PRODUCT_ID,
+      MIN_TIMESTAMP,
+      SELLER_PUBKEY,
+      AMOUNT_SATS
+    );
 
-    await jest.advanceTimersByTimeAsync(6000);
+    await jest.advanceTimersByTimeAsync(5000);
 
     const result = await promise;
 
-    expect(result).toBe(false);
+    expect(result.valid).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(result.errors).toContain("No valid zap receipt found after all retries");
   });
 
-  it("uses the correct filter parameters", async () => {
-    mockFetch.mockResolvedValue([{ id: "zap" }]);
-    const minTimestamp = 162000;
-    const productId = "item-xyz";
+  it("passes the correct filter to nostr.fetch", async () => {
+    mockVerifyEvent.mockReturnValue(true);
+    mockFetch.mockResolvedValue([makeReceipt()]);
 
-    await validateZapReceipt(mockNostrManager, productId, minTimestamp);
+    await validateZapReceipt(
+      mockNostrManager,
+      PRODUCT_ID,
+      MIN_TIMESTAMP,
+      SELLER_PUBKEY,
+      AMOUNT_SATS
+    );
 
     expect(mockFetch).toHaveBeenCalledWith([
       expect.objectContaining({
         kinds: [9735],
-        "#e": [productId],
-        since: minTimestamp,
+        "#e": [PRODUCT_ID],
+        since: MIN_TIMESTAMP,
       }),
     ]);
   });

--- a/utils/nostr/__tests__/zap-validator.test.ts
+++ b/utils/nostr/__tests__/zap-validator.test.ts
@@ -1,7 +1,13 @@
-import { validateZapReceipt, validateSingleReceipt } from "@/utils/nostr/zap-validator";
+import {
+  validateZapReceipt,
+  validateSingleReceipt,
+} from "@/utils/nostr/zap-validator";
 import { NostrManager } from "@/utils/nostr/nostr-manager";
 
 const mockVerifyEvent = jest.fn();
+const mockDecodeInvoice = jest.fn();
+const mockValidatePreimage = jest.fn();
+
 jest.mock("nostr-tools", () => {
   const actual = jest.requireActual("nostr-tools");
   return {
@@ -10,38 +16,85 @@ jest.mock("nostr-tools", () => {
   };
 });
 
-const SELLER_PUBKEY = "seller-pubkey-hex";
+jest.mock("@getalby/lightning-tools/bolt11", () => ({
+  decodeInvoice: (...args: unknown[]) => mockDecodeInvoice(...args),
+  validatePreimage: (...args: unknown[]) => mockValidatePreimage(...args),
+}));
+
 const BUYER_PUBKEY = "buyer-pubkey-hex";
+const LNURL_NOSTR_PUBKEY = "lnurl-provider-pubkey-hex";
+const OTHER_PUBKEY = "other-pubkey-hex";
 const PRODUCT_ID = "product-event-id";
 const AMOUNT_SATS = 100;
 const AMOUNT_MSAT = 100000;
 const MIN_TIMESTAMP = 2000;
+const BOLT11 = "lnbc-valid-invoice";
+const PAYMENT_HASH = "a".repeat(64);
+const EXPECTED_PREIMAGE = "b".repeat(64);
+const EXPECTED_LNURL = "lnurl1recipient";
 
-function defaultTags(): string[][] {
+function makeDecodedInvoice(
+  overrides?: Partial<{
+    paymentHash: string;
+    satoshi: number;
+    millisatoshi: number;
+    amountRaw: string;
+    timestamp: number;
+    expiry: number;
+    description: string;
+  }>
+): Record<string, unknown> {
+  return {
+    paymentHash: PAYMENT_HASH,
+    satoshi: AMOUNT_SATS,
+    millisatoshi: AMOUNT_MSAT,
+    amountRaw: String(AMOUNT_MSAT),
+    timestamp: MIN_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+function makeZapRequest(
+  overrides?: Partial<{
+    pubkey: string;
+    created_at: number;
+    kind: number;
+    tags: string[][];
+    content: string;
+    id: string;
+    sig: string;
+  }>
+): Record<string, unknown> {
+  return {
+    id: "zap-req-id",
+    pubkey: BUYER_PUBKEY,
+    created_at: MIN_TIMESTAMP,
+    kind: 9734,
+    tags: [
+      ["p", LNURL_NOSTR_PUBKEY],
+      ["e", PRODUCT_ID],
+      ["amount", String(AMOUNT_MSAT)],
+      ["lnurl", EXPECTED_LNURL],
+      ["relays", "wss://relay.damus.io"],
+    ],
+    content: "Order #order-123",
+    sig: "zap-req-sig",
+    ...overrides,
+  };
+}
+
+function defaultTags(zapRequest = makeZapRequest()): string[][] {
   return [
-    ["p", SELLER_PUBKEY],
+    ["p", LNURL_NOSTR_PUBKEY],
     ["e", PRODUCT_ID],
     ["amount", String(AMOUNT_MSAT)],
-    ["bolt11", "lnbc..."],
-    ["description", JSON.stringify({
-      id: "zap-req-id",
-      pubkey: BUYER_PUBKEY,
-      created_at: MIN_TIMESTAMP,
-      kind: 9734,
-      tags: [
-        ["p", SELLER_PUBKEY],
-        ["e", PRODUCT_ID],
-        ["amount", String(AMOUNT_MSAT)],
-        ["relays", "wss://relay.damus.io"],
-      ],
-      content: "Order #order-123",
-      sig: "zap-req-sig",
-    })],
-    ["preimage", "test-preimage"],
+    ["bolt11", BOLT11],
+    ["description", JSON.stringify(zapRequest)],
+    ["preimage", EXPECTED_PREIMAGE],
   ];
 }
 
-function withReplacedTag(
+function replaceTag(
   tags: string[][],
   tagName: string,
   newValues: string[]
@@ -49,18 +102,24 @@ function withReplacedTag(
   return tags.map((t) => (t[0] === tagName ? newValues : t));
 }
 
-function makeReceipt(overrides?: Partial<{
-  kind: number;
-  tags: string[][];
-  content: string;
-  pubkey: string;
-  created_at: number;
-  id: string;
-  sig: string;
-}>): Record<string, unknown> {
+function withoutTag(tags: string[][], tagName: string): string[][] {
+  return tags.filter((t) => t[0] !== tagName);
+}
+
+function makeReceipt(
+  overrides?: Partial<{
+    kind: number;
+    tags: string[][];
+    content: string;
+    pubkey: string;
+    created_at: number;
+    id: string;
+    sig: string;
+  }>
+): Record<string, unknown> {
   return {
     id: "receipt-id",
-    pubkey: SELLER_PUBKEY,
+    pubkey: LNURL_NOSTR_PUBKEY,
     created_at: MIN_TIMESTAMP + 10,
     kind: 9735,
     tags: defaultTags(),
@@ -70,46 +129,52 @@ function makeReceipt(overrides?: Partial<{
   };
 }
 
-function makeZapRequest(overrides?: Partial<{
-  pubkey: string;
-  created_at: number;
-  kind: number;
-  tags: string[][];
-  content: string;
-  id: string;
-  sig: string;
-}>): Record<string, unknown> {
+function validationOptions(
+  overrides?: Partial<{
+    productId: string;
+    expectedRecipientPubkey: string;
+    expectedReceiptSignerPubkey: string;
+    expectedAmountSats: number;
+    minTimestamp: number;
+    skipFreshnessCheck: boolean;
+    expectedPreimage: string;
+    expectedLnurl: string;
+  }>
+): Record<string, unknown> {
   return {
-    id: "zap-req-id",
-    pubkey: BUYER_PUBKEY,
-    created_at: MIN_TIMESTAMP,
-    kind: 9734,
-    tags: [
-      ["p", SELLER_PUBKEY],
-      ["e", PRODUCT_ID],
-      ["amount", String(AMOUNT_MSAT)],
-      ["relays", "wss://relay.damus.io"],
-    ],
-    content: "Order #order-123",
-    sig: "zap-req-sig",
+    productId: PRODUCT_ID,
+    expectedRecipientPubkey: LNURL_NOSTR_PUBKEY,
+    expectedReceiptSignerPubkey: LNURL_NOSTR_PUBKEY,
+    expectedAmountSats: AMOUNT_SATS,
+    minTimestamp: MIN_TIMESTAMP,
+    expectedLnurl: EXPECTED_LNURL,
     ...overrides,
   };
+}
+
+function receiptWithZapRequest(
+  zapRequest: Record<string, unknown>
+): Record<string, unknown> {
+  return makeReceipt({
+    tags: replaceTag(defaultTags(), "description", [
+      "description",
+      JSON.stringify(zapRequest),
+    ]),
+  });
 }
 
 describe("validateSingleReceipt", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockVerifyEvent.mockReturnValue(true);
+    mockDecodeInvoice.mockReturnValue(makeDecodedInvoice());
+    mockValidatePreimage.mockReturnValue(true);
   });
 
-  it("accepts a fully valid receipt", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
+  it("accepts a fully valid NIP-57 receipt signed by the LNURL provider", () => {
     const result = validateSingleReceipt(
       makeReceipt() as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(true);
@@ -117,6 +182,7 @@ describe("validateSingleReceipt", () => {
     expect(result.payerPubkey).toBe(BUYER_PUBKEY);
     expect(result.receiptId).toBe("receipt-id");
     expect(result.errors).toHaveLength(0);
+    expect(mockDecodeInvoice).toHaveBeenCalledWith(BOLT11);
   });
 
   it("rejects receipt with invalid signature", () => {
@@ -124,14 +190,21 @@ describe("validateSingleReceipt", () => {
 
     const result = validateSingleReceipt(
       makeReceipt() as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Invalid signature on zap receipt");
+  });
+
+  it("rejects receipt signed by a pubkey other than the LNURL provider nostrPubkey", () => {
+    const result = validateSingleReceipt(
+      makeReceipt({ pubkey: OTHER_PUBKEY }) as any,
+      validationOptions() as any
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Receipt signer does not match/);
   });
 
   it("verifies both receipt and zap request signatures", () => {
@@ -143,175 +216,127 @@ describe("validateSingleReceipt", () => {
 
     const result = validateSingleReceipt(
       makeReceipt() as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
-    expect(result.errors).toContain("Invalid signature on embedded zap request");
+    expect(result.errors).toContain(
+      "Invalid signature on embedded zap request"
+    );
     expect(callCount).toBe(2);
   });
 
   it("rejects receipt with wrong kind", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
     const result = validateSingleReceipt(
       makeReceipt({ kind: 1 }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toMatch(/Expected kind 9735/);
   });
 
-  it("rejects receipt with wrong seller pubkey", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
+  it("rejects receipt with wrong recipient p tag", () => {
     const result = validateSingleReceipt(
       makeReceipt({
-        tags: withReplacedTag(defaultTags(), "p", ["p", "wrong-pubkey"]),
+        tags: replaceTag(defaultTags(), "p", ["p", OTHER_PUBKEY]),
       }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/does not match seller/);
+    expect(result.errors[0]).toMatch(/does not match LNURL recipient/);
   });
 
   it("rejects receipt with wrong product id", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
     const result = validateSingleReceipt(
       makeReceipt() as any,
-      "different-product",
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      validationOptions({ productId: "different-product" }) as any
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toMatch(/does not match product/);
   });
 
-  it("rejects receipt without amount tag", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const withoutAmount = makeReceipt() as any;
-    withoutAmount.tags = withoutAmount.tags.filter((t: string[]) => t[0] !== "amount");
-
+  it("rejects receipt without bolt11 tag", () => {
     const result = validateSingleReceipt(
-      withoutAmount,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      makeReceipt({ tags: withoutTag(defaultTags(), "bolt11") }) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/Missing or invalid 'amount' tag/);
+    expect(result.errors[0]).toMatch(/Missing 'bolt11' tag/);
   });
 
-  it("rejects receipt with non-numeric amount (e.g. scientific notation)", () => {
-    mockVerifyEvent.mockReturnValue(true);
+  it("rejects receipt when bolt11 cannot be decoded", () => {
+    mockDecodeInvoice.mockReturnValue(null);
 
     const result = validateSingleReceipt(
-      makeReceipt({
-        tags: withReplacedTag(defaultTags(), "amount", ["amount", "1e5"]),
-      }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      makeReceipt() as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/Missing or invalid 'amount' tag/);
+    expect(result.errors[0]).toMatch(/Invalid 'bolt11' invoice/);
   });
 
-  it("rejects receipt with zero amount", () => {
-    mockVerifyEvent.mockReturnValue(true);
+  it("rejects receipt when invoice amount differs from expected product price", () => {
+    mockDecodeInvoice.mockReturnValue(
+      makeDecodedInvoice({
+        satoshi: 99,
+        millisatoshi: 99000,
+        amountRaw: "99000",
+      })
+    );
 
     const result = validateSingleReceipt(
-      makeReceipt({
-        tags: withReplacedTag(defaultTags(), "amount", ["amount", "0"]),
-      }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      makeReceipt() as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/Invalid amount/);
+    expect(result.errors[0]).toMatch(
+      /Invoice amount 99 sats does not match expected 100 sats/
+    );
   });
 
-  it("rejects receipt with amount mismatch", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
+  it("accepts receipt without relay amount tag because bolt11 is canonical", () => {
     const result = validateSingleReceipt(
-      makeReceipt({
-        tags: withReplacedTag(defaultTags(), "amount", ["amount", "50000"]),
-      }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
-    );
-
-    expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/does not match expected/);
-  });
-
-  it("accepts amount within rounding tolerance (1 sat difference)", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const oneSatOff = (AMOUNT_SATS - 1) * 1000;
-    const tags = defaultTags();
-    const descStr = tags.find((t) => t[0] === "description")?.[1];
-    const desc = JSON.parse(descStr ?? "{}");
-    desc.tags = (desc.tags as string[][]).map((t) =>
-      t[0] === "amount" ? ["amount", String(oneSatOff)] : t
-    );
-    const updatedTags = tags.map((t) =>
-      t[0] === "amount"
-        ? ["amount", String(oneSatOff)]
-        : t[0] === "description"
-          ? ["description", JSON.stringify(desc)]
-          : t
-    );
-
-    const result = validateSingleReceipt(
-      makeReceipt({ tags: updatedTags }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      makeReceipt({ tags: withoutTag(defaultTags(), "amount") }) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(true);
-    expect(result.amountSats).toBe(AMOUNT_SATS - 1);
+  });
+
+  it("rejects receipt with malformed relay amount tag", () => {
+    const result = validateSingleReceipt(
+      makeReceipt({
+        tags: replaceTag(defaultTags(), "amount", ["amount", "1e5"]),
+      }) as any,
+      validationOptions() as any
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Invalid 'amount' tag in zap receipt/);
+  });
+
+  it("rejects receipt when optional relay amount differs from bolt11 amount", () => {
+    const result = validateSingleReceipt(
+      makeReceipt({
+        tags: replaceTag(defaultTags(), "amount", ["amount", "50000"]),
+      }) as any,
+      validationOptions() as any
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/does not match invoice amount/);
   });
 
   it("rejects receipt without description tag", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const withoutDesc = makeReceipt() as any;
-    withoutDesc.tags = withoutDesc.tags.filter((t: string[]) => t[0] !== "description");
-
     const result = validateSingleReceipt(
-      withoutDesc,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      makeReceipt({ tags: withoutTag(defaultTags(), "description") }) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
@@ -319,197 +344,159 @@ describe("validateSingleReceipt", () => {
   });
 
   it("rejects receipt with non-JSON description", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const badDesc = makeReceipt() as any;
-    for (let i = 0; i < badDesc.tags.length; i++) {
-      const tag = badDesc.tags[i];
-      if (tag && tag[0] === "description") {
-        badDesc.tags[i] = ["description", "not-json"];
-      }
-    }
-
     const result = validateSingleReceipt(
-      badDesc,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      makeReceipt({
+        tags: replaceTag(defaultTags(), "description", [
+          "description",
+          "not-json",
+        ]),
+      }) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toMatch(/Failed to parse/);
   });
 
-  it("rejects receipt where description is not a zap request (wrong kind)", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const badZapReq = makeReceipt() as any;
-    const wrongKindReq = { ...makeZapRequest(), kind: 1 };
-    for (let i = 0; i < badZapReq.tags.length; i++) {
-      const tag = badZapReq.tags[i];
-      if (tag && tag[0] === "description") {
-        badZapReq.tags[i] = ["description", JSON.stringify(wrongKindReq)];
-      }
-    }
-
+  it("rejects receipt where description is not a zap request", () => {
     const result = validateSingleReceipt(
-      badZapReq,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      receiptWithZapRequest({ ...makeZapRequest(), kind: 1 }) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toMatch(/expected 9734/);
   });
 
-  it("rejects receipt where zap request has wrong 'p' tag", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const badPTag = makeReceipt() as any;
-    const wrongPReq = makeZapRequest({ tags: [["p", "wrong-pubkey"]] });
-    for (let i = 0; i < badPTag.tags.length; i++) {
-      const tag = badPTag.tags[i];
-      if (tag && tag[0] === "description") {
-        badPTag.tags[i] = ["description", JSON.stringify(wrongPReq)];
-      }
-    }
-
+  it("rejects receipt where zap request has wrong p tag", () => {
     const result = validateSingleReceipt(
-      badPTag,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      receiptWithZapRequest(
+        makeZapRequest({
+          tags: [
+            ["p", OTHER_PUBKEY],
+            ["e", PRODUCT_ID],
+            ["amount", String(AMOUNT_MSAT)],
+          ],
+        })
+      ) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/does not match seller/);
+    expect(result.errors[0]).toMatch(/does not match LNURL recipient/);
   });
 
-  it("rejects receipt where zap request has missing 'e' tag", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const badETag = makeReceipt() as any;
-    const noETagReq = makeZapRequest({ tags: [["p", SELLER_PUBKEY]] });
-    for (let i = 0; i < badETag.tags.length; i++) {
-      const tag = badETag.tags[i];
-      if (tag && tag[0] === "description") {
-        badETag.tags[i] = ["description", JSON.stringify(noETagReq)];
-      }
-    }
-
+  it("rejects receipt where zap request has missing e tag", () => {
     const result = validateSingleReceipt(
-      badETag,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      receiptWithZapRequest(
+        makeZapRequest({
+          tags: [
+            ["p", LNURL_NOSTR_PUBKEY],
+            ["amount", String(AMOUNT_MSAT)],
+          ],
+        })
+      ) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toMatch(/missing or does not match product/);
   });
 
-  it("rejects receipt where zap request has wrong 'e' tag", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const badETag = makeReceipt() as any;
-    const wrongETagReq = makeZapRequest({
-      tags: [
-        ["p", SELLER_PUBKEY],
-        ["e", "wrong-product"],
-      ],
-    });
-    for (let i = 0; i < badETag.tags.length; i++) {
-      const tag = badETag.tags[i];
-      if (tag && tag[0] === "description") {
-        badETag.tags[i] = ["description", JSON.stringify(wrongETagReq)];
-      }
-    }
-
+  it("rejects receipt where zap request amount is malformed", () => {
     const result = validateSingleReceipt(
-      badETag,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      receiptWithZapRequest(
+        makeZapRequest({
+          tags: [
+            ["p", LNURL_NOSTR_PUBKEY],
+            ["e", PRODUCT_ID],
+            ["amount", "1e5"],
+          ],
+        })
+      ) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/missing or does not match product/);
+    expect(result.errors[0]).toMatch(/Invalid 'amount' tag in zap request/);
   });
 
-  it("rejects receipt where zap request amount differs beyond tolerance", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const badAmount = makeReceipt() as any;
-    const amountDiffReq = makeZapRequest({
-      tags: [
-        ["p", SELLER_PUBKEY],
-        ["e", PRODUCT_ID],
-        ["amount", String(AMOUNT_MSAT + 2000)],
-      ],
-    });
-    for (let i = 0; i < badAmount.tags.length; i++) {
-      const tag = badAmount.tags[i];
-      if (tag && tag[0] === "description") {
-        badAmount.tags[i] = ["description", JSON.stringify(amountDiffReq)];
-      }
-    }
-
+  it("accepts receipt when zap request amount is absent because bolt11 is canonical", () => {
     const result = validateSingleReceipt(
-      badAmount,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
-    );
-
-    expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/does not match receipt amount/);
-  });
-
-  it("accepts receipt where zap request amount is within 1 sat tolerance", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const closeAmount = makeReceipt() as any;
-    const closeReq = makeZapRequest({
-      tags: [
-        ["p", SELLER_PUBKEY],
-        ["e", PRODUCT_ID],
-        ["amount", String(AMOUNT_MSAT + 500)],
-      ],
-    });
-    for (let i = 0; i < closeAmount.tags.length; i++) {
-      const tag = closeAmount.tags[i];
-      if (tag && tag[0] === "description") {
-        closeAmount.tags[i] = ["description", JSON.stringify(closeReq)];
-      }
-    }
-
-    const result = validateSingleReceipt(
-      closeAmount,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      receiptWithZapRequest(
+        makeZapRequest({
+          tags: [
+            ["p", LNURL_NOSTR_PUBKEY],
+            ["e", PRODUCT_ID],
+          ],
+        })
+      ) as any,
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(true);
   });
 
-  it("rejects receipt with timestamp outside the window", () => {
-    mockVerifyEvent.mockReturnValue(true);
+  it("rejects receipt where zap request amount differs from invoice amount", () => {
+    const result = validateSingleReceipt(
+      receiptWithZapRequest(
+        makeZapRequest({
+          tags: [
+            ["p", LNURL_NOSTR_PUBKEY],
+            ["e", PRODUCT_ID],
+            ["amount", String(AMOUNT_MSAT + 1000)],
+          ],
+        })
+      ) as any,
+      validationOptions() as any
+    );
 
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(
+      /Zap request amount does not match invoice amount/
+    );
+  });
+
+  it("rejects receipt where zap request lnurl conflicts with the expected LNURL", () => {
+    const result = validateSingleReceipt(
+      receiptWithZapRequest(
+        makeZapRequest({
+          tags: [
+            ["p", LNURL_NOSTR_PUBKEY],
+            ["e", PRODUCT_ID],
+            ["amount", String(AMOUNT_MSAT)],
+            ["lnurl", "lnurl1attacker"],
+          ],
+        })
+      ) as any,
+      validationOptions() as any
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/does not match expected LNURL/);
+  });
+
+  it("accepts receipt when optional lnurl tag is absent", () => {
+    const result = validateSingleReceipt(
+      receiptWithZapRequest(
+        makeZapRequest({
+          tags: [
+            ["p", LNURL_NOSTR_PUBKEY],
+            ["e", PRODUCT_ID],
+            ["amount", String(AMOUNT_MSAT)],
+          ],
+        })
+      ) as any,
+      validationOptions() as any
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects receipt with timestamp outside the freshness window", () => {
     const result = validateSingleReceipt(
       makeReceipt({ created_at: MIN_TIMESTAMP - 121 }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(false);
@@ -517,68 +504,58 @@ describe("validateSingleReceipt", () => {
   });
 
   it("skips freshness check when skipFreshnessCheck is true", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
     const result = validateSingleReceipt(
       makeReceipt({ created_at: 0 }) as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP,
-      { skipFreshnessCheck: true }
+      validationOptions({ skipFreshnessCheck: true }) as any
     );
 
     expect(result.valid).toBe(true);
   });
 
-  it("rejects receipt when expectedPreimage is set but receipt has no preimage tag", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const noPreimage = makeReceipt() as any;
-    noPreimage.tags = noPreimage.tags.filter((t: string[]) => t[0] !== "preimage");
-
-    const result = validateSingleReceipt(
-      noPreimage,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP,
-      { expectedPreimage: "should-be-present" }
-    );
-
-    expect(result.valid).toBe(false);
-    expect(result.errors[0]).toMatch(/Missing 'preimage' tag/);
-  });
-
-  it("rejects receipt when expectedPreimage does not match", () => {
-    mockVerifyEvent.mockReturnValue(true);
+  it("rejects receipt when expectedPreimage does not match invoice payment hash", () => {
+    mockValidatePreimage.mockReturnValue(false);
 
     const result = validateSingleReceipt(
       makeReceipt() as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP,
-      { expectedPreimage: "wrong-preimage" }
+      validationOptions({ expectedPreimage: EXPECTED_PREIMAGE }) as any
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(
+      /Preimage does not match invoice payment hash/
+    );
+    expect(mockValidatePreimage).toHaveBeenCalledWith(
+      EXPECTED_PREIMAGE,
+      PAYMENT_HASH
+    );
+  });
+
+  it("accepts receipt when expectedPreimage matches invoice payment hash and receipt omits preimage tag", () => {
+    const result = validateSingleReceipt(
+      makeReceipt({ tags: withoutTag(defaultTags(), "preimage") }) as any,
+      validationOptions({ expectedPreimage: EXPECTED_PREIMAGE }) as any
+    );
+
+    expect(result.valid).toBe(true);
+    expect(mockValidatePreimage).toHaveBeenCalledWith(
+      EXPECTED_PREIMAGE,
+      PAYMENT_HASH
+    );
+  });
+
+  it("rejects receipt when included preimage tag conflicts with expected preimage", () => {
+    const result = validateSingleReceipt(
+      makeReceipt({
+        tags: replaceTag(defaultTags(), "preimage", [
+          "preimage",
+          "wrong-preimage",
+        ]),
+      }) as any,
+      validationOptions({ expectedPreimage: EXPECTED_PREIMAGE }) as any
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toMatch(/Preimage mismatch/);
-  });
-
-  it("accepts receipt when expectedPreimage matches", () => {
-    mockVerifyEvent.mockReturnValue(true);
-
-    const result = validateSingleReceipt(
-      makeReceipt() as any,
-      PRODUCT_ID,
-      SELLER_PUBKEY,
-      AMOUNT_SATS,
-      MIN_TIMESTAMP,
-      { expectedPreimage: "test-preimage" }
-    );
-
-    expect(result.valid).toBe(true);
   });
 });
 
@@ -591,32 +568,30 @@ describe("validateZapReceipt", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockVerifyEvent.mockReturnValue(true);
+    mockDecodeInvoice.mockReturnValue(makeDecodedInvoice());
+    mockValidatePreimage.mockReturnValue(true);
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it("returns valid result when receipt passes crypto checks", async () => {
-    mockVerifyEvent.mockReturnValue(true);
+  it("returns valid result when receipt passes NIP-57 checks", async () => {
     mockFetch.mockResolvedValue([makeReceipt()]);
 
     const result = await validateZapReceipt(
       mockNostrManager,
-      PRODUCT_ID,
-      MIN_TIMESTAMP,
-      SELLER_PUBKEY,
-      AMOUNT_SATS
+      validationOptions() as any
     );
 
     expect(result.valid).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("retries when fetched receipts fail crypto validation", async () => {
-    mockVerifyEvent.mockReturnValue(true);
+  it("retries when fetched receipts fail validation", async () => {
     const badAmount = makeReceipt({
-      tags: withReplacedTag(defaultTags(), "amount", ["amount", "5000"]),
+      tags: replaceTag(defaultTags(), "amount", ["amount", "5000"]),
     });
     mockFetch
       .mockResolvedValueOnce([badAmount])
@@ -625,10 +600,7 @@ describe("validateZapReceipt", () => {
 
     const promise = validateZapReceipt(
       mockNostrManager,
-      PRODUCT_ID,
-      MIN_TIMESTAMP,
-      SELLER_PUBKEY,
-      AMOUNT_SATS
+      validationOptions() as any
     );
 
     await jest.advanceTimersByTimeAsync(3000);
@@ -640,15 +612,11 @@ describe("validateZapReceipt", () => {
   });
 
   it("returns invalid after all retries if no receipt validates", async () => {
-    mockVerifyEvent.mockReturnValue(true);
     mockFetch.mockResolvedValue([]);
 
     const promise = validateZapReceipt(
       mockNostrManager,
-      PRODUCT_ID,
-      MIN_TIMESTAMP,
-      SELLER_PUBKEY,
-      AMOUNT_SATS
+      validationOptions() as any
     );
 
     await jest.advanceTimersByTimeAsync(5000);
@@ -657,26 +625,21 @@ describe("validateZapReceipt", () => {
 
     expect(result.valid).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(5);
-    expect(result.errors).toContain("No valid zap receipt found after all retries");
+    expect(result.errors).toContain(
+      "No valid zap receipt found after all retries"
+    );
   });
 
   it("passes the correct filter to nostr.fetch", async () => {
-    mockVerifyEvent.mockReturnValue(true);
     mockFetch.mockResolvedValue([makeReceipt()]);
 
-    await validateZapReceipt(
-      mockNostrManager,
-      PRODUCT_ID,
-      MIN_TIMESTAMP,
-      SELLER_PUBKEY,
-      AMOUNT_SATS
-    );
+    await validateZapReceipt(mockNostrManager, validationOptions() as any);
 
     expect(mockFetch).toHaveBeenCalledWith([
       expect.objectContaining({
         kinds: [9735],
         "#e": [PRODUCT_ID],
-        since: MIN_TIMESTAMP,
+        since: MIN_TIMESTAMP - 120,
       }),
     ]);
   });

--- a/utils/nostr/zap-validator.ts
+++ b/utils/nostr/zap-validator.ts
@@ -1,10 +1,164 @@
-import { NostrManager } from "./nostr-manager";
+import { NostrManager, NostrEvent } from "./nostr-manager";
+import { verifyEvent } from "nostr-tools";
+
+export interface ZapReceiptValidationResult {
+  valid: boolean;
+  amountSats: number;
+  payerPubkey?: string;
+  receiptId?: string;
+  errors: string[];
+}
+
+interface ValidateOptions {
+  skipFreshnessCheck?: boolean;
+  expectedPreimage?: string;
+}
+
+function getTagValue(tags: string[][], tagName: string): string | undefined {
+  for (const tag of tags) {
+    if (tag[0] === tagName) {
+      return tag[1];
+    }
+  }
+  return undefined;
+}
+
+export function validateSingleReceipt(
+  receipt: NostrEvent,
+  productId: string,
+  sellerPubkey: string,
+  expectedAmountSats: number,
+  minTimestamp: number,
+  options?: ValidateOptions
+): ZapReceiptValidationResult {
+  const errors: string[] = [];
+  const skipFreshnessCheck = options?.skipFreshnessCheck ?? false;
+  const expectedPreimage = options?.expectedPreimage;
+
+  if (!verifyEvent(receipt)) {
+    errors.push("Invalid signature on zap receipt");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  if (receipt.kind !== 9735) {
+    errors.push(`Expected kind 9735, got ${receipt.kind}`);
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  const pTag = getTagValue(receipt.tags, "p");
+  if (pTag !== sellerPubkey) {
+    errors.push("Receipt 'p' tag does not match seller");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  const eTag = getTagValue(receipt.tags, "e");
+  if (eTag !== productId) {
+    errors.push("Receipt 'e' tag does not match product");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  const amountTag = getTagValue(receipt.tags, "amount");
+  if (amountTag === undefined || !/^\d+$/.test(amountTag)) {
+    errors.push("Missing or invalid 'amount' tag in zap receipt");
+    return { valid: false, amountSats: 0, errors };
+  }
+  const amountMsat = parseInt(amountTag, 10);
+  if (!Number.isSafeInteger(amountMsat) || amountMsat <= 0) {
+    errors.push("Invalid amount value in zap receipt");
+    return { valid: false, amountSats: 0, errors };
+  }
+  const amountSats = Math.round(amountMsat / 1000);
+  if (Math.abs(amountSats - expectedAmountSats) > 1) {
+    errors.push(
+      `Zap receipt amount ${amountSats} sats does not match expected ${expectedAmountSats} sats`
+    );
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  if (expectedPreimage !== undefined) {
+    const preimageTag = getTagValue(receipt.tags, "preimage");
+    if (preimageTag === undefined) {
+      errors.push("Missing 'preimage' tag in zap receipt (required for verification)");
+      return { valid: false, amountSats: 0, errors };
+    }
+    if (preimageTag !== expectedPreimage) {
+      errors.push("Preimage mismatch between receipt and payment");
+      return { valid: false, amountSats: 0, errors };
+    }
+  }
+
+  const descTag = getTagValue(receipt.tags, "description");
+  if (descTag === undefined) {
+    errors.push("Missing 'description' tag (zap request) in zap receipt");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  let zapRequest: NostrEvent;
+  try {
+    zapRequest = JSON.parse(descTag) as NostrEvent;
+  } catch {
+    errors.push("Failed to parse 'description' tag as event JSON");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  if (zapRequest.kind !== 9734) {
+    errors.push(`Embedded zap request has kind ${zapRequest.kind}, expected 9734`);
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  if (!verifyEvent(zapRequest)) {
+    errors.push("Invalid signature on embedded zap request");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  const reqPTag = getTagValue(zapRequest.tags, "p");
+  if (reqPTag !== sellerPubkey) {
+    errors.push("Zap request 'p' tag does not match seller");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  const reqETag = getTagValue(zapRequest.tags, "e");
+  if (reqETag !== productId) {
+    errors.push("Zap request 'e' tag missing or does not match product");
+    return { valid: false, amountSats: 0, errors };
+  }
+
+  const reqAmount = getTagValue(zapRequest.tags, "amount");
+  if (reqAmount !== undefined) {
+    const reqMsat = parseInt(reqAmount, 10);
+    if (Number.isSafeInteger(reqMsat) && Math.abs(reqMsat - amountMsat) > 1000) {
+      errors.push("Zap request amount does not match receipt amount");
+      return { valid: false, amountSats: 0, errors };
+    }
+  }
+
+  if (!skipFreshnessCheck) {
+    const WINDOW = 120;
+    const lowerBound = minTimestamp - WINDOW;
+    const upperBound = minTimestamp + WINDOW;
+    if (receipt.created_at < lowerBound || receipt.created_at > upperBound) {
+      errors.push("Receipt timestamp is outside acceptable window");
+      return { valid: false, amountSats: 0, errors };
+    }
+  }
+
+  return {
+    valid: true,
+    amountSats,
+    payerPubkey: zapRequest.pubkey,
+    receiptId: receipt.id,
+    errors: [],
+  };
+}
 
 export async function validateZapReceipt(
   nostr: NostrManager,
   productId: string,
-  minTimestamp: number
-): Promise<boolean> {
+  minTimestamp: number,
+  sellerPubkey: string,
+  expectedAmountSats: number,
+  expectedPreimage?: string
+): Promise<ZapReceiptValidationResult> {
   const filter = {
     kinds: [9735],
     "#e": [productId],
@@ -12,15 +166,31 @@ export async function validateZapReceipt(
   };
 
   const maxRetries = 5;
-  const delay = 1000;
+  const delayMs = 1000;
 
   for (let i = 0; i < maxRetries; i++) {
     const events = await nostr.fetch([filter]);
-    if (events.length > 0) {
-      return true;
+    for (const event of events) {
+      const result = validateSingleReceipt(
+        event,
+        productId,
+        sellerPubkey,
+        expectedAmountSats,
+        minTimestamp,
+        { expectedPreimage }
+      );
+      if (result.valid) {
+        return result;
+      }
     }
-    await new Promise((resolve) => setTimeout(resolve, delay));
+    if (i < maxRetries - 1) {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
   }
 
-  return false;
+  return {
+    valid: false,
+    amountSats: 0,
+    errors: ["No valid zap receipt found after all retries"],
+  };
 }

--- a/utils/nostr/zap-validator.ts
+++ b/utils/nostr/zap-validator.ts
@@ -1,5 +1,9 @@
 import { NostrManager, NostrEvent } from "./nostr-manager";
 import { verifyEvent } from "nostr-tools";
+import {
+  decodeInvoice,
+  validatePreimage,
+} from "@getalby/lightning-tools/bolt11";
 
 export interface ZapReceiptValidationResult {
   valid: boolean;
@@ -9,142 +13,264 @@ export interface ZapReceiptValidationResult {
   errors: string[];
 }
 
-interface ValidateOptions {
+export interface ZapReceiptValidationOptions {
+  productId: string;
+  expectedRecipientPubkey: string;
+  expectedReceiptSignerPubkey: string;
+  expectedAmountSats: number;
+  minTimestamp: number;
   skipFreshnessCheck?: boolean;
   expectedPreimage?: string;
+  expectedLnurl?: string;
 }
 
-function getTagValue(tags: string[][], tagName: string): string | undefined {
+const FRESHNESS_WINDOW_SECONDS = 120;
+
+function invalid(errors: string[]): ZapReceiptValidationResult {
+  return { valid: false, amountSats: 0, errors };
+}
+
+function getTagValue(tags: unknown, tagName: string): string | undefined {
+  if (!Array.isArray(tags)) {
+    return undefined;
+  }
+
   for (const tag of tags) {
-    if (tag[0] === tagName) {
+    if (
+      Array.isArray(tag) &&
+      tag[0] === tagName &&
+      typeof tag[1] === "string"
+    ) {
       return tag[1];
     }
   }
+
   return undefined;
+}
+
+function parsePositiveMillisats(
+  value: string | undefined,
+  label: string,
+  errors: string[]
+): number | undefined {
+  if (value === undefined || !/^\d+$/.test(value)) {
+    errors.push(`Invalid '${label}' tag in zap receipt`);
+    return undefined;
+  }
+
+  const millisats = Number(value);
+  if (!Number.isSafeInteger(millisats) || millisats <= 0) {
+    errors.push(`Invalid '${label}' value in zap receipt`);
+    return undefined;
+  }
+
+  return millisats;
+}
+
+function parsePositiveZapRequestMillisats(
+  value: string,
+  errors: string[]
+): number | undefined {
+  if (!/^\d+$/.test(value)) {
+    errors.push("Invalid 'amount' tag in zap request");
+    return undefined;
+  }
+
+  const millisats = Number(value);
+  if (!Number.isSafeInteger(millisats) || millisats <= 0) {
+    errors.push("Invalid 'amount' value in zap request");
+    return undefined;
+  }
+
+  return millisats;
+}
+
+function parseZapRequest(
+  description: string,
+  errors: string[]
+): NostrEvent | undefined {
+  try {
+    return JSON.parse(description) as NostrEvent;
+  } catch {
+    errors.push("Failed to parse 'description' tag as event JSON");
+    return undefined;
+  }
 }
 
 export function validateSingleReceipt(
   receipt: NostrEvent,
-  productId: string,
-  sellerPubkey: string,
-  expectedAmountSats: number,
-  minTimestamp: number,
-  options?: ValidateOptions
+  options: ZapReceiptValidationOptions
 ): ZapReceiptValidationResult {
   const errors: string[] = [];
-  const skipFreshnessCheck = options?.skipFreshnessCheck ?? false;
-  const expectedPreimage = options?.expectedPreimage;
+  const {
+    productId,
+    expectedRecipientPubkey,
+    expectedReceiptSignerPubkey,
+    expectedAmountSats,
+    minTimestamp,
+    skipFreshnessCheck = false,
+    expectedPreimage,
+    expectedLnurl,
+  } = options;
 
   if (!verifyEvent(receipt)) {
     errors.push("Invalid signature on zap receipt");
-    return { valid: false, amountSats: 0, errors };
+    return invalid(errors);
   }
 
   if (receipt.kind !== 9735) {
     errors.push(`Expected kind 9735, got ${receipt.kind}`);
-    return { valid: false, amountSats: 0, errors };
+    return invalid(errors);
+  }
+
+  if (receipt.pubkey !== expectedReceiptSignerPubkey) {
+    errors.push("Receipt signer does not match LNURL provider nostrPubkey");
+    return invalid(errors);
   }
 
   const pTag = getTagValue(receipt.tags, "p");
-  if (pTag !== sellerPubkey) {
-    errors.push("Receipt 'p' tag does not match seller");
-    return { valid: false, amountSats: 0, errors };
+  if (pTag !== expectedRecipientPubkey) {
+    errors.push("Receipt 'p' tag does not match LNURL recipient");
+    return invalid(errors);
   }
 
   const eTag = getTagValue(receipt.tags, "e");
   if (eTag !== productId) {
     errors.push("Receipt 'e' tag does not match product");
-    return { valid: false, amountSats: 0, errors };
+    return invalid(errors);
   }
 
-  const amountTag = getTagValue(receipt.tags, "amount");
-  if (amountTag === undefined || !/^\d+$/.test(amountTag)) {
-    errors.push("Missing or invalid 'amount' tag in zap receipt");
-    return { valid: false, amountSats: 0, errors };
+  const bolt11 = getTagValue(receipt.tags, "bolt11");
+  if (bolt11 === undefined) {
+    errors.push("Missing 'bolt11' tag in zap receipt");
+    return invalid(errors);
   }
-  const amountMsat = parseInt(amountTag, 10);
-  if (!Number.isSafeInteger(amountMsat) || amountMsat <= 0) {
-    errors.push("Invalid amount value in zap receipt");
-    return { valid: false, amountSats: 0, errors };
+
+  const decodedInvoice = decodeInvoice(bolt11);
+  if (
+    !decodedInvoice ||
+    !Number.isSafeInteger(decodedInvoice.millisatoshi) ||
+    decodedInvoice.millisatoshi <= 0 ||
+    typeof decodedInvoice.paymentHash !== "string" ||
+    decodedInvoice.paymentHash.length === 0
+  ) {
+    errors.push("Invalid 'bolt11' invoice in zap receipt");
+    return invalid(errors);
   }
-  const amountSats = Math.round(amountMsat / 1000);
-  if (Math.abs(amountSats - expectedAmountSats) > 1) {
+
+  const invoiceAmountMsat = decodedInvoice.millisatoshi;
+  const invoiceAmountSats = invoiceAmountMsat / 1000;
+  const expectedAmountMsat = expectedAmountSats * 1000;
+  if (!Number.isSafeInteger(expectedAmountMsat) || expectedAmountMsat <= 0) {
+    errors.push("Invalid expected zap amount");
+    return invalid(errors);
+  }
+
+  if (invoiceAmountMsat !== expectedAmountMsat) {
     errors.push(
-      `Zap receipt amount ${amountSats} sats does not match expected ${expectedAmountSats} sats`
+      `Invoice amount ${invoiceAmountSats} sats does not match expected ${expectedAmountSats} sats`
     );
-    return { valid: false, amountSats: 0, errors };
+    return invalid(errors);
+  }
+
+  const receiptAmountTag = getTagValue(receipt.tags, "amount");
+  if (receiptAmountTag !== undefined) {
+    const receiptAmountMsat = parsePositiveMillisats(
+      receiptAmountTag,
+      "amount",
+      errors
+    );
+    if (receiptAmountMsat === undefined) {
+      return invalid(errors);
+    }
+    if (receiptAmountMsat !== invoiceAmountMsat) {
+      errors.push("Zap receipt amount does not match invoice amount");
+      return invalid(errors);
+    }
   }
 
   if (expectedPreimage !== undefined) {
-    const preimageTag = getTagValue(receipt.tags, "preimage");
-    if (preimageTag === undefined) {
-      errors.push("Missing 'preimage' tag in zap receipt (required for verification)");
-      return { valid: false, amountSats: 0, errors };
+    if (!validatePreimage(expectedPreimage, decodedInvoice.paymentHash)) {
+      errors.push("Preimage does not match invoice payment hash");
+      return invalid(errors);
     }
-    if (preimageTag !== expectedPreimage) {
+
+    const receiptPreimage = getTagValue(receipt.tags, "preimage");
+    if (receiptPreimage !== undefined && receiptPreimage !== expectedPreimage) {
       errors.push("Preimage mismatch between receipt and payment");
-      return { valid: false, amountSats: 0, errors };
+      return invalid(errors);
     }
   }
 
   const descTag = getTagValue(receipt.tags, "description");
   if (descTag === undefined) {
     errors.push("Missing 'description' tag (zap request) in zap receipt");
-    return { valid: false, amountSats: 0, errors };
+    return invalid(errors);
   }
 
-  let zapRequest: NostrEvent;
-  try {
-    zapRequest = JSON.parse(descTag) as NostrEvent;
-  } catch {
-    errors.push("Failed to parse 'description' tag as event JSON");
-    return { valid: false, amountSats: 0, errors };
+  const zapRequest = parseZapRequest(descTag, errors);
+  if (zapRequest === undefined) {
+    return invalid(errors);
   }
 
   if (zapRequest.kind !== 9734) {
-    errors.push(`Embedded zap request has kind ${zapRequest.kind}, expected 9734`);
-    return { valid: false, amountSats: 0, errors };
+    errors.push(
+      `Embedded zap request has kind ${zapRequest.kind}, expected 9734`
+    );
+    return invalid(errors);
   }
 
   if (!verifyEvent(zapRequest)) {
     errors.push("Invalid signature on embedded zap request");
-    return { valid: false, amountSats: 0, errors };
+    return invalid(errors);
   }
 
   const reqPTag = getTagValue(zapRequest.tags, "p");
-  if (reqPTag !== sellerPubkey) {
-    errors.push("Zap request 'p' tag does not match seller");
-    return { valid: false, amountSats: 0, errors };
+  if (reqPTag !== expectedRecipientPubkey) {
+    errors.push("Zap request 'p' tag does not match LNURL recipient");
+    return invalid(errors);
   }
 
   const reqETag = getTagValue(zapRequest.tags, "e");
   if (reqETag !== productId) {
     errors.push("Zap request 'e' tag missing or does not match product");
-    return { valid: false, amountSats: 0, errors };
+    return invalid(errors);
   }
 
-  const reqAmount = getTagValue(zapRequest.tags, "amount");
-  if (reqAmount !== undefined) {
-    const reqMsat = parseInt(reqAmount, 10);
-    if (Number.isSafeInteger(reqMsat) && Math.abs(reqMsat - amountMsat) > 1000) {
-      errors.push("Zap request amount does not match receipt amount");
-      return { valid: false, amountSats: 0, errors };
+  const reqAmountTag = getTagValue(zapRequest.tags, "amount");
+  if (reqAmountTag !== undefined) {
+    const reqAmount = parsePositiveZapRequestMillisats(reqAmountTag, errors);
+    if (reqAmount === undefined) {
+      return invalid(errors);
+    }
+    if (reqAmount !== invoiceAmountMsat) {
+      errors.push("Zap request amount does not match invoice amount");
+      return invalid(errors);
     }
   }
 
+  const reqLnurl = getTagValue(zapRequest.tags, "lnurl");
+  if (
+    expectedLnurl !== undefined &&
+    reqLnurl !== undefined &&
+    reqLnurl !== expectedLnurl
+  ) {
+    errors.push("Zap request 'lnurl' tag does not match expected LNURL");
+    return invalid(errors);
+  }
+
   if (!skipFreshnessCheck) {
-    const WINDOW = 120;
-    const lowerBound = minTimestamp - WINDOW;
-    const upperBound = minTimestamp + WINDOW;
+    const lowerBound = minTimestamp - FRESHNESS_WINDOW_SECONDS;
+    const upperBound = minTimestamp + FRESHNESS_WINDOW_SECONDS;
     if (receipt.created_at < lowerBound || receipt.created_at > upperBound) {
       errors.push("Receipt timestamp is outside acceptable window");
-      return { valid: false, amountSats: 0, errors };
+      return invalid(errors);
     }
   }
 
   return {
     valid: true,
-    amountSats,
+    amountSats: invoiceAmountSats,
     payerPubkey: zapRequest.pubkey,
     receiptId: receipt.id,
     errors: [],
@@ -153,16 +279,12 @@ export function validateSingleReceipt(
 
 export async function validateZapReceipt(
   nostr: NostrManager,
-  productId: string,
-  minTimestamp: number,
-  sellerPubkey: string,
-  expectedAmountSats: number,
-  expectedPreimage?: string
+  options: ZapReceiptValidationOptions
 ): Promise<ZapReceiptValidationResult> {
   const filter = {
     kinds: [9735],
-    "#e": [productId],
-    since: minTimestamp,
+    "#e": [options.productId],
+    since: options.minTimestamp - FRESHNESS_WINDOW_SECONDS,
   };
 
   const maxRetries = 5;
@@ -171,14 +293,7 @@ export async function validateZapReceipt(
   for (let i = 0; i < maxRetries; i++) {
     const events = await nostr.fetch([filter]);
     for (const event of events) {
-      const result = validateSingleReceipt(
-        event,
-        productId,
-        sellerPubkey,
-        expectedAmountSats,
-        minTimestamp,
-        { expectedPreimage }
-      );
+      const result = validateSingleReceipt(event, options);
       if (result.valid) {
         return result;
       }
@@ -188,9 +303,5 @@ export async function validateZapReceipt(
     }
   }
 
-  return {
-    valid: false,
-    amountSats: 0,
-    errors: ["No valid zap receipt found after all retries"],
-  };
+  return invalid(["No valid zap receipt found after all retries"]);
 }


### PR DESCRIPTION
### Description

This PR hardens Shopstr's Zapsnag/NIP-57 payment validation so purchase and inventory flows no longer trust any relay-returned kind-9735 event by shape alone.

Before this change, a bogus relay event could be counted as a payment because receipt signatures, receipt signer identity, embedded zap requests, BOLT11 invoice amount, and preimage/payment-hash proof were not validated end to end.

### Changes

- Reworked `utils/nostr/zap-validator.ts` around an options-object API for `validateSingleReceipt()` and `validateZapReceipt()`.
- Verify receipt events with `verifyEvent()`, require kind `9735`, and require `receipt.pubkey === expectedReceiptSignerPubkey`.
- Treat the LNURL provider `nostrPubkey` as the expected receipt signer and zap recipient, per the LNURL/NIP-57 flow.
- Validate receipt and embedded zap-request `p` tags against the LNURL provider pubkey.
- Validate product `e` tags against the expected product id.
- Require and decode the receipt `bolt11` invoice, then use the invoice millisats as the canonical payment amount.
- Keep relay `amount` tags optional, but strict when present.
- Reject malformed zap-request amounts and invoice/request/receipt amount mismatches.
- Verify the returned WebLN preimage against the BOLT11 invoice payment hash when `expectedPreimage` is supplied.
- Reject conflicting optional LNURL tags when `expectedLnurl` is supplied.
- Keep the freshness window symmetric around payment start time while allowing inventory validation to skip freshness.
- Updated `components/ZapsnagButton.tsx` to resolve the seller profile Lightning Address, require NIP-57 support via `LightningAddress.nostrPubkey`, and pass the LNURL provider pubkey into purchase and inventory validation.
- Kept `product.pubkey` for seller profile lookup and encrypted shipping/order message recipient, so seller communication still goes to the listing author.
- Expanded unit coverage for validator edge cases and Zapsnag component wiring, including wrong receipt signer, missing/invalid `bolt11`, invoice amount mismatch, malformed zap-request amount, optional receipt amount mismatch, preimage/payment-hash validation, optional LNURL mismatch, and inventory validation against the LNURL provider key.

### Verification
- Temporary fake-money browser smoke in Chrome:
  - Local fake LNURL/WebLN/invoice/receipt/relay harness.
  - Real Shopstr `ZapsnagButton` UI and real receipt validator executed in browser.
  - Verified alert: `Order Placed & Verified! Preimage: 11111111...`
  - Verified invoice amount: `100000` msats = `100` sats.
  - Verified receipt validator result: `valid: true`, `errors: []`.
  - No mainnet or testnet sats were spent.
