### PR TITLE
refactor: extract duplicated NIP-17 gift-wrap logic into shared module

### DIFF
--- a/mcp/tools/write-tools.ts
+++ b/mcp/tools/write-tools.ts
@@ -6,7 +6,7 @@ import {
   signAndPublishEvent,
 } from "@/utils/mcp/nostr-signing";
 import { ApiKeyRecord, getAgentSigner } from "@/utils/mcp/auth";
-import { EventTemplate } from "nostr-tools";
+import { EventTemplate, getEventHash } from "nostr-tools";
 import { cacheEvent, getDbPool } from "@/utils/db/db-service";
 import { v4 as uuidv4 } from "uuid";
 import dns from "dns";
@@ -24,6 +24,7 @@ import {
   SIGNED_EVENT_HEADER,
 } from "@/utils/nostr/request-auth";
 import { getDefaultRelays, withBlastr } from "@/utils/nostr/relay-config";
+import { createGiftWrapEvent } from "@/utils/nostr/gift-wrap";
 
 const resolveCname = promisify(dns.resolveCname);
 const resolve4 = promisify(dns.resolve4);
@@ -1394,14 +1395,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
       if (!signer) return noSignerError();
 
       try {
-        const {
-          generateSecretKey,
-          getPublicKey,
-          finalizeEvent,
-          getEventHash,
-          nip44,
-        } = await import("nostr-tools");
-
         const senderPubkey = signer.getPubKey();
         const defaultRelays = getDefaultRelays();
         const relayHint = defaultRelays[0] || "wss://relay.damus.io";
@@ -1442,86 +1435,18 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
         const innerEventId = getEventHash(innerEventForHash as any);
         const fullInnerEvent = { id: innerEventId, ...innerEvent };
 
-        const randomPrivKey = generateSecretKey();
-        const randomPubKey = getPublicKey(randomPrivKey);
+        const stringifiedInner = JSON.stringify(fullInnerEvent);
 
-        async function createGiftWrap(
-          targetPubkey: string,
-          sealPubkey: string,
-          useRandomKey: boolean
-        ) {
-          const stringifiedInner = JSON.stringify(fullInnerEvent);
-          let encryptedSealContent: string;
-
-          if (useRandomKey) {
-            const conversationKey = nip44.getConversationKey(
-              randomPrivKey,
-              targetPubkey
-            );
-            encryptedSealContent = nip44.encrypt(
-              stringifiedInner,
-              conversationKey
-            );
-          } else {
-            encryptedSealContent = signer!.encrypt(
-              targetPubkey,
-              stringifiedInner
-            );
-          }
-
-          const now = Math.floor(Date.now() / 1000);
-          const randomOffset = Math.floor(Math.random() * 172800);
-          const sealTimestamp = now - randomOffset;
-
-          const sealEvent = {
-            pubkey: sealPubkey,
-            created_at: sealTimestamp,
-            content: encryptedSealContent,
-            kind: 13,
-            tags: [] as string[][],
-          };
-
-          let signedSeal;
-          if (useRandomKey) {
-            signedSeal = finalizeEvent(sealEvent, randomPrivKey);
-          } else {
-            signedSeal = signer!.sign(sealEvent);
-          }
-
-          const wrapPrivKey = generateSecretKey();
-          const wrapPubKey = getPublicKey(wrapPrivKey);
-
-          const stringifiedSeal = JSON.stringify(signedSeal);
-          const wrapConversationKey = nip44.getConversationKey(
-            wrapPrivKey,
-            targetPubkey
-          );
-          const encryptedWrap = nip44.encrypt(
-            stringifiedSeal,
-            wrapConversationKey
-          );
-
-          const wrapTimestamp = now - Math.floor(Math.random() * 172800);
-          const giftWrapEvent = {
-            pubkey: wrapPubKey,
-            created_at: wrapTimestamp,
-            content: encryptedWrap,
-            kind: 1059,
-            tags: [["p", targetPubkey, relayHint]],
-          };
-
-          return finalizeEvent(giftWrapEvent, wrapPrivKey);
-        }
-
-        const recipientWrap = await createGiftWrap(
+        const recipientWrap = await createGiftWrapEvent(
+          stringifiedInner,
           params.recipientPubkey,
-          senderPubkey,
-          false
+          { signer, relayHint }
         );
-        const senderWrap = await createGiftWrap(
+
+        const senderWrap = await createGiftWrapEvent(
+          stringifiedInner,
           senderPubkey,
-          randomPubKey,
-          true
+          { relayHint }
         );
 
         const relayManager = new McpRelayManager(withBlastr(defaultRelays));
@@ -1600,9 +1525,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
           (params.productTitle ? ` (${params.productTitle})` : "") +
           `\n\nNew Address: ${params.newAddress}`;
 
-        const { generateSecretKey, finalizeEvent, getEventHash, nip44 } =
-          await import("nostr-tools");
-
         const senderPubkey = signer.getPubKey();
         const defaultRelays = getDefaultRelays();
 
@@ -1623,55 +1545,10 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
         const innerEventId = getEventHash(innerEventForHash as any);
         const fullInnerEvent = { id: innerEventId, ...innerEvent };
 
-        const randomPrivKey = generateSecretKey();
-
-        async function createAddressChangeWrap(targetPubkey: string) {
-          const stringifiedInner = JSON.stringify(fullInnerEvent);
-          const conversationKey = nip44.getConversationKey(
-            randomPrivKey,
-            targetPubkey
-          );
-          const encryptedSealContent = nip44.encrypt(
-            stringifiedInner,
-            conversationKey
-          );
-
-          const now = Math.floor(Date.now() / 1000);
-          const randomOffset = Math.floor(Math.random() * 172800);
-          const sealTimestamp = now - randomOffset;
-
-          const sealEvent = {
-            created_at: sealTimestamp,
-            kind: 13,
-            tags: [],
-            content: encryptedSealContent,
-          };
-
-          const signedSeal = finalizeEvent(sealEvent, randomPrivKey);
-
-          const wrapPrivKey = generateSecretKey();
-          const wrapConversationKey = nip44.getConversationKey(
-            wrapPrivKey,
-            targetPubkey
-          );
-          const wrapContent = nip44.encrypt(
-            JSON.stringify(signedSeal),
-            wrapConversationKey
-          );
-
-          const wrapTimestamp = now - Math.floor(Math.random() * 172800);
-
-          const wrapEvent = {
-            created_at: wrapTimestamp,
-            kind: 1059,
-            tags: [["p", targetPubkey]],
-            content: wrapContent,
-          };
-
-          return finalizeEvent(wrapEvent, wrapPrivKey);
-        }
-
-        const sellerWrap = await createAddressChangeWrap(params.sellerPubkey);
+        const sellerWrap = await createGiftWrapEvent(
+          JSON.stringify(fullInnerEvent),
+          params.sellerPubkey
+        );
 
         const relayManager = new McpRelayManager(withBlastr(defaultRelays));
 
@@ -1753,9 +1630,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
           );
         }
 
-        const { generateSecretKey, finalizeEvent, getEventHash, nip44 } =
-          await import("nostr-tools");
-
         const senderPubkey = signer.getPubKey();
         const defaultRelays = getDefaultRelays();
         const relayHint: string =
@@ -1809,50 +1683,10 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
         const innerEventId = getEventHash(innerEventForHash as any);
         const fullInnerEvent = { id: innerEventId, ...innerEvent };
 
-        const randomPrivKey = generateSecretKey();
-
-        async function createWrap(targetPubkey: string) {
-          const stringifiedInner = JSON.stringify(fullInnerEvent);
-          const conversationKey = nip44.getConversationKey(
-            randomPrivKey,
-            targetPubkey
-          );
-          const encryptedContent = nip44.encrypt(
-            stringifiedInner,
-            conversationKey
-          );
-
-          const now = Math.floor(Date.now() / 1000);
-          const sealEvent = {
-            created_at: now - Math.floor(Math.random() * 172800),
-            kind: 13,
-            tags: [],
-            content: encryptedContent,
-          };
-          const signedSeal = finalizeEvent(sealEvent, randomPrivKey);
-
-          const wrapPrivKey = generateSecretKey();
-          const wrapConversationKey = nip44.getConversationKey(
-            wrapPrivKey,
-            targetPubkey
-          );
-          const wrapContent = nip44.encrypt(
-            JSON.stringify(signedSeal),
-            wrapConversationKey
-          );
-
-          return finalizeEvent(
-            {
-              created_at: now - Math.floor(Math.random() * 172800),
-              kind: 1059,
-              tags: [["p", targetPubkey]],
-              content: wrapContent,
-            },
-            wrapPrivKey
-          );
-        }
-
-        const buyerWrap = await createWrap(order.buyer_pubkey);
+        const buyerWrap = await createGiftWrapEvent(
+          JSON.stringify(fullInnerEvent),
+          order.buyer_pubkey
+        );
 
         const relayManager = new McpRelayManager(withBlastr(defaultRelays));
 
@@ -1983,9 +1817,6 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
 
         if (params.buyerPubkey && params.message) {
           try {
-            const { generateSecretKey, finalizeEvent, getEventHash, nip44 } =
-              await import("nostr-tools");
-
             const senderPubkey = signer.getPubKey();
             const defaultRelays = getDefaultRelays();
             const relayHint: string =
@@ -2023,45 +1854,9 @@ export function registerWriteTools(server: McpServer, apiKey: ApiKeyRecord) {
             const innerEventId = getEventHash(innerEventForHash as any);
             const fullInnerEvent = { id: innerEventId, ...innerEvent };
 
-            const randomPrivKey = generateSecretKey();
-
-            const stringifiedInner = JSON.stringify(fullInnerEvent);
-            const conversationKey = nip44.getConversationKey(
-              randomPrivKey,
+            const wrapEvent = await createGiftWrapEvent(
+              JSON.stringify(fullInnerEvent),
               buyerPubkey
-            );
-            const encryptedContent = nip44.encrypt(
-              stringifiedInner,
-              conversationKey
-            );
-
-            const now = Math.floor(Date.now() / 1000);
-            const sealEvent = {
-              created_at: now - Math.floor(Math.random() * 172800),
-              kind: 13,
-              tags: [],
-              content: encryptedContent,
-            };
-            const signedSeal = finalizeEvent(sealEvent, randomPrivKey);
-
-            const wrapPrivKey = generateSecretKey();
-            const wrapConversationKey = nip44.getConversationKey(
-              wrapPrivKey,
-              buyerPubkey
-            );
-            const wrapContent = nip44.encrypt(
-              JSON.stringify(signedSeal),
-              wrapConversationKey
-            );
-
-            const wrapEvent = finalizeEvent(
-              {
-                created_at: now - Math.floor(Math.random() * 172800),
-                kind: 1059,
-                tags: [["p", buyerPubkey]],
-                content: wrapContent,
-              },
-              wrapPrivKey
             );
 
             const relayManager = new McpRelayManager(withBlastr(defaultRelays));

--- a/utils/nostr/__tests__/gift-wrap.test.ts
+++ b/utils/nostr/__tests__/gift-wrap.test.ts
@@ -1,0 +1,154 @@
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  nip44,
+  verifyEvent,
+} from "nostr-tools";
+import {
+  createGiftWrapEvent,
+  type GiftWrapSigner,
+} from "@/utils/nostr/gift-wrap";
+
+const TWO_DAYS_SECONDS = 2 * 24 * 60 * 60;
+
+function decryptGiftWrap(
+  giftWrap: Awaited<ReturnType<typeof createGiftWrapEvent>>,
+  recipientPrivKey: Uint8Array
+) {
+  const wrapConversationKey = nip44.getConversationKey(
+    recipientPrivKey,
+    giftWrap.pubkey
+  );
+  const seal = JSON.parse(nip44.decrypt(giftWrap.content, wrapConversationKey));
+  const sealConversationKey = nip44.getConversationKey(
+    recipientPrivKey,
+    seal.pubkey
+  );
+  const innerContent = nip44.decrypt(seal.content, sealConversationKey);
+
+  return { seal, innerContent };
+}
+
+function createSigner(privKey: Uint8Array): GiftWrapSigner {
+  return {
+    encrypt(pubkey, content) {
+      const conversationKey = nip44.getConversationKey(privKey, pubkey);
+      return nip44.encrypt(content, conversationKey);
+    },
+    sign(event) {
+      return finalizeEvent(event, privKey);
+    },
+  };
+}
+
+describe("createGiftWrapEvent", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates a valid, decryptable gift wrap with a random seal key", async () => {
+    const recipientPrivKey = generateSecretKey();
+    const recipientPubkey = getPublicKey(recipientPrivKey);
+    const innerContent = JSON.stringify({ kind: 14, content: "secret" });
+    const nowMs = 1_750_000_000_000;
+    const nowSeconds = Math.floor(nowMs / 1000);
+    const sealRandomOffset = 0.25;
+    const wrapRandomOffset = 0.75;
+    jest.spyOn(Date, "now").mockReturnValue(nowMs);
+    const randomSpy = jest
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(sealRandomOffset)
+      .mockReturnValueOnce(wrapRandomOffset);
+
+    const giftWrap = await createGiftWrapEvent(innerContent, recipientPubkey);
+    const { seal, innerContent: decryptedInnerContent } = decryptGiftWrap(
+      giftWrap,
+      recipientPrivKey
+    );
+
+    expect(verifyEvent(JSON.parse(JSON.stringify(giftWrap)))).toBe(true);
+    expect(verifyEvent(seal)).toBe(true);
+    expect(giftWrap.kind).toBe(1059);
+    expect(giftWrap.tags).toEqual([["p", recipientPubkey]]);
+    expect(seal.kind).toBe(13);
+    expect(seal.tags).toEqual([]);
+    expect(giftWrap.pubkey).not.toBe(seal.pubkey);
+    expect(decryptedInnerContent).toBe(innerContent);
+    expect(seal.created_at).toBe(
+      nowSeconds - Math.floor(sealRandomOffset * TWO_DAYS_SECONDS)
+    );
+    expect(giftWrap.created_at).toBe(
+      nowSeconds - Math.floor(wrapRandomOffset * TWO_DAYS_SECONDS)
+    );
+    expect(randomSpy).toHaveBeenCalledTimes(2);
+    expect(() => decryptGiftWrap(giftWrap, generateSecretKey())).toThrow();
+  });
+
+  it("uses the signer for the seal and includes a relay hint", async () => {
+    const senderPrivKey = generateSecretKey();
+    const recipientPrivKey = generateSecretKey();
+    const recipientPubkey = getPublicKey(recipientPrivKey);
+    const relayHint = "wss://relay.example.com";
+    const innerContent = "sender-authenticated rumor";
+
+    const giftWrap = await createGiftWrapEvent(innerContent, recipientPubkey, {
+      signer: createSigner(senderPrivKey),
+      relayHint,
+    });
+    const { seal, innerContent: decryptedInnerContent } = decryptGiftWrap(
+      giftWrap,
+      recipientPrivKey
+    );
+
+    expect(giftWrap.tags).toEqual([["p", recipientPubkey, relayHint]]);
+    expect(seal.pubkey).toBe(getPublicKey(senderPrivKey));
+    expect(giftWrap.pubkey).not.toBe(seal.pubkey);
+    expect(seal.kind).toBe(13);
+    expect(seal.tags).toEqual([]);
+    expect(verifyEvent(seal)).toBe(true);
+    expect(decryptedInnerContent).toBe(innerContent);
+  });
+
+  it("uses an injected random key for the seal", async () => {
+    const sealPrivKey = generateSecretKey();
+    const recipientPrivKey = generateSecretKey();
+    const recipientPubkey = getPublicKey(recipientPrivKey);
+
+    const giftWrap = await createGiftWrapEvent("rumor", recipientPubkey, {
+      randomPrivKey: sealPrivKey,
+    });
+    const { seal, innerContent } = decryptGiftWrap(giftWrap, recipientPrivKey);
+
+    expect(seal.pubkey).toBe(getPublicKey(sealPrivKey));
+    expect(giftWrap.pubkey).not.toBe(seal.pubkey);
+    expect(seal.kind).toBe(13);
+    expect(seal.tags).toEqual([]);
+    expect(verifyEvent(seal)).toBe(true);
+    expect(innerContent).toBe("rumor");
+  });
+
+  it("generates a fresh wrapper key for every gift wrap", async () => {
+    const recipientPubkey = getPublicKey(generateSecretKey());
+
+    const first = await createGiftWrapEvent("same rumor", recipientPubkey);
+    const second = await createGiftWrapEvent("same rumor", recipientPubkey);
+
+    expect(first.pubkey).not.toBe(second.pubkey);
+  });
+
+  it("rejects ambiguous seal signing options", async () => {
+    const randomPrivKey = generateSecretKey();
+    const signer = createSigner(generateSecretKey());
+    const recipientPubkey = getPublicKey(generateSecretKey());
+
+    await expect(
+      createGiftWrapEvent("rumor", recipientPubkey, {
+        randomPrivKey,
+        signer,
+      })
+    ).rejects.toThrow(
+      "createGiftWrapEvent: randomPrivKey and signer are mutually exclusive"
+    );
+  });
+});

--- a/utils/nostr/gift-wrap.ts
+++ b/utils/nostr/gift-wrap.ts
@@ -1,0 +1,105 @@
+import { finalizeEvent, generateSecretKey, nip44 } from "nostr-tools";
+import type { NostrEvent } from "@/utils/types/types";
+
+export type GiftWrapSigner = {
+  encrypt(pubkey: string, content: string): string | Promise<string>;
+  sign(event: {
+    kind: number;
+    tags: string[][];
+    content: string;
+    created_at: number;
+  }): NostrEvent | Promise<NostrEvent>;
+};
+
+export async function createGiftWrapEvent(
+  innerContent: string,
+  recipientPubkey: string,
+  options?: {
+    randomPrivKey?: Uint8Array;
+    signer?: GiftWrapSigner;
+    relayHint?: string;
+  }
+): Promise<NostrEvent> {
+  if (options?.randomPrivKey && options?.signer) {
+    throw new Error(
+      "createGiftWrapEvent: randomPrivKey and signer are mutually exclusive"
+    );
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  const sealTimestamp = now - Math.floor(Math.random() * 172800);
+  let encryptedSealContent: string;
+  let signedSeal: NostrEvent;
+
+  if (options?.randomPrivKey) {
+    const conversationKey = nip44.getConversationKey(
+      options.randomPrivKey,
+      recipientPubkey
+    );
+    encryptedSealContent = nip44.encrypt(innerContent, conversationKey);
+    signedSeal = finalizeEvent(
+      {
+        created_at: sealTimestamp,
+        content: encryptedSealContent,
+        kind: 13,
+        tags: [],
+      },
+      options.randomPrivKey
+    );
+  } else if (options?.signer) {
+    encryptedSealContent = await options.signer.encrypt(
+      recipientPubkey,
+      innerContent
+    );
+    signedSeal = await options.signer.sign({
+      kind: 13,
+      tags: [],
+      content: encryptedSealContent,
+      created_at: sealTimestamp,
+    });
+  } else {
+    const randomPrivKey = generateSecretKey();
+    const conversationKey = nip44.getConversationKey(
+      randomPrivKey,
+      recipientPubkey
+    );
+    encryptedSealContent = nip44.encrypt(innerContent, conversationKey);
+    signedSeal = finalizeEvent(
+      {
+        created_at: sealTimestamp,
+        content: encryptedSealContent,
+        kind: 13,
+        tags: [],
+      },
+      randomPrivKey
+    );
+  }
+
+  const wrapPrivKey = generateSecretKey();
+  const wrapConversationKey = nip44.getConversationKey(
+    wrapPrivKey,
+    recipientPubkey
+  );
+  const wrapContent = nip44.encrypt(
+    JSON.stringify(signedSeal),
+    wrapConversationKey
+  );
+  const wrapTimestamp = now - Math.floor(Math.random() * 172800);
+
+  const wrapTags: string[][] = [
+    options?.relayHint
+      ? ["p", recipientPubkey, options.relayHint]
+      : ["p", recipientPubkey],
+  ];
+
+  return finalizeEvent(
+    {
+      created_at: wrapTimestamp,
+      content: wrapContent,
+      kind: 1059,
+      tags: wrapTags,
+    },
+    wrapPrivKey
+  );
+}


### PR DESCRIPTION
### Description

Eliminates 4 copies of near-identical NIP-17 gift-wrap encryption logic in the 3000-line `write-tools.ts` god-module by extracting into a focused, reusable utility. Each copy independently maintained the same seal (kind 13) -> wrap (kind 1059) construction pattern with NIP-44, leading to ~225 lines of duplicated code and a maintenance hazard (any NIP-17 spec change requires updating 4 locations).

### Changes

- **New**: `utils/nostr/gift-wrap.ts` — exports `createGiftWrapEvent(innerContent, recipientPubkey, options?)` supporting random-key mode, signer mode, and optional relay hint. Handles seal encryption, kind-13 seal creation + signing, second-layer NIP-44 encryption, and kind-1059 gift-wrap finalization.
- **Changed**: `mcp/tools/write-tools.ts` — replaced 4 inline gift-wrap implementations (`createGiftWrap` in `send_direct_message`, `createAddressChangeWrap` in `update_order_address`, `createWrap` in `send_shipping_update`, inline code in `update_order_status`) with calls to the shared module. Removed 4 dynamic `await import("nostr-tools")` blocks; moved `getEventHash` to static top-level import.

### Verification

- `tsc --noEmit` — zero errors
- `npm run test:ci` — 131 suites, 1551 tests passed, 18 skipped (all passing)
