### PR TITLE
test(checkout): add checkout-card.tsx coverage + shared test harness

### DIFF
--- a/components/utility-components/__tests__/checkout-card.test.tsx
+++ b/components/utility-components/__tests__/checkout-card.test.tsx
@@ -1,0 +1,593 @@
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+import CheckoutCard from "../checkout-card";
+import {
+  makeProductData,
+  renderWithCheckoutContext,
+  installFetchMock,
+  mockFetchJsonOnce,
+  type CheckoutContextOverrides,
+} from "@/test-utils/checkout-test-helpers";
+import { getLocalStorageJson } from "@/utils/safe-json";
+import { isP2pkEscrowFeatureEnabled } from "@/utils/cashu/p2pk-checkout";
+import type { ProductData } from "@/utils/parsers/product-parser-functions";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+jest.mock("@/utils/cashu/p2pk-checkout", () => ({
+  isP2pkEscrowFeatureEnabled: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock("next/router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+jest.mock("nostr-tools", () => ({
+  nip19: { decode: jest.fn(), encode: jest.fn(), npubEncode: jest.fn() },
+  Event: {},
+}));
+
+jest.mock("@heroui/react", () => {
+  const React = require("react");
+  return {
+    Button: ({ children, onClick, isDisabled, disabled }: any) =>
+      React.createElement(
+        "button",
+        { onClick, disabled: isDisabled ?? disabled },
+        children
+      ),
+    Chip: ({ children, startContent }: any) =>
+      React.createElement(
+        "div",
+        { "data-testid": "chip" },
+        startContent,
+        children
+      ),
+    Input: ({
+      label,
+      value,
+      onChange,
+      disabled,
+      isInvalid,
+      errorMessage,
+    }: any) =>
+      React.createElement(
+        "div",
+        null,
+        React.createElement("input", {
+          "aria-label": label,
+          value: value ?? "",
+          onChange,
+          disabled,
+        }),
+        isInvalid && errorMessage
+          ? React.createElement("span", { role: "alert" }, errorMessage)
+          : null
+      ),
+    useDisclosure: () => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      return {
+        isOpen,
+        onOpen: () => setIsOpen(true),
+        onClose: () => setIsOpen(false),
+      };
+    },
+    Dropdown: ({ children }: any) => React.createElement("div", null, children),
+    DropdownTrigger: ({ children }: any) =>
+      React.createElement("div", null, children),
+    DropdownMenu: ({ children }: any) =>
+      React.createElement("div", null, children),
+    DropdownItem: ({ children }: any) =>
+      React.createElement("div", null, children),
+  };
+});
+
+jest.mock("@heroicons/react/24/outline", () => ({
+  FaceFrownIcon: () => null,
+  FaceSmileIcon: () => null,
+  ArrowLongDownIcon: () => null,
+  ArrowLongUpIcon: () => null,
+  EllipsisVerticalIcon: () => null,
+}));
+
+jest.mock("@/utils/parsers/product-parser-functions", () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({}),
+  ProductData: {},
+}));
+
+jest.mock("@/utils/url-slugs", () => ({
+  getListingSlug: jest.fn().mockReturnValue("slug"),
+}));
+
+jest.mock("@/components/utility-components/profile/profile-dropdown", () => ({
+  ProfileWithDropdown: () => null,
+}));
+
+const mockDisplayCheckoutCost = jest.fn((_props: any) => null);
+jest.mock("@/components/utility-components/display-monetary-info", () => ({
+  DisplayCheckoutCost: (props: any) => mockDisplayCheckoutCost(props),
+}));
+
+const mockProductInvoiceCard = jest.fn((_props: any) => null);
+jest.mock("@/components/product-invoice-card", () => ({
+  __esModule: true,
+  default: (props: any) => mockProductInvoiceCard(props),
+}));
+
+jest.mock("@/components/free-shipping-notification", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/utility-components/failure-modal", () => ({
+  __esModule: true,
+  default: ({ bodyText, isOpen }: any) =>
+    isOpen ? <div role="alert">{bodyText}</div> : null,
+}));
+
+jest.mock("@/components/utility-components/success-modal", () => ({
+  __esModule: true,
+  default: ({ bodyText, isOpen }: any) =>
+    isOpen ? <div role="status">{bodyText}</div> : null,
+}));
+
+jest.mock("@/components/sign-in/SignInModal", () => ({
+  __esModule: true,
+  default: ({ isOpen }: any) =>
+    isOpen ? <div data-testid="sign-in-modal" /> : null,
+}));
+
+jest.mock("@/components/utility-components/volume-selector", () => ({
+  __esModule: true,
+  default: ({ volumes, onVolumeChange }: any) => (
+    <div>
+      {volumes.map((volume: string) => (
+        <button key={volume} onClick={() => onVolumeChange(volume)}>
+          {volume}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/utility-components/weight-selector", () => ({
+  __esModule: true,
+  default: ({ weights, onWeightChange }: any) => (
+    <div>
+      {weights.map((weight: string) => (
+        <button key={weight} onClick={() => onWeightChange(weight)}>
+          {weight}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/utility-components/bulk-selector", () => ({
+  __esModule: true,
+  default: ({ bulkPrices, onBulkChange }: any) => (
+    <div>
+      {Array.from(bulkPrices.keys() as IterableIterator<number>).map(
+        (units) => (
+          <button key={units} onClick={() => onBulkChange(String(units))}>
+            {`bulk-${units}`}
+          </button>
+        )
+      )}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ZapsnagButton", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/utility-components/modals/event-modals", () => ({
+  RawEventModal: () => null,
+  EventIdModal: () => null,
+}));
+
+jest.mock("@/components/utility-components/use-report-event-flow", () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockReturnValue({ openReportFlow: jest.fn(), reportFlowUi: null }),
+}));
+
+jest.mock(
+  "@/components/utility-components/dropdowns/location-dropdown",
+  () => ({
+    locationAvatar: jest.fn().mockReturnValue(null),
+  })
+);
+
+jest.mock("@/utils/safe-json", () => ({
+  getLocalStorageJson: jest.fn(),
+}));
+
+// ── Typed mock handles ────────────────────────────────────────────────────────
+
+const mockGetLocalStorageJson = getLocalStorageJson as jest.Mock;
+const mockIsP2pkEscrowFeatureEnabled = isP2pkEscrowFeatureEnabled as jest.Mock;
+
+// ── Fixtures & render helper ─────────────────────────────────────────────────
+
+const BUYER_PUBKEY = "buyer_pubkey";
+const SELLER_PUBKEY = "seller_pubkey";
+
+function renderCheckoutCard(
+  overrides: Partial<ProductData> = {},
+  contextOverrides: CheckoutContextOverrides = {}
+) {
+  const productData = makeProductData({ pubkey: SELLER_PUBKEY, ...overrides });
+  const rendered = renderWithCheckoutContext(
+    <CheckoutCard
+      productData={productData}
+      setInvoiceIsPaid={jest.fn()}
+      setInvoiceGenerationFailed={jest.fn()}
+      setCashuPaymentSent={jest.fn()}
+      setCashuPaymentFailed={jest.fn()}
+    />,
+    {
+      signer: { pubkey: BUYER_PUBKEY, isLoggedIn: true },
+      ...contextOverrides,
+    }
+  );
+  return { productData, ...rendered };
+}
+
+function makeVariantProduct(overrides: Partial<ProductData> = {}) {
+  return {
+    price: 1000,
+    sizes: ["S", "M"],
+    sizeQuantities: new Map([
+      ["S", 3],
+      ["M", 0],
+    ]),
+    volumes: ["500ml"],
+    volumePrices: new Map([["500ml", 700]]),
+    weights: ["1kg"],
+    weightPrices: new Map([["1kg", 800]]),
+    bulkPrices: new Map([[5, 2000]]),
+    ...overrides,
+  };
+}
+
+function latestCallProps(mockFn: jest.Mock) {
+  return mockFn.mock.calls[mockFn.mock.calls.length - 1][0];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsP2pkEscrowFeatureEnabled.mockReturnValue(false);
+  mockGetLocalStorageJson.mockImplementation(
+    (_key: string, fallback: unknown) => fallback
+  );
+  installFetchMock();
+  localStorage.clear();
+  jest.spyOn(Storage.prototype, "setItem");
+  delete (navigator as any).share;
+  delete (navigator as any).clipboard;
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("discount code — handleApplyDiscount / handleRemoveDiscount", () => {
+  it("applies a valid discount code and reflects appliedDiscount/discountedTotal in the displayed price", async () => {
+    const { productData } = renderCheckoutCard({
+      price: 1000,
+      shippingCost: 100,
+      currency: "SATS",
+    });
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "save20" },
+    });
+    mockFetchJsonOnce({ valid: true, discount_percentage: 20 });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await screen.findByRole("button", { name: "Remove" });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`pubkey=${productData.pubkey}`)
+    );
+
+    const props = latestCallProps(mockDisplayCheckoutCost);
+    expect(props.monetaryInfo.price).toBe(800);
+    expect(props.monetaryInfo.totalCost).toBe(900);
+    expect(props.monetaryInfo.discountPercentage).toBe(20);
+  });
+
+  it("shows discountError and leaves appliedDiscount at 0 when the API responds non-OK", async () => {
+    renderCheckoutCard();
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "badcode" },
+    });
+    mockFetchJsonOnce({}, { ok: false, status: 500 });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(
+      await screen.findByText("Failed to validate discount code")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows discountError and leaves appliedDiscount at 0 when the fetch call rejects", async () => {
+    renderCheckoutCard();
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "badcode" },
+    });
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("offline"));
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(
+      await screen.findByText("Failed to apply discount code")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears discountCode/appliedDiscount/discountError on handleRemoveDiscount", async () => {
+    renderCheckoutCard();
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "save20" },
+    });
+    mockFetchJsonOnce({ valid: true, discount_percentage: 20 });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByRole("button", { name: "Remove" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Remove" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+    expect(
+      (screen.getByLabelText("Discount Code") as HTMLInputElement).value
+    ).toBe("");
+  });
+
+  it("scopes the validation request to this product's pubkey (not a hardcoded value)", async () => {
+    const { productData } = renderCheckoutCard({ pubkey: "unique_seller_123" });
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "save20" },
+    });
+    mockFetchJsonOnce({ valid: true, discount_percentage: 20 });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await screen.findByRole("button", { name: "Remove" });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`pubkey=${productData.pubkey}`)
+    );
+  });
+});
+
+describe("pricing passthrough to ProductInvoiceCard", () => {
+  it("passes the pre-discount price through as originalPrice, leaving discount re-derivation to the child", async () => {
+    renderCheckoutCard({ price: 1000, shippingCost: 100, currency: "SATS" });
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "save20" },
+    });
+    mockFetchJsonOnce({ valid: true, discount_percentage: 20 });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByRole("button", { name: "Remove" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Buy Now" }));
+
+    expect(mockProductInvoiceCard).toHaveBeenCalled();
+    const props = latestCallProps(mockProductInvoiceCard);
+    expect(props.originalPrice).toBe(1000);
+    expect(props.discountCode).toBe("SAVE20");
+    expect(props.discountPercentage).toBe(20);
+    expect(props.productData.price).toBe(800);
+  });
+
+  it("resolves volumePrice/weightPrice/bulkPrice from the matching productData map when a selection is active", () => {
+    renderCheckoutCard(makeVariantProduct());
+
+    fireEvent.click(screen.getByRole("button", { name: "S" }));
+    fireEvent.click(screen.getByRole("button", { name: "500ml" }));
+    fireEvent.click(screen.getByRole("button", { name: "1kg" }));
+    fireEvent.click(screen.getByRole("button", { name: "bulk-5" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Buy Now" }));
+
+    expect(mockProductInvoiceCard).toHaveBeenCalled();
+    const props = latestCallProps(mockProductInvoiceCard);
+    expect(props.productData.volumePrice).toBe(700);
+    expect(props.productData.weightPrice).toBe(800);
+    expect(props.productData.bulkPrice).toBe(2000);
+    expect(props.productData.selectedBulkOption).toBe(5);
+  });
+});
+
+describe("handleAddToCart", () => {
+  it("shows FailureModal instead of adding to cart when totalCost < 1", () => {
+    renderCheckoutCard({ totalCost: 0, currency: "SATS" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add To Cart" }));
+
+    expect(
+      screen.getByText(
+        "The price and/or currency set for this listing was invalid."
+      )
+    ).toBeInTheDocument();
+    expect(Storage.prototype.setItem).not.toHaveBeenCalledWith(
+      "cart",
+      expect.anything()
+    );
+  });
+
+  it("shows FailureModal for an invalid currency", () => {
+    renderCheckoutCard({ currency: "FAKECUR", totalCost: 500 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add To Cart" }));
+
+    expect(
+      screen.getByText(
+        "The price and/or currency set for this listing was invalid."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("persists {code: discountCode} into localStorage cartDiscounts keyed by productData.pubkey, guarded by isCartDiscountsMap", async () => {
+    mockGetLocalStorageJson.mockImplementation(
+      (key: string, fallback: unknown) =>
+        key === "cartDiscounts" ? {} : fallback
+    );
+    const { productData } = renderCheckoutCard({
+      currency: "SATS",
+      totalCost: 900,
+    });
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "save15" },
+    });
+    mockFetchJsonOnce({ valid: true, discount_percentage: 15 });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByRole("button", { name: "Remove" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add To Cart" }));
+
+    expect(Storage.prototype.setItem).toHaveBeenCalledWith(
+      "cartDiscounts",
+      JSON.stringify({ [productData.pubkey]: { code: "SAVE15" } })
+    );
+  });
+
+  it("does not corrupt existing cartDiscounts entries for other products when adding this one", async () => {
+    mockGetLocalStorageJson.mockImplementation(
+      (key: string, fallback: unknown) =>
+        key === "cartDiscounts"
+          ? { other_seller_pubkey: { code: "OLD10" } }
+          : fallback
+    );
+    const { productData } = renderCheckoutCard({
+      currency: "SATS",
+      totalCost: 900,
+    });
+
+    fireEvent.change(screen.getByLabelText("Discount Code"), {
+      target: { value: "save15" },
+    });
+    mockFetchJsonOnce({ valid: true, discount_percentage: 15 });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByRole("button", { name: "Remove" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add To Cart" }));
+
+    expect(Storage.prototype.setItem).toHaveBeenCalledWith(
+      "cartDiscounts",
+      JSON.stringify({
+        other_seller_pubkey: { code: "OLD10" },
+        [productData.pubkey]: { code: "SAVE15" },
+      })
+    );
+  });
+});
+
+describe("handleShare", () => {
+  it("calls navigator.share when available", async () => {
+    const shareMock = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: shareMock,
+      configurable: true,
+    });
+    const { productData } = renderCheckoutCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(shareMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: productData.title,
+          url: expect.stringContaining("/listing/"),
+        })
+      )
+    );
+  });
+
+  it("falls back to clipboard + SuccessModal when navigator.share is undefined", async () => {
+    const writeTextMock = jest.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: writeTextMock },
+      configurable: true,
+    });
+    renderCheckoutCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    expect(writeTextMock).toHaveBeenCalledWith(
+      expect.stringContaining("/listing/")
+    );
+    expect(
+      await screen.findByText("Listing URL copied to clipboard!")
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Buy Now / Add to Cart gating", () => {
+  it("disables both buttons when a required size/volume/weight selection is missing", () => {
+    renderCheckoutCard(makeVariantProduct());
+
+    expect(screen.getByRole("button", { name: "Buy Now" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add To Cart" })).toBeDisabled();
+  });
+
+  it("enables both buttons once all required selections are made", () => {
+    renderCheckoutCard(makeVariantProduct());
+
+    fireEvent.click(screen.getByRole("button", { name: "S" }));
+    fireEvent.click(screen.getByRole("button", { name: "500ml" }));
+    fireEvent.click(screen.getByRole("button", { name: "1kg" }));
+
+    expect(screen.getByRole("button", { name: "Buy Now" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Add To Cart" })).toBeEnabled();
+  });
+
+  it("opens SignInModal instead of toggling isBeingPaid when toggleBuyNow is clicked while logged out", () => {
+    renderCheckoutCard({}, { signer: { pubkey: "", isLoggedIn: false } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Buy Now" }));
+
+    expect(screen.getByTestId("sign-in-modal")).toBeInTheDocument();
+    expect(mockProductInvoiceCard).not.toHaveBeenCalled();
+  });
+});
+
+describe("cart hydration on mount", () => {
+  it("hydrates cart state from localStorage via getLocalStorageJson", () => {
+    mockGetLocalStorageJson.mockImplementation(
+      (key: string, fallback: unknown) =>
+        key === "cart" ? [{ id: "prod1" }] : fallback
+    );
+
+    renderCheckoutCard({ id: "prod1" });
+
+    expect(screen.getByRole("button", { name: "Add To Cart" })).toBeDisabled();
+  });
+
+  it("defaults to an empty cart when getLocalStorageJson returns null", () => {
+    mockGetLocalStorageJson.mockImplementation(
+      (key: string, fallback: unknown) => (key === "cart" ? null : fallback)
+    );
+
+    renderCheckoutCard({ id: "prod1" });
+
+    expect(screen.getByRole("button", { name: "Add To Cart" })).toBeEnabled();
+  });
+});

--- a/test-utils/__tests__/checkout-test-helpers.smoke.test.tsx
+++ b/test-utils/__tests__/checkout-test-helpers.smoke.test.tsx
@@ -1,0 +1,92 @@
+import { screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { useContext } from "react";
+import {
+  makeProductData,
+  makeShopProfile,
+  makeMintQuoteResponse,
+  installFetchMock,
+  mockFetchJsonOnce,
+  renderWithCheckoutContext,
+} from "@/test-utils/checkout-test-helpers";
+import { SignerContext } from "@/components/utility-components/nostr-context-provider";
+import { CashuWalletContext } from "@/utils/context/context";
+
+function Probe() {
+  const { pubkey, isLoggedIn } = useContext(SignerContext);
+  const { cashuMints } = useContext(CashuWalletContext);
+  return (
+    <div>
+      <span>pubkey:{pubkey}</span>
+      <span>isLoggedIn:{String(isLoggedIn)}</span>
+      <span>mints:{cashuMints.join(",")}</span>
+    </div>
+  );
+}
+
+describe("checkout-test-helpers", () => {
+  it("makeProductData applies overrides on top of sane defaults", () => {
+    const product = makeProductData({ title: "Custom Title", price: 1200 });
+    expect(product.title).toBe("Custom Title");
+    expect(product.price).toBe(1200);
+    expect(product.currency).toBe("SATS");
+  });
+
+  it("makeShopProfile merges content overrides instead of replacing the whole object", () => {
+    const shop = makeShopProfile({
+      content: { name: "Custom Shop" } as any,
+    });
+    expect(shop.content.name).toBe("Custom Shop");
+    expect(shop.content.ui).toBeDefined();
+  });
+
+  it("makeMintQuoteResponse produces the ListingMintQuoteResponse shape", () => {
+    const quote = makeMintQuoteResponse({ amount: 750 });
+    expect(quote).toMatchObject({
+      request: expect.any(String),
+      quote: expect.any(String),
+      amount: 750,
+      mintUrl: expect.any(String),
+      pricing: expect.objectContaining({ total: 500 }),
+    });
+  });
+
+  it("renderWithCheckoutContext wires default context values through useContext", () => {
+    renderWithCheckoutContext(<Probe />);
+    expect(screen.getByText("pubkey:buyer_pubkey")).toBeInTheDocument();
+    expect(screen.getByText("isLoggedIn:true")).toBeInTheDocument();
+  });
+
+  it("renderWithCheckoutContext applies per-context overrides", () => {
+    renderWithCheckoutContext(<Probe />, {
+      signer: { pubkey: "other_pubkey", isLoggedIn: false },
+      cashuWallet: { cashuMints: ["https://mint.example.com"] },
+    });
+    expect(screen.getByText("pubkey:other_pubkey")).toBeInTheDocument();
+    expect(screen.getByText("isLoggedIn:false")).toBeInTheDocument();
+    expect(
+      screen.getByText("mints:https://mint.example.com")
+    ).toBeInTheDocument();
+  });
+
+  describe("fetch mocking", () => {
+    beforeEach(() => {
+      installFetchMock();
+    });
+
+    it("mockFetchJsonOnce queues a resolvable Response-shaped value", async () => {
+      mockFetchJsonOnce(makeMintQuoteResponse({ amount: 999 }));
+      const response = await fetch("/api/listing/mint-quote");
+      expect(response.ok).toBe(true);
+      const payload = await response.json();
+      expect(payload.amount).toBe(999);
+    });
+
+    it("mockFetchJsonOnce can queue a non-ok response", async () => {
+      mockFetchJsonOnce({ error: "nope" }, { ok: false, status: 400 });
+      const response = await fetch("/api/listing/mint-quote");
+      expect(response.ok).toBe(false);
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/test-utils/__tests__/checkout-test-helpers.smoke.test.tsx
+++ b/test-utils/__tests__/checkout-test-helpers.smoke.test.tsx
@@ -7,6 +7,7 @@ import {
   makeMintQuoteResponse,
   installFetchMock,
   mockFetchJsonOnce,
+  mockP2pkCheckoutModule,
   renderWithCheckoutContext,
 } from "@/test-utils/checkout-test-helpers";
 import { SignerContext } from "@/components/utility-components/nostr-context-provider";
@@ -40,14 +41,18 @@ describe("checkout-test-helpers", () => {
     expect(shop.content.ui).toBeDefined();
   });
 
-  it("makeMintQuoteResponse produces the ListingMintQuoteResponse shape", () => {
+  it("makeMintQuoteResponse keeps default SATS pricing coherent with amount", () => {
     const quote = makeMintQuoteResponse({ amount: 750 });
     expect(quote).toMatchObject({
       request: expect.any(String),
       quote: expect.any(String),
       amount: 750,
       mintUrl: expect.any(String),
-      pricing: expect.objectContaining({ total: 500 }),
+      pricing: expect.objectContaining({
+        unitPrice: 750,
+        subtotal: 750,
+        total: 750,
+      }),
     });
   });
 
@@ -67,6 +72,13 @@ describe("checkout-test-helpers", () => {
     expect(
       screen.getByText("mints:https://mint.example.com")
     ).toBeInTheDocument();
+  });
+
+  it("mockP2pkCheckoutModule includes the ProductInvoiceCard runtime contract", () => {
+    const p2pkModule = mockP2pkCheckoutModule();
+
+    expect(p2pkModule.isSellerP2pkEscrowActive).toEqual(expect.any(Function));
+    expect(p2pkModule.isSellerP2pkEscrowActive(undefined)).toBe(false);
   });
 
   describe("fetch mocking", () => {

--- a/test-utils/checkout-test-helpers.tsx
+++ b/test-utils/checkout-test-helpers.tsx
@@ -1,0 +1,372 @@
+import type { ReactElement } from "react";
+import { render } from "@testing-library/react";
+import type { ProductData } from "@/utils/parsers/product-parser-functions";
+import type { ShopProfile } from "@/utils/types/types";
+import type { ListingPricingResult } from "@/utils/payments/listing-pricing";
+import {
+  SignerContext,
+  NostrContext,
+} from "@/components/utility-components/nostr-context-provider";
+import {
+  ProductContext,
+  ShopMapContext,
+  ReviewsContext,
+  ProfileMapContext,
+  ChatsContext,
+  CashuWalletContext,
+} from "@/utils/context/context";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+export function makeProductData(
+  overrides: Partial<ProductData> = {}
+): ProductData {
+  return {
+    id: "prod1",
+    pubkey: "seller_pubkey",
+    createdAt: 0,
+    title: "Test Item",
+    summary: "A test item.",
+    publishedAt: "",
+    images: ["img.jpg"],
+    categories: [],
+    location: "Online",
+    price: 500,
+    currency: "SATS",
+    shippingType: "Free",
+    totalCost: 500,
+    status: "active",
+    ...overrides,
+  };
+}
+
+export function makeShopProfile(
+  overrides: Partial<ShopProfile> = {}
+): ShopProfile {
+  return {
+    pubkey: "seller_pubkey",
+    created_at: 0,
+    ...overrides,
+    content: {
+      name: "Test Shop",
+      about: "",
+      ui: { picture: "", banner: "", theme: "", darkMode: false },
+      merchants: [],
+      ...(overrides.content ?? {}),
+    },
+  };
+}
+
+export interface MintQuoteFixtureOverrides {
+  request?: string;
+  quote?: string;
+  amount?: number;
+  mintUrl?: string;
+  pricing?: Partial<ListingPricingResult>;
+}
+
+export function makeMintQuoteResponse(
+  overrides: MintQuoteFixtureOverrides = {}
+) {
+  return {
+    request: overrides.request ?? "lnbc5000n1mockinvoice",
+    quote: overrides.quote ?? "quote_id_123",
+    amount: overrides.amount ?? 500,
+    mintUrl: overrides.mintUrl ?? "https://mint.example.com",
+    pricing: {
+      unitPrice: 500,
+      subtotal: 500,
+      shippingCost: 0,
+      total: 500,
+      currency: "SATS",
+      ...overrides.pricing,
+    } as ListingPricingResult,
+  };
+}
+
+// ── Fetch mocking ─────────────────────────────────────────────────────────────
+
+export function installFetchMock(): jest.Mock {
+  const fetchMock = jest.fn();
+  (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
+  return fetchMock;
+}
+
+export function mockFetchJsonOnce(
+  body: unknown,
+  init: { ok?: boolean; status?: number } = {}
+): void {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 500);
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  });
+}
+
+// ── Context default values ───────────────────────────────────────────────────
+
+export function defaultSignerContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    signer: {},
+    isLoggedIn: true,
+    isAuthStateResolved: true,
+    pubkey: "buyer_pubkey",
+    npub: "npub1buyer",
+    newSigner: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function defaultNostrContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return { nostr: {}, setNostr: jest.fn(), ...overrides };
+}
+
+export function defaultChatsContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    chatsMap: new Map(),
+    isLoading: false,
+    addNewlyCreatedMessageEvent: jest.fn(),
+    markAllMessagesAsRead: jest.fn().mockResolvedValue([]),
+    newOrderIds: new Set<string>(),
+    ...overrides,
+  };
+}
+
+export function defaultProfileMapContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    profileData: new Map(),
+    isLoading: false,
+    updateProfileData: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function defaultCashuWalletContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    proofEvents: [],
+    cashuMints: [],
+    cashuProofs: [],
+    isLoading: false,
+    cashuPubkey: undefined,
+    cashuPrivkey: undefined,
+    walletIdentityUnavailable: false,
+    setProofEvents: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function defaultProductContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    productEvents: [],
+    isLoading: false,
+    addNewlyCreatedProductEvent: jest.fn(),
+    removeDeletedProductEvent: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function defaultShopMapContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    shopData: new Map(),
+    isLoading: false,
+    updateShopData: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function defaultReviewsContextValue(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    merchantReviewsData: new Map(),
+    productReviewsData: new Map(),
+    isLoading: false,
+    updateMerchantReviewsData: jest.fn(),
+    updateProductReviewsData: jest.fn(),
+    ...overrides,
+  };
+}
+
+// ── Render helper ─────────────────────────────────────────────────────────────
+
+export interface CheckoutContextOverrides {
+  signer?: Record<string, unknown>;
+  nostr?: Record<string, unknown>;
+  chats?: Record<string, unknown>;
+  profileMap?: Record<string, unknown>;
+  cashuWallet?: Record<string, unknown>;
+  product?: Record<string, unknown>;
+  shopMap?: Record<string, unknown>;
+  reviews?: Record<string, unknown>;
+}
+
+export function renderWithCheckoutContext(
+  ui: ReactElement,
+  overrides: CheckoutContextOverrides = {}
+) {
+  return render(
+    <SignerContext.Provider
+      value={defaultSignerContextValue(overrides.signer) as any}
+    >
+      <NostrContext.Provider
+        value={defaultNostrContextValue(overrides.nostr) as any}
+      >
+        <ChatsContext.Provider
+          value={defaultChatsContextValue(overrides.chats) as any}
+        >
+          <ProfileMapContext.Provider
+            value={defaultProfileMapContextValue(overrides.profileMap) as any}
+          >
+            <CashuWalletContext.Provider
+              value={
+                defaultCashuWalletContextValue(overrides.cashuWallet) as any
+              }
+            >
+              <ProductContext.Provider
+                value={defaultProductContextValue(overrides.product) as any}
+              >
+                <ShopMapContext.Provider
+                  value={defaultShopMapContextValue(overrides.shopMap) as any}
+                >
+                  <ReviewsContext.Provider
+                    value={defaultReviewsContextValue(overrides.reviews) as any}
+                  >
+                    {ui}
+                  </ReviewsContext.Provider>
+                </ShopMapContext.Provider>
+              </ProductContext.Provider>
+            </CashuWalletContext.Provider>
+          </ProfileMapContext.Provider>
+        </ChatsContext.Provider>
+      </NostrContext.Provider>
+    </SignerContext.Provider>
+  );
+}
+
+// ── Module mock factories ────────────────────────────────────────────────────
+
+export function mockQrCodeModule() {
+  return {
+    __esModule: true,
+    default: {
+      toDataURL: jest.fn().mockResolvedValue("data:image/png;base64,mock"),
+    },
+  };
+}
+
+export function mockGetAlbySdkModule() {
+  return {
+    NostrWebLNProvider: jest.fn().mockImplementation(() => ({
+      enable: jest.fn().mockResolvedValue(undefined),
+      sendPayment: jest.fn().mockResolvedValue({ preimage: "mock_preimage" }),
+      close: jest.fn(),
+    })),
+  };
+}
+
+export function mockGetAlbyLightningToolsModule() {
+  return {
+    getSatoshiValue: jest.fn().mockResolvedValue(500),
+    LightningAddress: jest.fn().mockImplementation(() => ({
+      fetch: jest.fn().mockResolvedValue(undefined),
+      requestInvoice: jest
+        .fn()
+        .mockResolvedValue({ paymentRequest: "lnbc5000n1mockinvoice" }),
+    })),
+  };
+}
+
+export function mockCashuTsModule() {
+  return {
+    Mint: jest.fn().mockImplementation(() => ({})),
+    Wallet: jest.fn().mockImplementation(() => ({
+      loadMint: jest.fn().mockResolvedValue(undefined),
+      createMeltQuoteBolt11: jest.fn(),
+      createMintQuoteBolt11: jest.fn(),
+      checkMintQuoteBolt11: jest.fn(),
+      checkMeltQuoteBolt11: jest
+        .fn()
+        .mockResolvedValue({ state: "UNPAID", change: [] }),
+      mintProofsBolt11: jest.fn(),
+      meltProofsBolt11: jest.fn(),
+      send: jest.fn(),
+      receive: jest.fn(),
+      keyChain: { getKeysets: jest.fn().mockResolvedValue([]) },
+    })),
+    getEncodedToken: jest.fn().mockReturnValue("cashuAmocktoken"),
+    getDecodedToken: jest.fn(),
+  };
+}
+
+export function mockMeltRetryServiceModule() {
+  return { safeMeltProofs: jest.fn() };
+}
+
+export function mockSwapRetryServiceModule() {
+  return { safeSwap: jest.fn() };
+}
+
+export function mockMintRetryServiceModule() {
+  return {
+    withMintRetry: jest.fn((fn: () => Promise<unknown>) => fn()),
+  };
+}
+
+export function mockP2pkCheckoutModule(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    isP2pkEscrowFeatureEnabled: jest.fn().mockReturnValue(false),
+    isP2pkMintAllowed: jest.fn().mockReturnValue(true),
+    resolveSellerCheckoutProfile: jest.fn().mockResolvedValue(null),
+    resolveP2pkCheckoutOutputConfig: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+export function mockNostrHelperFunctionsModule(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    getLocalStorageData: jest.fn().mockReturnValue({
+      mints: ["https://mint.example.com"],
+      tokens: [],
+      history: [],
+    }),
+    publishProofEvent: jest.fn().mockResolvedValue(undefined),
+    getSavedAddresses: jest.fn().mockReturnValue([]),
+    ...overrides,
+  };
+}
+
+export function mockGiftWrapModule(overrides: Record<string, unknown> = {}) {
+  return {
+    constructGiftWrappedEvent: jest.fn(),
+    constructMessageSeal: jest.fn(),
+    constructMessageGiftWrap: jest.fn(),
+    sendGiftWrappedMessageEvent: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+export function mockNextRouterModule(overrides: Record<string, unknown> = {}) {
+  return {
+    useRouter: () => ({ push: jest.fn(), query: {}, ...overrides }),
+  };
+}

--- a/test-utils/checkout-test-helpers.tsx
+++ b/test-utils/checkout-test-helpers.tsx
@@ -68,16 +68,18 @@ export interface MintQuoteFixtureOverrides {
 export function makeMintQuoteResponse(
   overrides: MintQuoteFixtureOverrides = {}
 ) {
+  const amount = overrides.amount ?? 500;
+
   return {
     request: overrides.request ?? "lnbc5000n1mockinvoice",
     quote: overrides.quote ?? "quote_id_123",
-    amount: overrides.amount ?? 500,
+    amount,
     mintUrl: overrides.mintUrl ?? "https://mint.example.com",
     pricing: {
-      unitPrice: 500,
-      subtotal: 500,
+      unitPrice: amount,
+      subtotal: amount,
       shippingCost: 0,
-      total: 500,
+      total: amount,
       currency: "SATS",
       ...overrides.pricing,
     } as ListingPricingResult,
@@ -334,6 +336,7 @@ export function mockP2pkCheckoutModule(
   return {
     isP2pkEscrowFeatureEnabled: jest.fn().mockReturnValue(false),
     isP2pkMintAllowed: jest.fn().mockReturnValue(true),
+    isSellerP2pkEscrowActive: jest.fn().mockReturnValue(false),
     resolveSellerCheckoutProfile: jest.fn().mockResolvedValue(null),
     resolveP2pkCheckoutOutputConfig: jest.fn().mockResolvedValue(null),
     ...overrides,


### PR DESCRIPTION
### Description

- Add `test-utils/checkout-test-helpers.tsx` — shared harness (fixtures, context-provider wrapper, fetch mocking, reusable jest.mock factories) for the checkout UI test effort. Deliberately placed outside `__tests__/` since Jest's default `testMatch` treats any file in one as a suite.
- Add `components/utility-components/__tests__/checkout-card.test.tsx` (18 tests). Existing `checkout-card-p2pk-badge.test.tsx` (P2PK badge) untouched.
- Found and documented (not silently fixed) a display-only rounding bug in the "You save X%" discount text (`checkout-card.tsx:850` double-applies a rounding formula) — charged totals are unaffected; tests assert against the real pricing props, not the buggy text.

### Resolved or fixed issue
`none`  

### Screenshots (if applicable)  
Add screenshots or examples if this PR includes UI-related changes.  

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines

### For more details on what to include, see:

[Bug Report Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
[Feature Request Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/feature_request.md)
[Documentation Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/documentation_improvement.md)
[Security Issue Template](https://github.com/shopstr-eng/shopstr/blob/main/.github/ISSUE_TEMPLATE/security_vulnerability.md)