### PR TITLE
perf(mcp): compact pagination cursors

### DIFF
--- a/packages/shopstr-mcp/src/tools/utils/pagination-cursor.ts
+++ b/packages/shopstr-mcp/src/tools/utils/pagination-cursor.ts
@@ -3,12 +3,15 @@ import { z } from "zod";
 
 import { MCP_ERROR_CODES, type McpErrorCode } from "../../errors.js";
 
-const CURSOR_VERSION = 1;
+const LEGACY_CURSOR_VERSION = 1;
+const CURSOR_VERSION = 2;
 const MAX_CURSOR_LENGTH = 16_384;
 const MAX_SEEN_IDS = 128;
 const MAX_RELAY_LIMIT = 500;
 const HEX_64_RE = /^[0-9a-f]{64}$/;
 const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+const CURSOR_MAGIC = Buffer.from("SC", "ascii");
+const CURSOR_HEADER_LENGTH = 45;
 
 const paginationCursorToolSchema = z.enum([
   "search_products",
@@ -16,18 +19,24 @@ const paginationCursorToolSchema = z.enum([
   "list_companies",
 ]);
 
-const paginationCursorPayloadSchema = z
+const paginationCursorFields = {
+  tool: paginationCursorToolSchema,
+  query: z.string().regex(HEX_64_RE),
+  boundary: z.number().int().nonnegative(),
+  seen: z
+    .array(z.string().regex(HEX_64_RE))
+    .max(MAX_SEEN_IDS)
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: "Cursor seen IDs must be unique",
+    }),
+};
+
+const paginationCursorInputSchema = z.object(paginationCursorFields).strict();
+
+const legacyPaginationCursorPayloadSchema = z
   .object({
-    v: z.literal(CURSOR_VERSION),
-    tool: paginationCursorToolSchema,
-    query: z.string().regex(HEX_64_RE),
-    boundary: z.number().int().nonnegative(),
-    seen: z
-      .array(z.string().regex(HEX_64_RE))
-      .max(MAX_SEEN_IDS)
-      .refine((ids) => new Set(ids).size === ids.length, {
-        message: "Cursor seen IDs must be unique",
-      }),
+    v: z.literal(LEGACY_CURSOR_VERSION),
+    ...paginationCursorFields,
   })
   .strict();
 
@@ -45,6 +54,20 @@ export type PaginationCursorExpected = {
 
 export type PaginationCursorInput = PaginationCursorExpected &
   PaginationCursorState;
+
+type DecodedPaginationCursor = PaginationCursorInput;
+
+const CURSOR_TOOL_CODES: Record<PaginationCursorTool, number> = {
+  search_products: 0,
+  get_reviews: 1,
+  list_companies: 2,
+};
+
+const CURSOR_TOOLS_BY_CODE: readonly PaginationCursorTool[] = [
+  "search_products",
+  "get_reviews",
+  "list_companies",
+];
 
 type PaginationEvent = {
   id: string;
@@ -85,28 +108,78 @@ export function decodePaginationCursor(
     throw invalidCursor();
   }
 
-  let rawPayload: unknown;
+  let payload: Buffer;
   try {
-    rawPayload = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+    payload = Buffer.from(cursor, "base64url");
   } catch {
     throw invalidCursor();
   }
 
-  const parsed = paginationCursorPayloadSchema.safeParse(rawPayload);
-  if (!parsed.success) {
-    throw invalidCursor();
-  }
+  const decoded =
+    payload[0] === 0x7b
+      ? decodeLegacyPaginationCursor(payload)
+      : decodePaginationCursorV2(payload);
 
-  if (
-    parsed.data.tool !== expected.tool ||
-    parsed.data.query !== expected.query
-  ) {
+  if (decoded.tool !== expected.tool || decoded.query !== expected.query) {
     throw invalidCursor("Pagination cursor does not match this request");
   }
 
   return {
-    boundary: parsed.data.boundary,
-    seen: parsed.data.seen,
+    boundary: decoded.boundary,
+    seen: decoded.seen,
+  };
+}
+
+function decodeLegacyPaginationCursor(
+  payload: Buffer
+): DecodedPaginationCursor {
+  let rawPayload: unknown;
+  try {
+    rawPayload = JSON.parse(payload.toString("utf8"));
+  } catch {
+    throw invalidCursor();
+  }
+
+  const parsed = legacyPaginationCursorPayloadSchema.safeParse(rawPayload);
+  if (!parsed.success) throw invalidCursor();
+
+  return parsed.data;
+}
+
+function decodePaginationCursorV2(payload: Buffer): DecodedPaginationCursor {
+  if (
+    payload.length < CURSOR_HEADER_LENGTH ||
+    !payload.subarray(0, 2).equals(CURSOR_MAGIC) ||
+    payload[2] !== CURSOR_VERSION
+  ) {
+    throw invalidCursor();
+  }
+
+  const tool = CURSOR_TOOLS_BY_CODE[payload[3]!];
+  const seenCount = payload[44]!;
+  if (
+    tool === undefined ||
+    seenCount > MAX_SEEN_IDS ||
+    payload.length !== CURSOR_HEADER_LENGTH + seenCount * 32
+  ) {
+    throw invalidCursor();
+  }
+
+  const boundaryBigInt = payload.readBigUInt64BE(4);
+  if (boundaryBigInt > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw invalidCursor();
+  }
+
+  const seen = Array.from({ length: seenCount }, (_, index) =>
+    payload.subarray(45 + index * 32, 45 + (index + 1) * 32).toString("hex")
+  );
+  if (new Set(seen).size !== seen.length) throw invalidCursor();
+
+  return {
+    tool,
+    query: payload.subarray(12, 44).toString("hex"),
+    boundary: Number(boundaryBigInt),
+    seen,
   };
 }
 
@@ -169,15 +242,26 @@ export function createPaginationCursor(input: PaginationCursorInput): string {
     );
   }
 
-  const parsed = paginationCursorPayloadSchema.safeParse({
-    v: CURSOR_VERSION,
-    ...input,
-  });
+  const parsed = paginationCursorInputSchema.safeParse(input);
   if (!parsed.success) {
     throw invalidCursor("Cannot create an invalid pagination cursor");
   }
 
-  return Buffer.from(JSON.stringify(parsed.data)).toString("base64url");
+  return encodePaginationCursorV2(parsed.data);
+}
+
+function encodePaginationCursorV2(input: PaginationCursorInput): string {
+  const payload = Buffer.alloc(CURSOR_HEADER_LENGTH + input.seen.length * 32);
+  CURSOR_MAGIC.copy(payload, 0);
+  payload.writeUInt8(CURSOR_VERSION, 2);
+  payload.writeUInt8(CURSOR_TOOL_CODES[input.tool], 3);
+  payload.writeBigUInt64BE(BigInt(input.boundary), 4);
+  Buffer.from(input.query, "hex").copy(payload, 12);
+  payload.writeUInt8(input.seen.length, 44);
+  input.seen.forEach((identity, index) => {
+    Buffer.from(identity, "hex").copy(payload, 45 + index * 32);
+  });
+  return payload.toString("base64url");
 }
 
 export function getPaginatedRelayLimit(

--- a/packages/shopstr-mcp/test/pagination-cursor.node.mjs
+++ b/packages/shopstr-mcp/test/pagination-cursor.node.mjs
@@ -42,6 +42,78 @@ test("round-trips a versioned cursor and fingerprints fixed-order query values",
   );
 });
 
