### PR TITLE
refactor: consolidate duplicated getTagValue into shared tag-utils module

### DIFF
--- a/mcp/resources.ts
+++ b/mcp/resources.ts
@@ -5,18 +5,7 @@ import {
   parseShippingFromTags,
 } from "@/utils/parsers/product-tag-helpers";
 import { NostrEvent } from "@/utils/types/types";
-
-function getTagValue(tags: string[][], key: string): string | undefined {
-  const tag = tags.find((t) => t[0] === key);
-  return tag ? tag[1] : undefined;
-}
-
-function getAllTagValues(tags: string[][], key: string): string[] {
-  return tags
-    .filter((t) => t[0] === key)
-    .map((t) => t[1]!)
-    .filter(Boolean);
-}
+import { getTagValue, getAllTagValues } from "@/utils/nostr/tag-utils";
 
 function buildCatalogEntry(event: NostrEvent) {
   const tags = event.tags || [];

--- a/mcp/tools/read-tools.ts
+++ b/mcp/tools/read-tools.ts
@@ -8,6 +8,7 @@ import {
 import { NostrEvent } from "@/utils/types/types";
 import { registerTool } from "./register-tool";
 import { ToolContext } from "../audit-log";
+import { getTagValue, getAllTagValues } from "@/utils/nostr/tag-utils";
 
 const DB_TIMEOUT_MS = 15_000;
 
@@ -192,18 +193,6 @@ async function validateDiscountCodeStrict(
   } finally {
     if (client) client.release();
   }
-}
-
-function getTagValue(tags: string[][], key: string): string | undefined {
-  const tag = tags.find((t) => t[0] === key);
-  return tag ? tag[1] : undefined;
-}
-
-function getAllTagValues(tags: string[][], key: string): string[] {
-  return tags
-    .filter((t) => t[0] === key)
-    .map((t) => t[1]!)
-    .filter(Boolean);
 }
 
 function determinePaymentMethods(

--- a/utils/mcp/request-proof.ts
+++ b/utils/mcp/request-proof.ts
@@ -1,5 +1,6 @@
 import { type Event } from "nostr-tools";
 import { NostrEventTemplate } from "@/utils/nostr/nostr-manager";
+import { getTagValue } from "@/utils/nostr/tag-utils";
 
 export const MCP_SIGNED_EVENT_HEADER = "x-mcp-signed-event";
 export const MCP_REQUEST_PROOF_KIND = 27235;
@@ -60,10 +61,6 @@ export function buildMcpRequestProofTemplate(
   };
 }
 
-function getTagValue(event: Event, tagName: string): string | undefined {
-  return event.tags.find((tag) => tag[0] === tagName)?.[1];
-}
-
 export function matchesMcpRequestProof(
   event: Event,
   proof: McpRequestProof
@@ -74,7 +71,7 @@ export function matchesMcpRequestProof(
 
   const expectedTags = buildMcpRequestProofTags(proof);
   return expectedTags.every(
-    ([tagName, tagValue]) => getTagValue(event, tagName) === tagValue
+    ([tagName, tagValue]) => getTagValue(event.tags, tagName) === tagValue
   );
 }
 

--- a/utils/nostr/nip98-auth.ts
+++ b/utils/nostr/nip98-auth.ts
@@ -2,6 +2,7 @@ import CryptoJS from "crypto-js";
 import { verifyEvent } from "nostr-tools";
 import type { NextApiRequest } from "next";
 import type { NostrSigner } from "@/utils/nostr/signers/nostr-signer";
+import { getTagValue } from "@/utils/nostr/tag-utils";
 
 type NostrHttpAuthEvent = {
   id: string;
@@ -30,10 +31,6 @@ function toBase64(value: string): string {
 
 function fromBase64(value: string): string {
   return Buffer.from(value, "base64").toString("utf-8");
-}
-
-function getTagValue(tags: string[][], key: string): string | undefined {
-  return tags.find((tag) => tag[0] === key)?.[1];
 }
 
 function getRequestOrigin(req: NextApiRequest): string {

--- a/utils/nostr/request-auth.ts
+++ b/utils/nostr/request-auth.ts
@@ -2,6 +2,7 @@ import type { Event } from "nostr-tools";
 import { verifyEvent } from "nostr-tools";
 import type { NextApiRequest } from "next";
 import { NostrEventTemplate } from "@/utils/nostr/nostr-manager";
+import { getTagValue } from "@/utils/nostr/tag-utils";
 
 export const SIGNED_EVENT_HEADER = "x-signed-event";
 export const SIGNED_HTTP_REQUEST_KIND = 27235;
@@ -37,10 +38,6 @@ function sortedProofFields(
         : ([[key, normalizedValue]] as Array<[string, string]>);
     })
     .sort(([left], [right]) => left.localeCompare(right));
-}
-
-function getTagValue(event: Event, tagName: string): string | undefined {
-  return event.tags.find((tag) => tag[0] === tagName)?.[1];
 }
 
 export function buildSignedHttpRequestProofTemplate(
@@ -97,7 +94,7 @@ export function matchesSignedHttpRequestProof(
     return (
       typeof tagName === "string" &&
       typeof tagValue === "string" &&
-      getTagValue(event, tagName) === tagValue
+      getTagValue(event.tags, tagName) === tagValue
     );
   });
 }

--- a/utils/nostr/tag-utils.ts
+++ b/utils/nostr/tag-utils.ts
@@ -1,0 +1,18 @@
+export function getTagValue(tags: string[][], key: string): string | undefined {
+  return tags.find((tag) => tag[0] === key)?.[1];
+}
+
+export function getAllTagValues(tags: string[][], key: string): string[] {
+  return tags
+    .filter((t) => t[0] === key)
+    .map((t) => t[1]!)
+    .filter(Boolean);
+}
+
+export function getDTag(tags: string[][]): string | undefined {
+  return getTagValue(tags, "d");
+}
+
+export function hasTag(tags: string[][], key: string, value: string): boolean {
+  return tags.some((tag) => tag[0] === key && tag[1] === value);
+}


### PR DESCRIPTION
### Description

Consolidate 7 duplicate implementations of getTagValue across the codebase into a single shared module. This eliminates code duplication and ensures consistent tag parsing behavior everywhere.

### Changes

- New file: utils/nostr/tag-utils.ts - exports getTagValue, getAllTagValues, getDTag, hasTag
- mcp/resources.ts - removed inline getTagValue + getAllTagValues, imports from shared module
- mcp/tools/read-tools.ts - removed inline getTagValue + getAllTagValues, imports from shared module
- utils/nostr/nip98-auth.ts - removed inline getTagValue, imports from shared module
- utils/mcp/request-proof.ts - removed inline getTagValue, caller passes event.tags
- utils/nostr/request-auth.ts - removed inline getTagValue, caller passes event.tags

### Verification

- TypeScript compiles with zero errors (tsc --noEmit)
- All 131 test suites pass (1519 tests, 0 failures)