### PR TITLE
Check NIP 11 metadata before NIP 50 search

### DIFF
--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -170,7 +170,7 @@ const renderDisplayProducts = ({
 const expectNip50RelayFetches = (
   fetchMock: jest.Mock,
   expectedFilter: Record<string, unknown>,
-  expectedRelays = ["wss://relay.example", ...DEFAULT_NIP50_SEARCH_RELAYS]
+  expectedRelays = [...DEFAULT_NIP50_SEARCH_RELAYS, "wss://relay.example"]
 ) => {
   expect(fetchMock).toHaveBeenCalledTimes(expectedRelays.length);
   expectedRelays.forEach((relay, index) => {

--- a/components/__tests__/display-products.test.tsx
+++ b/components/__tests__/display-products.test.tsx
@@ -185,6 +185,13 @@ const expectNip50RelayFetches = (
 };
 
 describe("DisplayProducts search filtering", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ supported_nips: [1, 11, 50] }),
+    }) as unknown as typeof global.fetch;
+  });
+
   it("matches literal special characters in search queries", async () => {
     render(
       <SignerContext.Provider

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -833,7 +833,60 @@ describe("fetch-service NIP-50 search helpers", () => {
     expect(result.productEvents).toEqual([firstRelayResult, secondRelayResult]);
   });
 
-  it("routes search to selected relays that advertise NIP-50 before curated fallbacks", async () => {
+  it("prioritizes a selected curated relay ahead of unselected fallbacks", async () => {
+    const selectedRelayResult = {
+      id: "selected-curated-result",
+      pubkey: "selected-seller",
+      created_at: 10,
+      kind: 30402,
+      tags: [
+        ["d", "selected-coffee"],
+        ["title", "Selected Coffee Beans"],
+        ["price", "12", "USD"],
+      ],
+      content: "Selected curated relay result",
+      sig: "sig-selected",
+    };
+    const fallbackRelayResult = {
+      id: "unselected-fallback-result",
+      pubkey: "fallback-seller",
+      created_at: 20,
+      kind: 30402,
+      tags: [
+        ["d", "fallback-coffee"],
+        ["title", "Fallback Coffee Beans"],
+        ["price", "14", "USD"],
+      ],
+      content: "Unselected fallback relay result",
+      sig: "sig-fallback",
+    };
+    const selectedRelay = DEFAULT_NIP50_SEARCH_RELAYS[1]!;
+    const nostr = {
+      fetch: jest.fn((_, __, relays: string[]) => {
+        if (relays[0] === selectedRelay) {
+          return Promise.resolve([selectedRelayResult]);
+        }
+        if (relays[0] === DEFAULT_NIP50_SEARCH_RELAYS[0]) {
+          return Promise.resolve([fallbackRelayResult]);
+        }
+        return Promise.resolve([]);
+      }),
+    };
+
+    const result = await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      [selectedRelay],
+      "coffee"
+    );
+
+    expectNip50RelayFetches(nostr.fetch);
+    expect(result.productEvents).toEqual([
+      selectedRelayResult,
+      fallbackRelayResult,
+    ]);
+  });
+
+  it("starts curated fallbacks before metadata-gated selected relays", async () => {
     const searchListing = {
       id: "fallback-product",
       pubkey: "fallback-seller",
@@ -862,8 +915,8 @@ describe("fetch-service NIP-50 search helpers", () => {
     );
 
     expectNip50RelayFetches(nostr.fetch, [
-      "wss://relay.damus.io",
       ...DEFAULT_NIP50_SEARCH_RELAYS,
+      "wss://relay.damus.io",
     ]);
     expect(global.fetch).toHaveBeenCalledWith(
       "https://relay.damus.io/",
@@ -980,15 +1033,11 @@ describe("fetch-service NIP-50 search helpers", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("queries selected NIP-50 relays before adding backup NIP-50 relays", async () => {
-    const selectedSearchRelay = "wss://relay.nostr.band";
+  it("queries curated relays before metadata-gated selected relays", async () => {
     const searchRelays = [
+      ...DEFAULT_NIP50_SEARCH_RELAYS,
       "wss://relay.damus.io",
-      selectedSearchRelay,
       "wss://nos.lol",
-      ...DEFAULT_NIP50_SEARCH_RELAYS.filter(
-        (relay) => relay !== selectedSearchRelay
-      ),
     ];
     const nostr = {
       fetch: jest.fn().mockResolvedValue([]),
@@ -1008,16 +1057,9 @@ describe("fetch-service NIP-50 search helpers", () => {
   });
 
   it("deduplicates normalized selected NIP-50 relays before adding backup relays", async () => {
-    const selectedSearchRelays = [
-      "wss://relay.noswhere.com",
-      "wss://search.nos.today",
-      "wss://relay.damus.io",
-    ];
     const searchRelays = [
-      ...selectedSearchRelays,
-      ...DEFAULT_NIP50_SEARCH_RELAYS.filter(
-        (relay) => !selectedSearchRelays.includes(relay)
-      ),
+      ...DEFAULT_NIP50_SEARCH_RELAYS,
+      "wss://relay.damus.io",
     ];
     const nostr = {
       fetch: jest.fn().mockResolvedValue([]),
@@ -1056,8 +1098,8 @@ describe("fetch-service NIP-50 search helpers", () => {
     );
 
     expectNip50RelayFetches(nostr.fetch, [
-      "wss://search.example",
       ...DEFAULT_NIP50_SEARCH_RELAYS,
+      "wss://search.example",
     ]);
   });
 
@@ -1084,6 +1126,93 @@ describe("fetch-service NIP-50 search helpers", () => {
     expect(nostr.fetch).toHaveBeenCalledTimes(
       (DEFAULT_NIP50_SEARCH_RELAYS.length + 1) * 2
     );
+  });
+
+  it("retries a transient relay metadata failure on the next search", async () => {
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([]),
+    };
+    const relayInfoFetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValue(makeRelayInfoResponse([1, 11, 50]));
+    global.fetch = relayInfoFetch as unknown as typeof global.fetch;
+
+    await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://search.example"],
+      "coffee"
+    );
+    await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://search.example"],
+      "coffee"
+    );
+
+    expect(relayInfoFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires cached relay metadata support after five minutes", async () => {
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([]),
+    };
+    const relayInfoFetch = jest
+      .fn()
+      .mockResolvedValue(makeRelayInfoResponse([1, 11, 50]));
+    global.fetch = relayInfoFetch as unknown as typeof global.fetch;
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1_000);
+
+    try {
+      await fetchNip50ProductSearch(
+        nostr as unknown as NostrManager,
+        ["wss://search.example"],
+        "coffee"
+      );
+      nowSpy.mockReturnValue(1_000 + 5 * 60_000 - 1);
+      await fetchNip50ProductSearch(
+        nostr as unknown as NostrManager,
+        ["wss://search.example"],
+        "coffee"
+      );
+      nowSpy.mockReturnValue(1_000 + 5 * 60_000 + 1);
+      await fetchNip50ProductSearch(
+        nostr as unknown as NostrManager,
+        ["wss://search.example"],
+        "coffee"
+      );
+
+      expect(relayInfoFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("starts curated relay searches while selected relay metadata is pending", async () => {
+    let resolveRelayInfo!: (
+      response: ReturnType<typeof makeRelayInfoResponse>
+    ) => void;
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveRelayInfo = resolve;
+        })
+    ) as unknown as typeof global.fetch;
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([]),
+    };
+
+    const searchPromise = fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://search.example"],
+      "coffee"
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expectNip50RelayFetches(nostr.fetch);
+
+    resolveRelayInfo(makeRelayInfoResponse([1, 11, 50]));
+    await searchPromise;
   });
 
   it("uses default NIP-50 relays when no selected relays are available", async () => {

--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -45,6 +45,25 @@ const expectNip50RelayFetches = (
   });
 };
 
+const makeRelayInfoResponse = (supportedNips: unknown[]) => ({
+  ok: true,
+  json: jest.fn().mockResolvedValue({ supported_nips: supportedNips }),
+});
+
+const mockRelayInfoSupport = (
+  supportByRelay: Record<string, unknown[]> = {}
+) => {
+  global.fetch = jest.fn((url: string) => {
+    const relayUrl = String(url)
+      .replace(/^https:/i, "wss:")
+      .replace(/^http:/i, "ws:")
+      .replace(/\/+$/, "");
+    return Promise.resolve(
+      makeRelayInfoResponse(supportByRelay[relayUrl] ?? [1, 11])
+    );
+  }) as unknown as typeof global.fetch;
+};
+
 describe("getProductEventKey", () => {
   it("builds the correct key for every input shape", () => {
     expect(
@@ -543,6 +562,7 @@ describe("getUniqueProofs", () => {
 describe("fetch-service NIP-50 search helpers", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRelayInfoSupport();
   });
 
   it("builds NIP-50 search filters only for marketplace listings", () => {
@@ -678,10 +698,7 @@ describe("fetch-service NIP-50 search helpers", () => {
       "coffee"
     );
 
-    expectNip50RelayFetches(nostr.fetch, [
-      "wss://relay.example",
-      ...DEFAULT_NIP50_SEARCH_RELAYS,
-    ]);
+    expectNip50RelayFetches(nostr.fetch);
     expect(result.productEvents).toEqual([newer]);
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([newer]);
   });
@@ -721,7 +738,7 @@ describe("fetch-service NIP-50 search helpers", () => {
       return result;
     });
 
-    for (let index = 0; index < 5 && !resolveCache; index += 1) {
+    for (let index = 0; index < 20 && !resolveCache; index += 1) {
       await Promise.resolve();
     }
 
@@ -816,7 +833,7 @@ describe("fetch-service NIP-50 search helpers", () => {
     expect(result.productEvents).toEqual([firstRelayResult, secondRelayResult]);
   });
 
-  it("routes search to selected relays before curated NIP-50 fallbacks", async () => {
+  it("routes search to selected relays that advertise NIP-50 before curated fallbacks", async () => {
     const searchListing = {
       id: "fallback-product",
       pubkey: "fallback-seller",
@@ -833,6 +850,10 @@ describe("fetch-service NIP-50 search helpers", () => {
     const nostr = {
       fetch: jest.fn().mockResolvedValue([searchListing]),
     };
+    mockRelayInfoSupport({
+      "wss://relay.damus.io": [1, 11, 50],
+      "wss://nos.lol": [1, 11],
+    });
 
     const result = await fetchNip50ProductSearch(
       nostr as unknown as NostrManager,
@@ -842,9 +863,15 @@ describe("fetch-service NIP-50 search helpers", () => {
 
     expectNip50RelayFetches(nostr.fetch, [
       "wss://relay.damus.io",
-      "wss://nos.lol",
       ...DEFAULT_NIP50_SEARCH_RELAYS,
     ]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://relay.damus.io/",
+      expect.objectContaining({
+        headers: { Accept: "application/nostr+json" },
+        signal: expect.any(AbortSignal),
+      })
+    );
     expect(result.productEvents).toEqual([searchListing]);
     expect(cacheEventsToDatabase).toHaveBeenCalledWith([searchListing]);
   });
@@ -953,7 +980,7 @@ describe("fetch-service NIP-50 search helpers", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("queries selected relays before adding backup NIP-50 relays", async () => {
+  it("queries selected NIP-50 relays before adding backup NIP-50 relays", async () => {
     const selectedSearchRelay = "wss://relay.nostr.band";
     const searchRelays = [
       "wss://relay.damus.io",
@@ -966,6 +993,10 @@ describe("fetch-service NIP-50 search helpers", () => {
     const nostr = {
       fetch: jest.fn().mockResolvedValue([]),
     };
+    mockRelayInfoSupport({
+      "wss://relay.damus.io": [1, 11, 50],
+      "wss://nos.lol": [1, 11, "50"],
+    });
 
     await fetchNip50ProductSearch(
       nostr as unknown as NostrManager,
@@ -991,6 +1022,9 @@ describe("fetch-service NIP-50 search helpers", () => {
     const nostr = {
       fetch: jest.fn().mockResolvedValue([]),
     };
+    mockRelayInfoSupport({
+      "wss://relay.damus.io": [1, 11, 50],
+    });
 
     await fetchNip50ProductSearch(
       nostr as unknown as NostrManager,
@@ -1004,6 +1038,52 @@ describe("fetch-service NIP-50 search helpers", () => {
     );
 
     expectNip50RelayFetches(nostr.fetch, searchRelays);
+  });
+
+  it("skips selected relays that do not advertise NIP-50", async () => {
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([]),
+    };
+    mockRelayInfoSupport({
+      "wss://relay.example": [1, 11],
+      "wss://search.example": [1, 11, 50],
+    });
+
+    await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://relay.example", "wss://search.example"],
+      "coffee"
+    );
+
+    expectNip50RelayFetches(nostr.fetch, [
+      "wss://search.example",
+      ...DEFAULT_NIP50_SEARCH_RELAYS,
+    ]);
+  });
+
+  it("caches selected relay NIP-50 metadata checks across searches", async () => {
+    const nostr = {
+      fetch: jest.fn().mockResolvedValue([]),
+    };
+    mockRelayInfoSupport({
+      "wss://search.example": [1, 11, 50],
+    });
+
+    await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://search.example"],
+      "coffee"
+    );
+    await fetchNip50ProductSearch(
+      nostr as unknown as NostrManager,
+      ["wss://search.example"],
+      "coffee"
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(nostr.fetch).toHaveBeenCalledTimes(
+      (DEFAULT_NIP50_SEARCH_RELAYS.length + 1) * 2
+    );
   });
 
   it("uses default NIP-50 relays when no selected relays are available", async () => {

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -66,6 +66,7 @@ type SearchFilter = Filter & { search: string };
 
 const PRODUCT_SEARCH_LIMIT = 100;
 export const NIP50_SEARCH_TIMEOUT_MS = 10_000;
+export const NIP11_RELAY_INFO_TIMEOUT_MS = 3_000;
 const COMMUNITY_POST_BATCH_CONCURRENCY = 4;
 export const DEFAULT_NIP50_SEARCH_RELAYS = [
   "wss://relay.nostr.band",
@@ -75,6 +76,9 @@ export const DEFAULT_NIP50_SEARCH_RELAYS = [
   "wss://antiprimal.net",
   "wss://relay.ditto.pub",
 ];
+
+const nip50RelaySupportCache = new Map<string, Promise<boolean>>();
+let relayInfoFetchImpl: typeof globalThis.fetch | undefined;
 
 function normalizeRelayUrl(relay: string): string {
   const trimmedRelay = relay.trim();
@@ -99,8 +103,91 @@ function getUniqueRelayUrls(relays: string[]): string[] {
   return Array.from(relayMap.values());
 }
 
-function getNip50SearchRelays(relays: string[]): string[] {
-  const selectedSearchRelays = getUniqueRelayUrls(relays);
+function buildRelayInformationUrl(relay: string): string | null {
+  try {
+    const url = new URL(relay);
+
+    if (url.protocol === "wss:") {
+      url.protocol = "https:";
+    } else if (url.protocol === "ws:") {
+      url.protocol = "http:";
+    } else if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return null;
+    }
+
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function relayInfoAdvertisesNip50(relayInfo: unknown): boolean {
+  if (!relayInfo || typeof relayInfo !== "object") return false;
+
+  const supportedNips = (relayInfo as { supported_nips?: unknown })
+    .supported_nips;
+
+  return (
+    Array.isArray(supportedNips) &&
+    supportedNips.some((nip) => nip === 50 || nip === "50")
+  );
+}
+
+async function fetchRelayAdvertisesNip50(relay: string): Promise<boolean> {
+  const fetchImpl = globalThis.fetch;
+  if (typeof fetchImpl !== "function") return false;
+
+  if (relayInfoFetchImpl !== fetchImpl) {
+    nip50RelaySupportCache.clear();
+    relayInfoFetchImpl = fetchImpl;
+  }
+
+  const relayCacheKey = relay.toLowerCase();
+  const cachedSupport = nip50RelaySupportCache.get(relayCacheKey);
+  if (cachedSupport) return cachedSupport;
+
+  const supportPromise = (async () => {
+    const relayInformationUrl = buildRelayInformationUrl(relay);
+    if (!relayInformationUrl) return false;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      NIP11_RELAY_INFO_TIMEOUT_MS
+    );
+
+    try {
+      const response = await fetchImpl(relayInformationUrl, {
+        headers: { Accept: "application/nostr+json" },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) return false;
+
+      return relayInfoAdvertisesNip50(await response.json());
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  })();
+
+  nip50RelaySupportCache.set(relayCacheKey, supportPromise);
+  return supportPromise;
+}
+
+async function getNip50SearchRelays(relays: string[]): Promise<string[]> {
+  const knownSearchRelaySet = new Set(
+    DEFAULT_NIP50_SEARCH_RELAYS.map((relay) => relay.toLowerCase())
+  );
+  const selectedSearchRelays = (
+    await Promise.all(
+      getUniqueRelayUrls(relays).map(async (relay) => {
+        if (knownSearchRelaySet.has(relay.toLowerCase())) return relay;
+        return (await fetchRelayAdvertisesNip50(relay)) ? relay : null;
+      })
+    )
+  ).filter((relay): relay is string => !!relay);
   const selectedSearchRelaySet = new Set(
     selectedSearchRelays.map((relay) => relay.toLowerCase())
   );
@@ -108,12 +195,9 @@ function getNip50SearchRelays(relays: string[]): string[] {
     (relay) => !selectedSearchRelaySet.has(relay.toLowerCase())
   );
 
-  // All user-selected relays are queried first, then any curated NIP-50 relays
-  // not already in the user's list are appended as fallbacks. Note: this means
-  // search terms are sent to every user-configured relay, not just those that
-  // advertise NIP-50 support. Non-NIP-50 relays may return unfiltered results,
-  // but fetchNip50ProductSearch post-filters via eventMatchesProductSearch so
-  // only matching events reach the UI — the only cost is extra bandwidth.
+  // User-selected relays that advertise NIP-50 are queried first, then curated
+  // search relays are appended as fallbacks. Results are still post-filtered
+  // because relays can return extraneous events.
   return [...selectedSearchRelays, ...backupSearchRelays];
 }
 
@@ -202,7 +286,7 @@ export async function fetchNip50ProductSearch(
     return { productEvents: [] };
   }
 
-  const searchRelays = getNip50SearchRelays(relays);
+  const searchRelays = await getNip50SearchRelays(relays);
 
   const fetchSearchEvents = async (targetRelays: string[]) => {
     if (targetRelays.length === 0) return Promise.resolve([]);

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -67,6 +67,7 @@ type SearchFilter = Filter & { search: string };
 const PRODUCT_SEARCH_LIMIT = 100;
 export const NIP50_SEARCH_TIMEOUT_MS = 10_000;
 const NIP11_RELAY_INFO_TIMEOUT_MS = 3_000;
+const NIP11_RELAY_INFO_CACHE_TTL_MS = 5 * 60_000;
 const COMMUNITY_POST_BATCH_CONCURRENCY = 4;
 export const DEFAULT_NIP50_SEARCH_RELAYS = [
   "wss://relay.nostr.band",
@@ -77,7 +78,12 @@ export const DEFAULT_NIP50_SEARCH_RELAYS = [
   "wss://relay.ditto.pub",
 ];
 
-const nip50RelaySupportCache = new Map<string, Promise<boolean>>();
+interface Nip50RelaySupportCacheEntry {
+  expiresAt: number;
+  supportPromise: Promise<boolean>;
+}
+
+const nip50RelaySupportCache = new Map<string, Nip50RelaySupportCacheEntry>();
 let relayInfoFetchImpl: typeof globalThis.fetch | undefined;
 
 function normalizeRelayUrl(relay: string): string {
@@ -144,12 +150,20 @@ async function fetchRelayAdvertisesNip50(relay: string): Promise<boolean> {
 
   const relayCacheKey = relay.toLowerCase();
   const cachedSupport = nip50RelaySupportCache.get(relayCacheKey);
-  if (cachedSupport) return cachedSupport;
+  if (cachedSupport && cachedSupport.expiresAt > Date.now()) {
+    return cachedSupport.supportPromise;
+  }
+  if (cachedSupport) nip50RelaySupportCache.delete(relayCacheKey);
 
-  const supportPromise = (async () => {
-    const relayInformationUrl = buildRelayInformationUrl(relay);
-    if (!relayInformationUrl) return false;
+  const relayInformationUrl = buildRelayInformationUrl(relay);
+  if (!relayInformationUrl) return false;
 
+  const cacheEntry: Nip50RelaySupportCacheEntry = {
+    expiresAt: Date.now() + NIP11_RELAY_INFO_CACHE_TTL_MS,
+    supportPromise: Promise.resolve(false),
+  };
+
+  cacheEntry.supportPromise = (async () => {
     const controller = new AbortController();
     const timeoutId = setTimeout(
       () => controller.abort(),
@@ -162,21 +176,26 @@ async function fetchRelayAdvertisesNip50(relay: string): Promise<boolean> {
         signal: controller.signal,
       });
 
-      if (!response.ok) return false;
+      if (!response.ok) throw new Error("Relay information request failed");
 
       return relayInfoAdvertisesNip50(await response.json());
     } catch {
+      if (nip50RelaySupportCache.get(relayCacheKey) === cacheEntry) {
+        nip50RelaySupportCache.delete(relayCacheKey);
+      }
       return false;
     } finally {
       clearTimeout(timeoutId);
     }
   })();
 
-  nip50RelaySupportCache.set(relayCacheKey, supportPromise);
-  return supportPromise;
+  nip50RelaySupportCache.set(relayCacheKey, cacheEntry);
+  return cacheEntry.supportPromise;
 }
 
-async function getNip50SearchRelays(relays: string[]): Promise<string[]> {
+async function getSelectedNip50SearchRelays(
+  relays: string[]
+): Promise<string[]> {
   const knownSearchRelaySet = new Set(
     DEFAULT_NIP50_SEARCH_RELAYS.map((relay) => relay.toLowerCase())
   );
@@ -188,17 +207,8 @@ async function getNip50SearchRelays(relays: string[]): Promise<string[]> {
       })
     )
   ).filter((relay): relay is string => !!relay);
-  const selectedSearchRelaySet = new Set(
-    selectedSearchRelays.map((relay) => relay.toLowerCase())
-  );
-  const backupSearchRelays = DEFAULT_NIP50_SEARCH_RELAYS.filter(
-    (relay) => !selectedSearchRelaySet.has(relay.toLowerCase())
-  );
 
-  // User-selected relays that advertise NIP-50 are queried first, then curated
-  // search relays are appended as fallbacks. Results are still post-filtered
-  // because relays can return extraneous events.
-  return [...selectedSearchRelays, ...backupSearchRelays];
+  return selectedSearchRelays;
 }
 
 export function getProductEventKey(event: NostrEvent): string {
@@ -286,8 +296,6 @@ export async function fetchNip50ProductSearch(
     return { productEvents: [] };
   }
 
-  const searchRelays = await getNip50SearchRelays(relays);
-
   const fetchSearchEvents = async (targetRelays: string[]) => {
     if (targetRelays.length === 0) return Promise.resolve([]);
 
@@ -308,14 +316,42 @@ export async function fetchNip50ProductSearch(
     return relayResults.flat();
   };
 
+  const curatedSearchEventsByRelay = new Map(
+    DEFAULT_NIP50_SEARCH_RELAYS.map((relay) => [
+      relay.toLowerCase(),
+      fetchSearchEvents([relay]),
+    ])
+  );
+  const selectedSearchRelays = await getSelectedNip50SearchRelays(relays);
+  const selectedSearchRelaySet = new Set(
+    selectedSearchRelays.map((relay) => relay.toLowerCase())
+  );
+  const selectedSearchEventsPromise = Promise.all(
+    selectedSearchRelays.map(
+      (relay) =>
+        curatedSearchEventsByRelay.get(relay.toLowerCase()) ??
+        fetchSearchEvents([relay])
+    )
+  ).then((relayResults) => relayResults.flat());
+  const fallbackSearchEventsPromise = Promise.all(
+    DEFAULT_NIP50_SEARCH_RELAYS.filter(
+      (relay) => !selectedSearchRelaySet.has(relay.toLowerCase())
+    ).map((relay) => curatedSearchEventsByRelay.get(relay.toLowerCase())!)
+  ).then((relayResults) => relayResults.flat());
+
   const filterSearchProductEvents = (events: NostrEvent[]) =>
     events.filter(
       (event) => event.id && event.sig && event.pubkey && event.kind === 30402
     );
 
-  let searchProductEvents = filterSearchProductEvents(
-    await fetchSearchEvents(searchRelays)
-  );
+  const [selectedSearchEvents, fallbackSearchEvents] = await Promise.all([
+    selectedSearchEventsPromise,
+    fallbackSearchEventsPromise,
+  ]);
+  let searchProductEvents = filterSearchProductEvents([
+    ...selectedSearchEvents,
+    ...fallbackSearchEvents,
+  ]);
   let relevantSearchProductEvents = searchProductEvents.filter((event) =>
     eventMatchesProductSearch(event, searchQuery)
   );

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -66,7 +66,7 @@ type SearchFilter = Filter & { search: string };
 
 const PRODUCT_SEARCH_LIMIT = 100;
 export const NIP50_SEARCH_TIMEOUT_MS = 10_000;
-export const NIP11_RELAY_INFO_TIMEOUT_MS = 3_000;
+const NIP11_RELAY_INFO_TIMEOUT_MS = 3_000;
 const COMMUNITY_POST_BATCH_CONCURRENCY = 4;
 export const DEFAULT_NIP50_SEARCH_RELAYS = [
   "wss://relay.nostr.band",


### PR DESCRIPTION
Earlier the search was technically safe because we post filtered results, but we were still sending the search filter to user-selected relays even if they didn’t support NIP 50.

i changed it so we now check the relay’s NIP 11 metadata first and only treat it as a search relay if supported_nips includes 50. after that we still append our known fallback search relays, and we still post-filter results client-side just in case a relay returns noisy data.

why: NIP 50 recommends checking supported_nips before using search, so this makes the implementation cleaner and avoids sending search queries to relays that may ignore search and return broad results.

NIP 50 says clients should use supported_nips to learn if a relay supports search: [https://github.com/nostr-protocol/nips/blob/master/50.md](https://github.com/nostr-protocol/nips/blob/master/50.md)

NIP 11 defines supported_nips in relay metadata: [https://github.com/nostr-protocol/nips/blob/master/11.md](https://github.com/nostr-protocol/nips/blob/master/11.md)
