### PR TITLE
Add marketplace report moderation and search relay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A global, permissionless Nostr marketplace for Bitcoin commerce.
 - [x] NIP-46: Nostr Remote Signing
 - [x] NIP-47: Wallet Connect
 - [x] NIP-49: Private Key Encryption
-- [ ] NIP-50: Search Capability
+- [ ] NIP-50: Search Capability (partial: product search)
 - [x] NIP-51: Lists
-- [ ] NIP-56: Reporting
+- [ ] NIP-56: Reporting (partial: profile/listing reports)
 - [x] NIP-57: Lightning Zaps
 - [ ] NIP-58: Badges
 - [x] NIP-60: Cashu Wallet

--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -6,6 +6,7 @@ import {
   ProductContext,
   ProfileMapContext,
   RelaysContext,
+  ReportsContext,
 } from "@/utils/context/context";
 import {
   NostrContext,
@@ -34,16 +35,27 @@ jest.mock(
     function MockProductCard({
       productData,
       href,
+      reportSignal,
     }: {
       productData: { id: string; title: string };
       href?: string | null;
+      reportSignal?: { level: string };
     }) {
       return href ? (
-        <a data-testid={`product-${productData.id}`} href={href}>
+        <a
+          data-testid={`product-${productData.id}`}
+          data-report-level={reportSignal?.level}
+          href={href}
+        >
           {productData.title}
         </a>
       ) : (
-        <div data-testid={`product-${productData.id}`}>{productData.title}</div>
+        <div
+          data-testid={`product-${productData.id}`}
+          data-report-level={reportSignal?.level}
+        >
+          {productData.title}
+        </div>
       );
     }
 );
@@ -51,6 +63,15 @@ jest.mock(
 jest.mock("../display-product-modal", () => () => null);
 jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
   deleteEvent: jest.fn(),
+  REPORT_TYPES: [
+    "nudity",
+    "malware",
+    "profanity",
+    "illegal",
+    "spam",
+    "impersonation",
+    "other",
+  ],
 }));
 jest.mock("@/utils/db/db-client", () => ({
   cacheEventsToDatabase: jest.fn().mockResolvedValue(undefined),
@@ -67,6 +88,9 @@ const renderDisplayProducts = ({
   productEvents = [],
   relayList = ["wss://relay.example"],
   selectedSearch = "coffee",
+  reportEvents = [],
+  followList = [],
+  firstDegreeFollowsLength = 0,
   addNewlyCreatedProductEvent = jest.fn(),
   removeDeletedProductEvent = jest.fn(),
 }: {
@@ -75,6 +99,9 @@ const renderDisplayProducts = ({
   productEvents?: NostrEvent[];
   relayList?: string[];
   selectedSearch?: string;
+  reportEvents?: NostrEvent[];
+  followList?: string[];
+  firstDegreeFollowsLength?: number;
   addNewlyCreatedProductEvent?: jest.Mock;
   removeDeletedProductEvent?: jest.Mock;
 }) =>
@@ -102,26 +129,34 @@ const renderDisplayProducts = ({
           >
             <FollowsContext.Provider
               value={{
-                followList: [],
-                firstDegreeFollowsLength: 0,
+                followList,
+                firstDegreeFollowsLength,
                 isLoading: false,
               }}
             >
-              <ProductContext.Provider
+              <ReportsContext.Provider
                 value={{
-                  productEvents,
                   isLoading: false,
-                  addNewlyCreatedProductEvent,
-                  removeDeletedProductEvent,
+                  reportEvents,
+                  addReportEvent: jest.fn(),
                 }}
               >
-                <DisplayProducts
-                  focusedPubkey={focusedPubkey}
-                  selectedCategories={new Set()}
-                  selectedLocation=""
-                  selectedSearch={selectedSearch}
-                />
-              </ProductContext.Provider>
+                <ProductContext.Provider
+                  value={{
+                    productEvents,
+                    isLoading: false,
+                    addNewlyCreatedProductEvent,
+                    removeDeletedProductEvent,
+                  }}
+                >
+                  <DisplayProducts
+                    focusedPubkey={focusedPubkey}
+                    selectedCategories={new Set()}
+                    selectedLocation=""
+                    selectedSearch={selectedSearch}
+                  />
+                </ProductContext.Provider>
+              </ReportsContext.Provider>
             </FollowsContext.Provider>
           </ProfileMapContext.Provider>
         </RelaysContext.Provider>
@@ -131,10 +166,11 @@ const renderDisplayProducts = ({
 
 const expectNip50RelayFetches = (
   fetchMock: jest.Mock,
-  expectedFilter: Record<string, unknown>
+  expectedFilter: Record<string, unknown>,
+  expectedRelays = ["wss://relay.example", ...DEFAULT_NIP50_SEARCH_RELAYS]
 ) => {
-  expect(fetchMock).toHaveBeenCalledTimes(DEFAULT_NIP50_SEARCH_RELAYS.length);
-  DEFAULT_NIP50_SEARCH_RELAYS.forEach((relay, index) => {
+  expect(fetchMock).toHaveBeenCalledTimes(expectedRelays.length);
+  expectedRelays.forEach((relay, index) => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       index + 1,
       expect.arrayContaining([expect.objectContaining(expectedFilter)]),
@@ -286,6 +322,47 @@ describe("DisplayProducts search filtering", () => {
     });
   });
 
+  it("passes trusted report moderation signals to product cards", async () => {
+    const productEvent = {
+      id: "local-product-1",
+      pubkey: "seller-pubkey",
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "local-coffee"],
+        ["title", "Local Coffee"],
+        ["price", "12", "USD"],
+        ["image", "https://example.com/local-coffee.png"],
+      ],
+      content: "Fresh local coffee",
+      sig: "sig-local-product",
+    } as NostrEvent;
+
+    renderDisplayProducts({
+      nostr: { fetch: jest.fn().mockResolvedValue([]) },
+      productEvents: [productEvent],
+      selectedSearch: "",
+      reportEvents: [
+        {
+          id: "report-1",
+          pubkey: "viewer-pubkey",
+          created_at: 11,
+          kind: 1984,
+          tags: [["e", "local-product-1", "spam"]],
+          content: "",
+          sig: "sig-report-1",
+        } as NostrEvent,
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("product-local-product-1")).toHaveAttribute(
+        "data-report-level",
+        "reported_by_you"
+      );
+    });
+  });
+
   it("does not add transient NIP-50 search results to shared product context", async () => {
     const relayProduct = {
       id: "relay-product-1",
@@ -410,7 +487,7 @@ describe("DisplayProducts search filtering", () => {
       expect(screen.getByText("No products found...")).toBeInTheDocument();
     });
     expect(nostr.fetch).toHaveBeenCalledTimes(
-      DEFAULT_NIP50_SEARCH_RELAYS.length
+      DEFAULT_NIP50_SEARCH_RELAYS.length + 1
     );
   });
 

--- a/components/display-products.tsx
+++ b/components/display-products.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useMemo } from "react";
 import { deleteEvent } from "@/utils/nostr/nostr-helper-functions";
 import { NostrEvent } from "../utils/types/types";
 import {
   ProductContext,
   FollowsContext,
   RelaysContext,
+  ReportsContext,
 } from "../utils/context/context";
 import ProductCard from "./utility-components/product-card";
 import DisplayProductModal from "./display-product-modal";
@@ -27,6 +28,11 @@ import {
   fetchNip50ProductSearch,
   getProductEventKey,
 } from "@/utils/nostr/fetch-service";
+import {
+  getDirectFollowPubkeys,
+  getListingReportSignal,
+  summarizeReportEvents,
+} from "@/utils/nostr/report-moderation";
 import { nip19 } from "nostr-tools";
 
 const isNip19SearchQuery = (search: string) => {
@@ -65,6 +71,7 @@ const DisplayProducts = ({
   const [isNip50SearchLoading, setIsNip50SearchLoading] = useState(false);
   const productEventContext = useContext(ProductContext);
   const followsContext = useContext(FollowsContext);
+  const reportsContext = useContext(ReportsContext);
   const relaysContext = useContext(RelaysContext);
   const [focusedProduct, setFocusedProduct] = useState<ProductData>();
   const [showModal, setShowModal] = useState(false);
@@ -79,6 +86,23 @@ const DisplayProducts = ({
 
   const { nostr } = useContext(NostrContext);
   const { signer, pubkey: userPubkey } = useContext(SignerContext);
+  const directFollowPubkeys = useMemo(
+    () =>
+      getDirectFollowPubkeys(
+        followsContext.followList,
+        followsContext.firstDegreeFollowsLength
+      ),
+    [followsContext.followList, followsContext.firstDegreeFollowsLength]
+  );
+  const reportSummaries = useMemo(
+    () =>
+      summarizeReportEvents({
+        reportEvents: reportsContext.reportEvents,
+        directFollowPubkeys,
+        userPubkey,
+      }),
+    [reportsContext.reportEvents, directFollowPubkeys, userPubkey]
+  );
 
   const searchRelaysKey = Array.from(
     new Set([
@@ -109,7 +133,12 @@ const DisplayProducts = ({
   useEffect(() => {
     const normalizedSearch = selectedSearch.trim();
 
-    if (!normalizedSearch || isNip19SearchQuery(normalizedSearch) || !nostr) {
+    if (
+      !normalizedSearch ||
+      isNip19SearchQuery(normalizedSearch) ||
+      !nostr ||
+      typeof nostr.fetch !== "function"
+    ) {
       setNip50ProductEvents([]);
       setIsNip50SearchLoading(false);
       return;
@@ -411,6 +440,10 @@ const DisplayProducts = ({
                     productData={productData}
                     onProductClick={onProductClick}
                     href={getProductHref(productData)}
+                    reportSignal={getListingReportSignal(
+                      productData,
+                      reportSummaries
+                    )}
                   />
                 )
               )}

--- a/components/home/marketplace.tsx
+++ b/components/home/marketplace.tsx
@@ -21,16 +21,18 @@ import {
   FaceSmileIcon,
   PlusIcon,
   EllipsisVerticalIcon,
+  ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import { useRouter } from "next/router";
 import { nip19, Event } from "nostr-tools";
-import { useContext, useEffect, useState, useRef } from "react";
+import { useContext, useEffect, useState, useRef, useMemo } from "react";
 import {
   ReviewsContext,
   ShopMapContext,
   FollowsContext,
   ProductContext,
   ProfileMapContext,
+  ReportsContext,
 } from "@/utils/context/context";
 import DisplayProducts from "../display-products";
 import LocationDropdown from "../utility-components/dropdowns/location-dropdown";
@@ -55,6 +57,12 @@ import {
   isNpub,
 } from "@/utils/url-slugs";
 import { useDebounce } from "@/utils/hooks/useDebounce";
+import {
+  getDirectFollowPubkeys,
+  getProfileReportSignal,
+  getReportModerationLabel,
+  summarizeReportEvents,
+} from "@/utils/nostr/report-moderation";
 
 export function normalizeNpub(
   npub: string | string[] | undefined
@@ -122,11 +130,37 @@ function MarketplacePage({
   const reviewsContext = useContext(ReviewsContext);
   const shopMapContext = useContext(ShopMapContext);
   const followsContext = useContext(FollowsContext);
+  const reportsContext = useContext(ReportsContext);
   const productEventContext = useContext(ProductContext);
   const profileMapContext = useContext(ProfileMapContext);
 
   const { pubkey: userPubkey, isLoggedIn: loggedIn } =
     useContext(SignerContext);
+  const directFollowPubkeys = useMemo(
+    () =>
+      getDirectFollowPubkeys(
+        followsContext.followList,
+        followsContext.firstDegreeFollowsLength
+      ),
+    [followsContext.followList, followsContext.firstDegreeFollowsLength]
+  );
+  const reportSummaries = useMemo(
+    () =>
+      summarizeReportEvents({
+        reportEvents: reportsContext.reportEvents,
+        directFollowPubkeys,
+        userPubkey,
+      }),
+    [reportsContext.reportEvents, directFollowPubkeys, userPubkey]
+  );
+  const profileReportSignal = getProfileReportSignal(
+    focusedPubkey,
+    reportSummaries
+  );
+  const profileReportLabel = getReportModerationLabel(
+    profileReportSignal,
+    "profile"
+  );
 
   const searchBarRef = useRef<HTMLDivElement>(null);
   const hasTrustGraph =
@@ -590,6 +624,12 @@ function MarketplacePage({
                 />
               ) : null}
             </div>
+          </div>
+        )}
+        {focusedPubkey && profileReportSignal.level !== "none" && (
+          <div className="mt-2 flex w-full items-center gap-2 rounded-md border border-red-400/40 bg-red-500/10 px-3 py-2 text-red-600 dark:text-red-300">
+            <ExclamationTriangleIcon className="h-5 w-5 shrink-0" />
+            <span className="text-sm font-medium">{profileReportLabel}</span>
           </div>
         )}
       </div>

--- a/components/utility-components/__tests__/product-card.test.tsx
+++ b/components/utility-components/__tests__/product-card.test.tsx
@@ -227,6 +227,50 @@ describe("ProductCard", () => {
       );
       expect(screen.getByText("Sold")).toBeInTheDocument();
     });
+
+    it("shows a trusted report warning without hiding the listing", () => {
+      renderWithContext(
+        <ProductCard
+          productData={mockProductData}
+          reportSignal={{
+            level: "trusted_warning",
+            reportCount: 1,
+            reportTypes: ["spam"],
+          }}
+        />
+      );
+
+      expect(screen.getByText("1 trusted listing report")).toBeInTheDocument();
+      expect(screen.queryByText("Show listing")).not.toBeInTheDocument();
+    });
+
+    it("blurs a listing with enough trusted reports until revealed", () => {
+      renderWithContext(
+        <ProductCard
+          productData={mockProductData}
+          href="/listing/test-slug"
+          reportSignal={{
+            level: "trusted_blur",
+            reportCount: 3,
+            reportTypes: ["illegal"],
+          }}
+        />
+      );
+
+      expect(
+        screen.getAllByText("3 trusted listing reports").length
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getByText("Reported by trusted marketplace contacts.")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Test Product").closest("[inert]")
+      ).not.toBeNull();
+
+      fireEvent.click(screen.getByText("Show listing"));
+      expect(screen.queryByText("Show listing")).not.toBeInTheDocument();
+      expect(screen.getByText("Test Product").closest("[inert]")).toBeNull();
+    });
   });
 });
 

--- a/components/utility-components/product-card.tsx
+++ b/components/utility-components/product-card.tsx
@@ -30,11 +30,17 @@ import {
   isSellerP2pkEscrowActive,
   isP2pkEscrowFeatureEnabled,
 } from "@/utils/cashu/p2pk-checkout";
+import {
+  EMPTY_REPORT_MODERATION_SIGNAL,
+  getReportModerationLabel,
+  ReportModerationSignal,
+} from "@/utils/nostr/report-moderation";
 
 export default function ProductCard({
   productData,
   onProductClick,
   href,
+  reportSignal = EMPTY_REPORT_MODERATION_SIGNAL,
 }: {
   productData: ProductData;
   onProductClick?: (
@@ -42,9 +48,12 @@ export default function ProductCard({
     e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
   ) => void;
   href?: string | null;
+  reportSignal?: ReportModerationSignal;
 }) {
   const [showRawEventModal, setShowRawEventModal] = useState(false);
   const [showEventIdModal, setShowEventIdModal] = useState(false);
+  const [hasRevealedReportedContent, setHasRevealedReportedContent] =
+    useState(false);
 
   const router = useRouter();
   const { pubkey: userPubkey } = useContext(SignerContext);
@@ -183,6 +192,17 @@ export default function ProductCard({
   };
 
   const isCardInteractive = Boolean(href || onProductClick);
+  const shouldBlurReportedContent =
+    reportSignal.level === "reported_by_you" ||
+    reportSignal.level === "trusted_blur";
+  const isReportContentBlurred =
+    shouldBlurReportedContent && !hasRevealedReportedContent;
+  const reportLabel = getReportModerationLabel(reportSignal, "listing");
+  const reportDescription =
+    reportSignal.level === "reported_by_you"
+      ? "You flagged this listing."
+      : "Reported by trusted marketplace contacts.";
+  const revealReportedContent = () => setHasRevealedReportedContent(true);
 
   const handleNjumpClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -303,6 +323,22 @@ export default function ProductCard({
               </div>
             )}
 
+            {reportSignal.level !== "none" && (
+              <div className="mb-2 flex items-center gap-2">
+                <Chip
+                  color={
+                    reportSignal.level === "trusted_warning"
+                      ? "warning"
+                      : "danger"
+                  }
+                  size="sm"
+                  variant="flat"
+                >
+                  {reportLabel}
+                </Chip>
+              </div>
+            )}
+
             {/* Price */}
             <div className="mb-3">
               {!isZapsnag ? (
@@ -381,7 +417,31 @@ export default function ProductCard({
     <div
       className={`${cardHoverStyle} my-4 w-full rounded-2xl bg-white shadow-md transition-all duration-300 dark:bg-neutral-900`}
     >
-      <div className="w-full overflow-hidden rounded-2xl">{content}</div>
+      <div className="relative w-full overflow-hidden rounded-2xl">
+        <div
+          aria-hidden={isReportContentBlurred}
+          inert={isReportContentBlurred}
+          className={isReportContentBlurred ? "blur-sm" : ""}
+        >
+          {content}
+        </div>
+        {isReportContentBlurred && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/55 p-4 text-center text-white">
+            <div>
+              <p className="text-base font-semibold">{reportLabel}</p>
+              <p className="text-sm opacity-90">{reportDescription}</p>
+            </div>
+            <Button
+              size="sm"
+              variant="flat"
+              onClick={revealReportedContent}
+              onPress={revealReportedContent}
+            >
+              Show listing
+            </Button>
+          </div>
+        )}
+      </div>
       <RawEventModal
         isOpen={showRawEventModal}
         onClose={() => setShowRawEventModal(false)}

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -666,7 +666,10 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expectNip50RelayFetches(nostr.fetch);
+    expectNip50RelayFetches(nostr.fetch, [
+      "wss://relay.example",
+      ...DEFAULT_NIP50_SEARCH_RELAYS,
+    ]);
     expect(result.productEvents).toEqual([newer]);
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([newer]);
   });
@@ -801,7 +804,7 @@ describe("fetch-service NIP-50 search helpers", () => {
     expect(result.productEvents).toEqual([firstRelayResult, secondRelayResult]);
   });
 
-  it("routes search to curated NIP-50 relays instead of general user relays", async () => {
+  it("routes search to selected relays before curated NIP-50 fallbacks", async () => {
     const searchListing = {
       id: "fallback-product",
       pubkey: "fallback-seller",
@@ -825,7 +828,11 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expectNip50RelayFetches(nostr.fetch);
+    expectNip50RelayFetches(nostr.fetch, [
+      "wss://relay.damus.io",
+      "wss://nos.lol",
+      ...DEFAULT_NIP50_SEARCH_RELAYS,
+    ]);
     expect(result.productEvents).toEqual([searchListing]);
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([searchListing]);
   });
@@ -927,10 +934,12 @@ describe("fetch-service NIP-50 search helpers", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("keeps known selected NIP-50 relays while dropping unsupported selected relays", async () => {
+  it("queries selected relays before adding backup NIP-50 relays", async () => {
     const selectedSearchRelay = "wss://relay.nostr.band";
     const searchRelays = [
+      "wss://relay.damus.io",
       selectedSearchRelay,
+      "wss://nos.lol",
       ...DEFAULT_NIP50_SEARCH_RELAYS.filter(
         (relay) => relay !== selectedSearchRelay
       ),
@@ -952,6 +961,7 @@ describe("fetch-service NIP-50 search helpers", () => {
     const selectedSearchRelays = [
       "wss://relay.noswhere.com",
       "wss://search.nos.today",
+      "wss://relay.damus.io",
     ];
     const searchRelays = [
       ...selectedSearchRelays,

--- a/utils/nostr/__tests__/report-moderation.test.ts
+++ b/utils/nostr/__tests__/report-moderation.test.ts
@@ -1,0 +1,206 @@
+import { ProductData } from "@/utils/parsers/product-parser-functions";
+import {
+  getDirectFollowPubkeys,
+  getListingReportSignal,
+  getProfileReportSignal,
+  summarizeReportEvents,
+} from "../report-moderation";
+
+const makeReport = ({
+  id,
+  pubkey,
+  tags,
+}: {
+  id: string;
+  pubkey: string;
+  tags: string[][];
+}) => ({
+  id,
+  pubkey,
+  created_at: 1,
+  kind: 1984,
+  tags,
+  content: "",
+  sig: `sig-${id}`,
+});
+
+const product = {
+  id: "listing-1",
+  pubkey: "seller-1",
+  title: "Coffee",
+  summary: "",
+  images: [],
+  categories: [],
+  location: "",
+  price: 1,
+  currency: "USD",
+  createdAt: 1,
+  publishedAt: "",
+  totalCost: 1,
+} as ProductData;
+
+describe("report moderation helpers", () => {
+  it("uses only first-degree follows as trusted reporters", () => {
+    expect(
+      getDirectFollowPubkeys(["direct-1", "direct-2", "second-degree"], 2)
+    ).toEqual(["direct-1", "direct-2"]);
+  });
+
+  it("ignores malformed report events and unknown report types", () => {
+    const summaries = summarizeReportEvents({
+      reportEvents: [
+        makeReport({
+          id: "bad-kind",
+          pubkey: "direct-1",
+          tags: [["e", "listing-1", "not-a-type"]],
+        }),
+        {
+          ...makeReport({ id: "wrong-kind", pubkey: "direct-1", tags: [] }),
+          kind: 1,
+        },
+        makeReport({
+          id: "good",
+          pubkey: "direct-1",
+          tags: [["e", "listing-1", "spam"]],
+        }),
+      ],
+      directFollowPubkeys: ["direct-1"],
+      userPubkey: "viewer",
+    });
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      reporterPubkey: "direct-1",
+      targetKind: "listing",
+      targetId: "listing-1",
+      reportType: "spam",
+      isTrustedReport: true,
+    });
+  });
+
+  it("warns on one trusted listing report and blurs on three", () => {
+    const oneTrustedSummary = summarizeReportEvents({
+      reportEvents: [
+        makeReport({
+          id: "report-1",
+          pubkey: "direct-1",
+          tags: [["e", "listing-1", "spam"]],
+        }),
+      ],
+      directFollowPubkeys: ["direct-1"],
+      userPubkey: "viewer",
+    });
+
+    expect(getListingReportSignal(product, oneTrustedSummary)).toMatchObject({
+      level: "trusted_warning",
+      reportCount: 1,
+      reportTypes: ["spam"],
+    });
+
+    const threeTrustedSummaries = summarizeReportEvents({
+      reportEvents: ["direct-1", "direct-2", "direct-3"].map((pubkey, index) =>
+        makeReport({
+          id: `report-${index}`,
+          pubkey,
+          tags: [["e", "listing-1", "illegal"]],
+        })
+      ),
+      directFollowPubkeys: ["direct-1", "direct-2", "direct-3"],
+      userPubkey: "viewer",
+    });
+
+    expect(
+      getListingReportSignal(product, threeTrustedSummaries)
+    ).toMatchObject({
+      level: "trusted_blur",
+      reportCount: 3,
+      reportTypes: ["illegal"],
+    });
+  });
+
+  it("does not treat a listing report's untyped p tag as a profile report", () => {
+    const summaries = summarizeReportEvents({
+      reportEvents: [
+        makeReport({
+          id: "listing-report",
+          pubkey: "direct-1",
+          tags: [
+            ["e", "listing-1", "spam"],
+            ["p", "seller-1"],
+          ],
+        }),
+      ],
+      directFollowPubkeys: ["direct-1"],
+      userPubkey: "viewer",
+    });
+
+    expect(getListingReportSignal(product, summaries)).toMatchObject({
+      level: "trusted_warning",
+      reportCount: 1,
+    });
+    expect(getProfileReportSignal("seller-1", summaries)).toMatchObject({
+      level: "none",
+      reportCount: 0,
+    });
+  });
+
+  it("counts unique trusted reporters for blur threshold", () => {
+    const summaries = summarizeReportEvents({
+      reportEvents: [1, 2, 3].map((index) =>
+        makeReport({
+          id: `repeat-report-${index}`,
+          pubkey: "direct-1",
+          tags: [["e", "listing-1", "spam"]],
+        })
+      ),
+      directFollowPubkeys: ["direct-1"],
+      userPubkey: "viewer",
+    });
+
+    expect(getListingReportSignal(product, summaries)).toMatchObject({
+      level: "trusted_warning",
+      reportCount: 1,
+      reportTypes: ["spam"],
+    });
+  });
+
+  it("prioritizes current user's own reports", () => {
+    const summaries = summarizeReportEvents({
+      reportEvents: [
+        makeReport({
+          id: "own-report",
+          pubkey: "viewer",
+          tags: [["e", "listing-1", "other"]],
+        }),
+      ],
+      directFollowPubkeys: [],
+      userPubkey: "viewer",
+    });
+
+    expect(getListingReportSignal(product, summaries)).toMatchObject({
+      level: "reported_by_you",
+      reportCount: 1,
+      reportTypes: ["other"],
+    });
+  });
+
+  it("summarizes trusted profile reports", () => {
+    const summaries = summarizeReportEvents({
+      reportEvents: [
+        makeReport({
+          id: "profile-report",
+          pubkey: "direct-1",
+          tags: [["p", "seller-1", "impersonation"]],
+        }),
+      ],
+      directFollowPubkeys: ["direct-1"],
+      userPubkey: "viewer",
+    });
+
+    expect(getProfileReportSignal("seller-1", summaries)).toMatchObject({
+      level: "trusted_warning",
+      reportCount: 1,
+      reportTypes: ["impersonation"],
+    });
+  });
+});

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -89,12 +89,7 @@ function getUniqueRelayUrls(relays: string[]): string[] {
 }
 
 function getNip50SearchRelays(relays: string[]): string[] {
-  const knownSearchRelaySet = new Set(
-    DEFAULT_NIP50_SEARCH_RELAYS.map((relay) => relay.toLowerCase())
-  );
-  const selectedSearchRelays = getUniqueRelayUrls(relays).filter((relay) =>
-    knownSearchRelaySet.has(relay.toLowerCase())
-  );
+  const selectedSearchRelays = getUniqueRelayUrls(relays);
   const selectedSearchRelaySet = new Set(
     selectedSearchRelays.map((relay) => relay.toLowerCase())
   );

--- a/utils/nostr/report-moderation.ts
+++ b/utils/nostr/report-moderation.ts
@@ -5,10 +5,7 @@ import { NostrEvent } from "@/utils/types/types";
 export type ReportTargetKind = "listing" | "profile" | "blob";
 
 export type ReportModerationLevel =
-  | "none"
-  | "reported_by_you"
-  | "trusted_warning"
-  | "trusted_blur";
+  "none" | "reported_by_you" | "trusted_warning" | "trusted_blur";
 
 export interface ReportModerationSignal {
   level: ReportModerationLevel;

--- a/utils/nostr/report-moderation.ts
+++ b/utils/nostr/report-moderation.ts
@@ -1,0 +1,170 @@
+import { REPORT_TYPES, ReportType } from "@/utils/nostr/nostr-helper-functions";
+import { ProductData } from "@/utils/parsers/product-parser-functions";
+import { NostrEvent } from "@/utils/types/types";
+
+export type ReportTargetKind = "listing" | "profile" | "blob";
+
+export type ReportModerationLevel =
+  | "none"
+  | "reported_by_you"
+  | "trusted_warning"
+  | "trusted_blur";
+
+export interface ReportModerationSignal {
+  level: ReportModerationLevel;
+  reportCount: number;
+  reportTypes: ReportType[];
+}
+
+export const EMPTY_REPORT_MODERATION_SIGNAL: ReportModerationSignal = {
+  level: "none",
+  reportCount: 0,
+  reportTypes: [],
+};
+
+export interface ReportSummary {
+  id: string;
+  reporterPubkey: string;
+  targetKind: ReportTargetKind;
+  targetId: string;
+  reportType: ReportType;
+  isOwnReport: boolean;
+  isTrustedReport: boolean;
+}
+
+const REPORT_TYPE_SET = new Set<string>(REPORT_TYPES);
+const TRUSTED_BLUR_THRESHOLD = 3;
+
+function isReportType(value: unknown): value is ReportType {
+  return typeof value === "string" && REPORT_TYPE_SET.has(value);
+}
+
+function buildSignal(summaries: ReportSummary[]): ReportModerationSignal {
+  const trustedOrOwnReports = summaries.filter(
+    (summary) => summary.isOwnReport || summary.isTrustedReport
+  );
+
+  if (trustedOrOwnReports.length === 0) {
+    return EMPTY_REPORT_MODERATION_SIGNAL;
+  }
+
+  const reportTypes = Array.from(
+    new Set(trustedOrOwnReports.map((summary) => summary.reportType))
+  );
+  const reportCount = new Set(
+    trustedOrOwnReports.map((summary) => summary.reporterPubkey)
+  ).size;
+
+  if (trustedOrOwnReports.some((summary) => summary.isOwnReport)) {
+    return {
+      level: "reported_by_you",
+      reportCount,
+      reportTypes,
+    };
+  }
+
+  return {
+    level:
+      reportCount >= TRUSTED_BLUR_THRESHOLD
+        ? "trusted_blur"
+        : "trusted_warning",
+    reportCount,
+    reportTypes,
+  };
+}
+
+export function getReportModerationLabel(
+  signal: ReportModerationSignal,
+  targetLabel: "listing" | "profile"
+): string {
+  if (signal.level === "reported_by_you") {
+    return `You reported this ${targetLabel}`;
+  }
+
+  if (signal.level === "trusted_blur") {
+    return `${signal.reportCount} trusted ${targetLabel} reports`;
+  }
+
+  if (signal.level === "trusted_warning") {
+    return `${signal.reportCount} trusted ${targetLabel} report${
+      signal.reportCount === 1 ? "" : "s"
+    }`;
+  }
+
+  return "";
+}
+
+export function getDirectFollowPubkeys(
+  followList: string[],
+  firstDegreeFollowsLength: number
+): string[] {
+  return followList.slice(0, Math.max(0, firstDegreeFollowsLength));
+}
+
+export function summarizeReportEvents({
+  reportEvents,
+  directFollowPubkeys,
+  userPubkey,
+}: {
+  reportEvents: NostrEvent[];
+  directFollowPubkeys: string[];
+  userPubkey?: string | null;
+}): ReportSummary[] {
+  const trustedReporterSet = new Set(directFollowPubkeys);
+
+  return reportEvents.flatMap((event): ReportSummary[] => {
+    if (!event?.id || event.kind !== 1984 || !event.pubkey) return [];
+
+    const isOwnReport = Boolean(userPubkey && event.pubkey === userPubkey);
+    const isTrustedReport = trustedReporterSet.has(event.pubkey);
+
+    return (event.tags || []).flatMap((tag): ReportSummary[] => {
+      const reportType = tag[2];
+      if (
+        (tag[0] !== "e" && tag[0] !== "p" && tag[0] !== "x") ||
+        !tag[1] ||
+        !isReportType(reportType)
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          id: `${event.id}:${tag[0]}:${tag[1]}`,
+          reporterPubkey: event.pubkey,
+          targetKind:
+            tag[0] === "e" ? "listing" : tag[0] === "p" ? "profile" : "blob",
+          targetId: tag[1],
+          reportType,
+          isOwnReport,
+          isTrustedReport,
+        },
+      ];
+    });
+  });
+}
+
+export function getListingReportSignal(
+  product: ProductData,
+  summaries: ReportSummary[]
+): ReportModerationSignal {
+  const listingSummaries = summaries.filter(
+    (summary) =>
+      summary.targetKind === "listing" && summary.targetId === product.id
+  );
+
+  return buildSignal(listingSummaries);
+}
+
+export function getProfileReportSignal(
+  pubkey: string | undefined,
+  summaries: ReportSummary[]
+): ReportModerationSignal {
+  if (!pubkey) return EMPTY_REPORT_MODERATION_SIGNAL;
+
+  const profileSummaries = summaries.filter(
+    (summary) => summary.targetKind === "profile" && summary.targetId === pubkey
+  );
+
+  return buildSignal(profileSummaries);
+}


### PR DESCRIPTION
Adds partial NIP-56 marketplace moderation: own/trusted listing report badges, blur-on-threshold, and storefront profile report warnings.

Updates partial NIP-50 product search to query selected relays before curated fallback search relays.