### PR TITLE
deps: bump @types/node to 26.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@testing-library/user-event": "14.6.1",
         "@types/crypto-js": "4.2.2",
         "@types/jest": "30.0.0",
-        "@types/node": "25.9.1",
+        "@types/node": "26.0.1",
         "@types/pg": "8.20.0",
         "@types/qrcode": "1.5.6",
         "@types/react": "19.2.17",
@@ -8011,13 +8011,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/pg": {
@@ -19141,9 +19141,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@testing-library/user-event": "14.6.1",
     "@types/crypto-js": "4.2.2",
     "@types/jest": "30.0.0",
-    "@types/node": "25.9.1",
+    "@types/node": "26.0.1",
     "@types/pg": "8.20.0",
     "@types/qrcode": "1.5.6",
     "@types/react": "19.2.17",


### PR DESCRIPTION
## Summary

- Keep `@heroui/react` pinned at `2.8.10`.
- Bump only `@types/node` from `25.9.1` to `26.0.1`.
- Update the lockfile's `undici-types` entry required by `@types/node@26.0.1`.

This is the safe alternative to the broader Dependabot PR that also attempted the breaking HeroUI v3 update [here](https://github.com/shopstr-eng/shopstr/pull/557)