+test("emits compact version 2 cursors", () => {
+  const cursor = createPaginationCursor({
+    ...expected,
+    boundary: 42,
+    seen: [hex("a"), hex("b")],
+  });
+  const bytes = Buffer.from(cursor, "base64url");
+
+  assert.equal(bytes.subarray(0, 2).toString("ascii"), "SC");
+  assert.equal(bytes[2], 2);
+  assert.deepEqual(decodePaginationCursor(cursor, expected), {
+    boundary: 42,
+    seen: [hex("a"), hex("b")],
+  });
+});
+
+test("decodes legacy version 1 JSON cursors", () => {
+  const cursor = encodeCursor({
+    v: 1,
+    ...expected,
+    boundary: 42,
+    seen: [hex("a"), hex("b")],
+  });
+
+  assert.deepEqual(decodePaginationCursor(cursor, expected), {
+    boundary: 42,
+    seen: [hex("a"), hex("b")],
+  });
+});
+
+test("keeps compact cursors within the planned size ceilings", () => {
+  const makeSeen = (count) =>
+    Array.from({ length: count }, (_, index) =>
+      index.toString(16).padStart(64, "0")
+    );
+
+  assert.ok(
+    createPaginationCursor({
+      ...expected,
+      boundary: 42,
+      seen: makeSeen(37),
+    }).length <= 1_640
+  );
+  assert.ok(
+    createPaginationCursor({
+      ...expected,
+      boundary: 42,
+      seen: makeSeen(128),
+    }).length <= 5_522
+  );
+});
+
+test("rejects malformed version 2 binary cursors", () => {
+  const valid = Buffer.from(
+    createPaginationCursor({ ...expected, boundary: 42, seen: [hex("a")] }),
+    "base64url"
+  );
+  const badVersion = Buffer.from(valid);
+  badVersion[2] = 3;
+  const badTool = Buffer.from(valid);
+  badTool[3] = 255;
+  const badCount = Buffer.from(valid);
+  badCount[44] = 2;
+
+  for (const bytes of [valid.subarray(0, 44), badVersion, badTool, badCount]) {
+    assertCursorError(
+      () => decodePaginationCursor(bytes.toString("base64url"), expected),
+      MCP_ERROR_CODES.VALIDATION_ERROR
+    );
+  }
+});
+
 test("rejects malformed and strictly invalid cursor payloads", () => {
   const invalidPayloads = [
     "not a base64url cursor",


### PR DESCRIPTION
## Summary
- emit compact binary v2 pagination cursors using raw SHA-256 digest bytes
- keep strict decoding support for existing JSON v1 cursors
- reduce cursor size from about 3.5 KB to 1.64 KB at 37 identities and from about 11.6 KB to 5.52 KB at the 128-identity cap
- reject malformed or mismatched v2 payloads without changing the public MCP cursor API
