### PR TITLE
test(parsers): 100% coverage for nip98-auth and request-auth

### DIFF
--- a/utils/nostr/__tests__/nip98-auth.test.ts
+++ b/utils/nostr/__tests__/nip98-auth.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import CryptoJS from "crypto-js";
 
 const verifyEventMock = jest.fn();
@@ -27,9 +31,10 @@ describe("verifyNip98Request", () => {
     verifyEventMock.mockReturnValue(true);
   });
 
-  it("creates NIP-98 authorization headers in the Node runtime", async () => {
-    const originalBtoa = (globalThis as any).btoa;
-    delete (globalThis as any).btoa;
+  it("creates UTF-8 NIP-98 authorization headers in the Node runtime", async () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    delete (globalThis as { window?: unknown }).window;
+    const url = "http://localhost:3000/api/db/update-order-status?note=€";
 
     const signer = {
       sign: jest.fn().mockResolvedValue({
@@ -38,7 +43,7 @@ describe("verifyNip98Request", () => {
         kind: 27235,
         created_at: 1710000000,
         tags: [
-          ["u", "http://localhost:3000/api/db/update-order-status"],
+          ["u", url],
           ["method", "POST"],
         ],
         content: "",
@@ -47,18 +52,14 @@ describe("verifyNip98Request", () => {
     } as any;
 
     try {
-      const header = await createNip98AuthorizationHeader(
-        signer,
-        "http://localhost:3000/api/db/update-order-status",
-        "post"
-      );
+      const header = await createNip98AuthorizationHeader(signer, url, "post");
 
       expect(signer.sign).toHaveBeenCalledWith(
         expect.objectContaining({
           kind: 27235,
           content: "",
           tags: [
-            ["u", "http://localhost:3000/api/db/update-order-status"],
+            ["u", url],
             ["method", "POST"],
           ],
         })
@@ -73,12 +74,12 @@ describe("verifyNip98Request", () => {
         pubkey: "f".repeat(64),
         kind: 27235,
         tags: [
-          ["u", "http://localhost:3000/api/db/update-order-status"],
+          ["u", url],
           ["method", "POST"],
         ],
       });
     } finally {
-      (globalThis as any).btoa = originalBtoa;
+      (globalThis as { window?: unknown }).window = originalWindow;
     }
   });
 

--- a/utils/nostr/__tests__/nip98-auth.test.ts
+++ b/utils/nostr/__tests__/nip98-auth.test.ts
@@ -10,7 +10,10 @@ jest.mock("nostr-tools", () => {
   };
 });
 
-import { verifyNip98Request } from "@/utils/nostr/nip98-auth";
+import {
+  createNip98AuthorizationHeader,
+  verifyNip98Request,
+} from "@/utils/nostr/nip98-auth";
 
 function buildAuthHeader(event: Record<string, unknown>): string {
   return `Nostr ${Buffer.from(JSON.stringify(event), "utf-8").toString(
@@ -22,6 +25,120 @@ describe("verifyNip98Request", () => {
   beforeEach(() => {
     verifyEventMock.mockReset();
     verifyEventMock.mockReturnValue(true);
+  });
+
+  it("creates NIP-98 authorization headers in the Node runtime", async () => {
+    const originalBtoa = (globalThis as any).btoa;
+    delete (globalThis as any).btoa;
+
+    const signer = {
+      sign: jest.fn().mockResolvedValue({
+        id: "auth-event-1",
+        pubkey: "f".repeat(64),
+        kind: 27235,
+        created_at: 1710000000,
+        tags: [
+          ["u", "http://localhost:3000/api/db/update-order-status"],
+          ["method", "POST"],
+        ],
+        content: "",
+        sig: "valid",
+      }),
+    } as any;
+
+    try {
+      const header = await createNip98AuthorizationHeader(
+        signer,
+        "http://localhost:3000/api/db/update-order-status",
+        "post"
+      );
+
+      expect(signer.sign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 27235,
+          content: "",
+          tags: [
+            ["u", "http://localhost:3000/api/db/update-order-status"],
+            ["method", "POST"],
+          ],
+        })
+      );
+
+      expect(header.startsWith("Nostr ")).toBe(true);
+      const decoded = JSON.parse(
+        Buffer.from(header.substring(6), "base64").toString("utf-8")
+      );
+      expect(decoded).toMatchObject({
+        id: "auth-event-1",
+        pubkey: "f".repeat(64),
+        kind: 27235,
+        tags: [
+          ["u", "http://localhost:3000/api/db/update-order-status"],
+          ["method", "POST"],
+        ],
+      });
+    } finally {
+      (globalThis as any).btoa = originalBtoa;
+    }
+  });
+
+  it("creates NIP-98 authorization headers with payloads in the browser runtime", async () => {
+    const originalWindow = (globalThis as any).window;
+    const originalBtoa = (globalThis as any).btoa;
+    (globalThis as any).window = {};
+    (globalThis as any).btoa = jest.fn().mockReturnValue("browser-base64");
+
+    const signer = {
+      sign: jest.fn().mockResolvedValue({
+        id: "auth-event-2",
+        pubkey: "f".repeat(64),
+        kind: 27235,
+        created_at: 1710000000,
+        tags: [
+          ["u", "https://localhost:3000/api/db/update-order-status"],
+          ["method", "POST"],
+          [
+            "payload",
+            CryptoJS.SHA256('{"orderId":"o1"}').toString(CryptoJS.enc.Hex),
+          ],
+        ],
+        content: "",
+        sig: "valid",
+      }),
+    } as any;
+
+    try {
+      const header = await createNip98AuthorizationHeader(
+        signer,
+        "https://localhost:3000/api/db/update-order-status",
+        "POST",
+        JSON.stringify({ orderId: "o1" })
+      );
+
+      expect((globalThis as any).btoa).toHaveBeenCalledTimes(1);
+      expect(header).toBe("Nostr browser-base64");
+      expect(signer.sign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 27235,
+          content: "",
+          tags: [
+            ["u", "https://localhost:3000/api/db/update-order-status"],
+            ["method", "POST"],
+            [
+              "payload",
+              CryptoJS.SHA256('{"orderId":"o1"}').toString(CryptoJS.enc.Hex),
+            ],
+          ],
+        })
+      );
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = originalWindow;
+      }
+      (globalThis as any).btoa = originalBtoa;
+    }
   });
 
   it("rejects missing authorization headers", async () => {
@@ -37,6 +154,52 @@ describe("verifyNip98Request", () => {
     ).resolves.toEqual({
       ok: false,
       error: "Missing NIP-98 authorization header",
+    });
+  });
+
+  it("rejects malformed authorization payloads", async () => {
+    const req = {
+      headers: {
+        host: "localhost:3000",
+        authorization: `Nostr ${Buffer.from("not-json", "utf-8").toString(
+          "base64"
+        )}`,
+      },
+      url: "/api/db/update-order-status",
+    } as any;
+
+    await expect(
+      verifyNip98Request(req, "POST", { orderId: "o1" })
+    ).resolves.toEqual({
+      ok: false,
+      error: "Malformed NIP-98 authorization",
+    });
+  });
+
+  it("rejects invalid authorization event kinds", async () => {
+    const req = {
+      headers: {
+        host: "localhost:3000",
+        authorization: buildAuthHeader({
+          pubkey: "f".repeat(64),
+          kind: 1,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [
+            ["u", "http://localhost:3000/api/db/update-order-status"],
+            ["method", "POST"],
+          ],
+          content: "",
+          sig: "valid",
+        }),
+      },
+      url: "/api/db/update-order-status",
+    } as any;
+
+    await expect(
+      verifyNip98Request(req, "POST", { orderId: "o1" })
+    ).resolves.toEqual({
+      ok: false,
+      error: "Invalid authorization event kind",
     });
   });
 
@@ -93,6 +256,60 @@ describe("verifyNip98Request", () => {
     ).resolves.toEqual({
       ok: false,
       error: "Authorization URL mismatch",
+    });
+  });
+
+  it("rejects method mismatches", async () => {
+    const req = {
+      headers: {
+        host: "localhost:3000",
+        authorization: buildAuthHeader({
+          pubkey: "f".repeat(64),
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [
+            ["u", "http://localhost:3000/api/db/update-order-status"],
+            ["method", "GET"],
+          ],
+          content: "",
+          sig: "valid",
+        }),
+      },
+      url: "/api/db/update-order-status",
+    } as any;
+
+    await expect(
+      verifyNip98Request(req, "POST", { orderId: "o1" })
+    ).resolves.toEqual({
+      ok: false,
+      error: "Authorization method mismatch",
+    });
+  });
+
+  it("rejects expired authorization events", async () => {
+    const req = {
+      headers: {
+        host: "localhost:3000",
+        authorization: buildAuthHeader({
+          pubkey: "f".repeat(64),
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000) - 999,
+          tags: [
+            ["u", "http://localhost:3000/api/db/update-order-status"],
+            ["method", "POST"],
+          ],
+          content: "",
+          sig: "valid",
+        }),
+      },
+      url: "/api/db/update-order-status",
+    } as any;
+
+    await expect(
+      verifyNip98Request(req, "POST", { orderId: "o1" })
+    ).resolves.toEqual({
+      ok: false,
+      error: "Authorization event expired",
     });
   });
 
@@ -157,11 +374,33 @@ describe("verifyNip98Request", () => {
     });
   });
 
-  it("accepts valid signed authorization events", async () => {
-    const body = JSON.stringify({
-      orderId: "order-1",
-      status: "confirmed",
+  it("accepts GET requests without a payload hash", async () => {
+    const req = {
+      headers: {
+        host: "localhost:3000",
+        authorization: buildAuthHeader({
+          pubkey: "f".repeat(64),
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [
+            ["u", "http://localhost:3000/api/db/update-order-status"],
+            ["method", "GET"],
+          ],
+          content: "",
+          sig: "valid",
+        }),
+      },
+      url: "/api/db/update-order-status",
+    } as any;
+
+    await expect(verifyNip98Request(req, "GET")).resolves.toEqual({
+      ok: true,
+      pubkey: "f".repeat(64),
     });
+  });
+
+  it("accepts string request bodies when the payload hash matches", async () => {
+    const body = JSON.stringify({ orderId: "order-1", status: "confirmed" });
     const payloadHash = CryptoJS.SHA256(body).toString(CryptoJS.enc.Hex);
 
     const req = {
@@ -173,6 +412,40 @@ describe("verifyNip98Request", () => {
           created_at: Math.floor(Date.now() / 1000),
           tags: [
             ["u", "http://localhost:3000/api/db/update-order-status"],
+            ["method", "POST"],
+            ["payload", payloadHash],
+          ],
+          content: "",
+          sig: "valid",
+        }),
+      },
+      url: "/api/db/update-order-status",
+      body,
+    } as any;
+
+    await expect(verifyNip98Request(req, "POST")).resolves.toEqual({
+      ok: true,
+      pubkey: "f".repeat(64),
+    });
+  });
+
+  it("accepts valid signed authorization events", async () => {
+    const body = JSON.stringify({
+      orderId: "order-1",
+      status: "confirmed",
+    });
+    const payloadHash = CryptoJS.SHA256(body).toString(CryptoJS.enc.Hex);
+
+    const req = {
+      headers: {
+        "x-forwarded-proto": ["https"],
+        host: "localhost:3000",
+        authorization: buildAuthHeader({
+          pubkey: "f".repeat(64),
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [
+            ["u", "https://localhost:3000/api/db/update-order-status"],
             ["method", "POST"],
             ["payload", payloadHash],
           ],

--- a/utils/nostr/__tests__/request-auth.test.ts
+++ b/utils/nostr/__tests__/request-auth.test.ts
@@ -9,8 +9,26 @@ jest.mock("nostr-tools", () => {
 });
 
 import {
+  SIGNED_EVENT_HEADER,
+  SIGNED_HTTP_REQUEST_KIND,
+  SIGNED_HTTP_REQUEST_MAX_AGE_SECONDS,
+  buildClearFailedRelayPublishProof,
+  buildCustomDomainCreateProof,
+  buildCustomDomainDeleteProof,
+  buildDeleteCachedEventsProof,
   buildDiscountCodeCreateProof,
+  buildDiscountCodeDeleteProof,
+  buildDiscountCodesListProof,
+  buildListFailedRelayPublishesProof,
+  buildMessagesListProof,
   buildSignedHttpRequestProofTemplate,
+  buildStorefrontSlugCreateProof,
+  buildStorefrontSlugDeleteProof,
+  buildTrackFailedRelayPublishProof,
+  extractSignedEventFromRequest,
+  isSignedHttpRequestFresh,
+  matchesSignedHttpRequestProof,
+  parseSignedEventHeader,
   verifySignedHttpRequestProof,
 } from "@/utils/nostr/request-auth";
 
@@ -18,6 +36,275 @@ describe("verifySignedHttpRequestProof", () => {
   beforeEach(() => {
     verifyEventMock.mockReset();
     verifyEventMock.mockReturnValue(true);
+  });
+
+  it("builds sorted proof templates and skips empty field values", () => {
+    const proof = {
+      action: "create_discount_code",
+      method: "POST" as const,
+      path: "/api/db/discount-codes",
+      pubkey: "f".repeat(64),
+      fields: {
+        zeta: "last",
+        alpha: "first",
+        empty: "",
+        nil: null,
+        missing: undefined,
+        count: 3,
+      },
+    };
+
+    const template = buildSignedHttpRequestProofTemplate(proof as any);
+
+    expect(template.kind).toBe(SIGNED_HTTP_REQUEST_KIND);
+    expect(template.content).toBe("");
+    expect(template.tags).toEqual([
+      ["action", "create_discount_code"],
+      ["method", "POST"],
+      ["path", "/api/db/discount-codes"],
+      ["pubkey", "f".repeat(64)],
+      ["alpha", "first"],
+      ["count", "3"],
+      ["zeta", "last"],
+    ]);
+  });
+
+  it("builds proof templates without fields", () => {
+    const template = buildSignedHttpRequestProofTemplate({
+      action: "list_discount_codes",
+      method: "GET",
+      path: "/api/db/discount-codes",
+      pubkey: "f".repeat(64),
+    } as any);
+
+    expect(template.tags).toEqual([
+      ["action", "list_discount_codes"],
+      ["method", "GET"],
+      ["path", "/api/db/discount-codes"],
+      ["pubkey", "f".repeat(64)],
+    ]);
+  });
+
+  it("parses signed event headers and extracts signed events from requests", () => {
+    const event = {
+      id: "event-1",
+      kind: SIGNED_HTTP_REQUEST_KIND,
+      pubkey: "f".repeat(64),
+    };
+
+    expect(parseSignedEventHeader(JSON.stringify(event))).toEqual(event);
+    expect(parseSignedEventHeader("not-json")).toBeNull();
+
+    expect(
+      extractSignedEventFromRequest({
+        headers: {
+          [SIGNED_EVENT_HEADER]: JSON.stringify(event),
+        },
+      } as any)
+    ).toEqual(event);
+
+    expect(
+      extractSignedEventFromRequest({
+        headers: {
+          [SIGNED_EVENT_HEADER]: [JSON.stringify(event), "ignored"],
+        },
+      } as any)
+    ).toEqual(event);
+
+    expect(
+      extractSignedEventFromRequest({
+        headers: {
+          [SIGNED_EVENT_HEADER]: 123,
+        },
+      } as any)
+    ).toBeUndefined();
+
+    expect(
+      extractSignedEventFromRequest({
+        headers: {
+          [SIGNED_EVENT_HEADER]: "not-json",
+        },
+      } as any)
+    ).toBeUndefined();
+  });
+
+  it("matches and rejects signed request proofs by event shape", () => {
+    const proof = buildDiscountCodeCreateProof({
+      code: "SUMMER20",
+      pubkey: "f".repeat(64),
+      discountPercentage: 20,
+    });
+    const template = buildSignedHttpRequestProofTemplate(proof);
+    const matchingEvent = {
+      id: "proof-1",
+      pubkey: proof.pubkey,
+      kind: template.kind,
+      created_at: template.created_at,
+      tags: template.tags,
+      content: "",
+      sig: "valid",
+    } as any;
+
+    expect(matchesSignedHttpRequestProof(matchingEvent, proof)).toBe(true);
+    expect(
+      matchesSignedHttpRequestProof({ ...matchingEvent, kind: 1 }, proof)
+    ).toBe(false);
+    expect(
+      matchesSignedHttpRequestProof({ ...matchingEvent, content: "x" }, proof)
+    ).toBe(false);
+    expect(
+      matchesSignedHttpRequestProof(
+        {
+          ...matchingEvent,
+          tags: template.tags.filter(([tagName]) => tagName !== "action"),
+        },
+        proof
+      )
+    ).toBe(false);
+  });
+
+  it("checks signed request freshness at the configured boundary", () => {
+    const createdAt = 1_000;
+    expect(
+      isSignedHttpRequestFresh({ created_at: createdAt } as any, createdAt)
+    ).toBe(true);
+    expect(
+      isSignedHttpRequestFresh(
+        {
+          created_at: createdAt - SIGNED_HTTP_REQUEST_MAX_AGE_SECONDS - 1,
+        } as any,
+        createdAt
+      )
+    ).toBe(false);
+  });
+
+  it("builds the remaining proof templates", () => {
+    expect(buildDiscountCodesListProof("f".repeat(64))).toEqual({
+      action: "list_discount_codes",
+      method: "GET",
+      path: "/api/db/discount-codes",
+      pubkey: "f".repeat(64),
+    });
+
+    expect(buildMessagesListProof("f".repeat(64))).toEqual({
+      action: "list_messages",
+      method: "GET",
+      path: "/api/db/fetch-messages",
+      pubkey: "f".repeat(64),
+    });
+
+    expect(
+      buildDiscountCodeDeleteProof({
+        code: "SUMMER20",
+        pubkey: "f".repeat(64),
+      })
+    ).toEqual({
+      action: "delete_discount_code",
+      method: "DELETE",
+      path: "/api/db/discount-codes",
+      pubkey: "f".repeat(64),
+      fields: { code: "SUMMER20" },
+    });
+
+    expect(
+      buildDeleteCachedEventsProof({
+        pubkey: "f".repeat(64),
+        eventIds: ["event-c", "event-a", "event-b"],
+      })
+    ).toEqual({
+      action: "delete_cached_events",
+      method: "POST",
+      path: "/api/db/delete-events",
+      pubkey: "f".repeat(64),
+      fields: { eventIds: "event-a,event-b,event-c" },
+    });
+
+    expect(
+      buildStorefrontSlugCreateProof({
+        pubkey: "f".repeat(64),
+        slug: "my-shop",
+      })
+    ).toEqual({
+      action: "register_storefront_slug",
+      method: "POST",
+      path: "/api/storefront/register-slug",
+      pubkey: "f".repeat(64),
+      fields: { slug: "my-shop" },
+    });
+
+    expect(buildStorefrontSlugDeleteProof("f".repeat(64))).toEqual({
+      action: "delete_storefront_slug",
+      method: "DELETE",
+      path: "/api/storefront/register-slug",
+      pubkey: "f".repeat(64),
+    });
+
+    expect(
+      buildCustomDomainCreateProof({
+        pubkey: "f".repeat(64),
+        domain: "shop.example",
+      })
+    ).toEqual({
+      action: "set_storefront_custom_domain",
+      method: "POST",
+      path: "/api/storefront/custom-domain",
+      pubkey: "f".repeat(64),
+      fields: { domain: "shop.example" },
+    });
+
+    expect(buildCustomDomainDeleteProof("f".repeat(64))).toEqual({
+      action: "delete_storefront_custom_domain",
+      method: "DELETE",
+      path: "/api/storefront/custom-domain",
+      pubkey: "f".repeat(64),
+    });
+
+    expect(
+      buildTrackFailedRelayPublishProof({
+        pubkey: "f".repeat(64),
+        eventId: "event-1",
+      })
+    ).toEqual({
+      action: "track_failed_relay_publish",
+      method: "POST",
+      path: "/api/db/track-failed-publish",
+      pubkey: "f".repeat(64),
+      fields: { eventId: "event-1" },
+    });
+
+    expect(buildListFailedRelayPublishesProof("f".repeat(64))).toEqual({
+      action: "list_failed_relay_publishes",
+      method: "GET",
+      path: "/api/db/get-failed-publishes",
+      pubkey: "f".repeat(64),
+    });
+
+    expect(
+      buildClearFailedRelayPublishProof({
+        pubkey: "f".repeat(64),
+        eventId: "event-1",
+      })
+    ).toEqual({
+      action: "clear_failed_relay_publish",
+      method: "POST",
+      path: "/api/db/clear-failed-publish",
+      pubkey: "f".repeat(64),
+      fields: { eventId: "event-1" },
+    });
+
+    expect(
+      buildClearFailedRelayPublishProof({
+        pubkey: "f".repeat(64),
+        eventId: "event-1",
+        incrementRetry: true,
+      })
+    ).toEqual({
+      action: "increment_failed_relay_publish_retry",
+      method: "POST",
+      path: "/api/db/clear-failed-publish",
+      pubkey: "f".repeat(64),
+      fields: { eventId: "event-1", incrementRetry: "true" },
+    });
   });
 
   it("rejects missing signed proofs", () => {

--- a/utils/nostr/nip98-auth.ts
+++ b/utils/nostr/nip98-auth.ts
@@ -22,11 +22,16 @@ function sha256Hex(value: string): string {
 }
 
 function toBase64(value: string): string {
-  if (typeof btoa === "function") {
-    return btoa(value);
+  if (typeof window === "undefined") {
+    return Buffer.from(value, "utf-8").toString("base64");
   }
 
-  return Buffer.from(value, "utf-8").toString("base64");
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
 }
 
 function fromBase64(value: string): string {

--- a/utils/nostr/nip98-auth.ts
+++ b/utils/nostr/nip98-auth.ts
@@ -22,11 +22,11 @@ function sha256Hex(value: string): string {
 }
 
 function toBase64(value: string): string {
-  if (typeof window === "undefined") {
-    return Buffer.from(value, "utf-8").toString("base64");
+  if (typeof btoa === "function") {
+    return btoa(value);
   }
 
-  return btoa(value);
+  return Buffer.from(value, "utf-8").toString("base64");
 }
 
 function fromBase64(value: string): string {


### PR DESCRIPTION
### Description
- Improved the coverage for nip98-auth and request-auth.    

### Resolved or fixed issue
`none`  

### Screenshots (if applicable)  
Add screenshots or examples if this PR includes UI-related changes.  

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

### For more details on what to include, see:

[Bug Report Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
[Feature Request Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/feature_request.md)
[Documentation Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/documentation_improvement.md)
[Security Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/security_vulnerability.md)