### PR TITLE
refactor: extract relay config from nostr-helper-functions into dedicated module

### DIFF
--- a/mcp/tools/write-tools.ts
+++ b/mcp/tools/write-tools.ts
@@ -23,6 +23,7 @@ import {
   buildSignedHttpRequestProofTemplate,
   SIGNED_EVENT_HEADER,
 } from "@/utils/nostr/request-auth";
+import { getDefaultRelays, withBlastr } from "@/utils/nostr/relay-config";
 
 const resolveCname = promisify(dns.resolveCname);
 const resolve4 = promisify(dns.resolve4);
@@ -1402,9 +1403,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
         } = await import("nostr-tools");
 
         const senderPubkey = signer.getPubKey();
-        const { getDefaultRelays, withBlastr } =
-          await import("@/utils/nostr/nostr-helper-functions");
-
         const defaultRelays = getDefaultRelays();
         const relayHint = defaultRelays[0] || "wss://relay.damus.io";
 
@@ -1606,8 +1604,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
           await import("nostr-tools");
 
         const senderPubkey = signer.getPubKey();
-        const { getDefaultRelays, withBlastr } =
-          await import("@/utils/nostr/nostr-helper-functions");
         const defaultRelays = getDefaultRelays();
 
         const innerEvent = {
@@ -1759,8 +1755,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
 
         const { generateSecretKey, finalizeEvent, getEventHash, nip44 } =
           await import("nostr-tools");
-        const { getDefaultRelays, withBlastr } =
-          await import("@/utils/nostr/nostr-helper-functions");
 
         const senderPubkey = signer.getPubKey();
         const defaultRelays = getDefaultRelays();
@@ -1991,8 +1985,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
           try {
             const { generateSecretKey, finalizeEvent, getEventHash, nip44 } =
               await import("nostr-tools");
-            const { getDefaultRelays, withBlastr } =
-              await import("@/utils/nostr/nostr-helper-functions");
 
             const senderPubkey = signer.getPubKey();
             const defaultRelays = getDefaultRelays();
@@ -2729,9 +2721,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
         });
         const encryptedContent = signer.encrypt(pubkey, proofData);
 
-        const { getDefaultRelays, withBlastr } =
-          await import("@/utils/nostr/nostr-helper-functions");
-
         const relays = withBlastr(getDefaultRelays());
         const tags: string[][] = [["mint", mintUrl]];
         for (const relay of relays) {
@@ -2789,9 +2778,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
           pubkey,
           JSON.stringify(mintTags)
         );
-
-        const { getDefaultRelays, withBlastr } =
-          await import("@/utils/nostr/nostr-helper-functions");
 
         const relays = withBlastr(getDefaultRelays());
         const tags: string[][] = [["d", pubkey]];

--- a/utils/mcp/__tests__/relay-allowlist.test.ts
+++ b/utils/mcp/__tests__/relay-allowlist.test.ts
@@ -13,20 +13,6 @@ jest.mock("nostr-tools", () => ({
   },
 }));
 
-jest.mock("@/utils/nostr/nostr-helper-functions", () => ({
-  getDefaultRelays: jest.fn(() => [
-    "wss://relay.damus.io",
-    "wss://nos.lol",
-    "wss://purplepag.es",
-    "wss://relay.primal.net",
-    "wss://relay.nostr.band",
-  ]),
-  withBlastr: jest.fn((relays: string[]) => [
-    ...relays,
-    "wss://sendit.nosflare.com",
-  ]),
-}));
-
 jest.mock("@/utils/db/db-service", () => ({ cacheEvent: jest.fn() }));
 
 import { McpRelayManager, MCP_RELAY_ALLOWLIST } from "../nostr-signing";

--- a/utils/mcp/nostr-signing.ts
+++ b/utils/mcp/nostr-signing.ts
@@ -15,10 +15,7 @@ import {
 } from "crypto";
 import { NostrEvent } from "@/utils/types/types";
 import { cacheEvent } from "@/utils/db/db-service";
-import {
-  getDefaultRelays,
-  withBlastr,
-} from "@/utils/nostr/nostr-helper-functions";
+import { getDefaultRelays, withBlastr } from "@/utils/nostr/relay-config";
 
 const ALGORITHM = "aes-256-gcm";
 

--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -31,6 +31,8 @@ import {
 import { newPromiseWithTimeout } from "@/utils/timeout";
 import { getLocalStorageJson } from "@/utils/safe-json";
 import { buildWalletConfigV1 } from "@/utils/cashu/wallet-config";
+import { getDefaultRelays, withBlastr } from "./relay-config";
+export { getDefaultRelays, withBlastr };
 
 export const REPORT_TYPES = [
   "nudity",
@@ -43,10 +45,6 @@ export const REPORT_TYPES = [
 ] as const;
 
 export type ReportType = (typeof REPORT_TYPES)[number];
-
-function containsRelay(relays: string[], relay: string): boolean {
-  return relays.some((r) => r.includes(relay));
-}
 
 function generateRandomTimestamp(): number {
   const now = Math.floor(Date.now() / 1000);
@@ -1770,26 +1768,6 @@ export function nostrExtensionLoaded() {
     return false;
   }
   return true;
-}
-
-export function getDefaultRelays(): string[] {
-  return [
-    "wss://relay.damus.io",
-    "wss://nos.lol",
-    "wss://purplepag.es",
-    "wss://relay.primal.net",
-    "wss://relay.nostr.band",
-  ];
-}
-
-export function withBlastr(relays: string[]): string[] {
-  const out = [...relays];
-
-  const blastrRelay = "wss://sendit.nosflare.com";
-  if (!containsRelay(out, blastrRelay)) {
-    out.push(blastrRelay);
-  }
-  return out;
 }
 
 export function getDefaultMint(): string {

--- a/utils/nostr/relay-config.ts
+++ b/utils/nostr/relay-config.ts
@@ -1,0 +1,23 @@
+function containsRelay(relays: string[], relay: string): boolean {
+  return relays.some((r) => r.includes(relay));
+}
+
+export function getDefaultRelays(): string[] {
+  return [
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+    "wss://purplepag.es",
+    "wss://relay.primal.net",
+    "wss://relay.nostr.band",
+  ];
+}
+
+export function withBlastr(relays: string[]): string[] {
+  const out = [...relays];
+
+  const blastrRelay = "wss://sendit.nosflare.com";
+  if (!containsRelay(out, blastrRelay)) {
+    out.push(blastrRelay);
+  }
+  return out;
+}


### PR DESCRIPTION
### Description

Extracts the relay configuration utilities (getDefaultRelays, withBlastr, containsRelay) from the 1908-line god-module nostr-helper-functions.ts into a focused relay-config.ts module. Breaks the tight coupling chain where nostr-signing.ts and write-tools.ts imported from the god-object.

### Changes

- **New**: utils/nostr/relay-config.ts — houses containsRelay (private), getDefaultRelays(), withBlastr()
- **Changed**: utils/nostr/nostr-helper-functions.ts — removed the three functions; added import + re-export for backward compatibility
- **Changed**: utils/mcp/nostr-signing.ts — imports directly from ./relay-config instead of ./nostr-helper-functions
- **Changed**: mcp/tools/write-tools.ts — replaced 6 dynamic await import(...) blocks with a single static top-level import

### Verification

- tsc --noEmit — zero errors
- npm run test:ci — 131 suites, 1520 tests passed, 18 skipped (all passing)
