### PR TITLE
fix: prevent orders loading deadlock

### DIFF
--- a/utils/nostr/__tests__/fetch-service.test.ts
+++ b/utils/nostr/__tests__/fetch-service.test.ts
@@ -4653,7 +4653,7 @@ describe("fetchGiftWrappedChatsAndMessages", () => {
     expect(result.profileSetFromChats).toContain(senderPubkey);
   });
 
-  it("logs error and alert when a message event has no p-tag (lines 1030-1038)", async () => {
+  it("skips a message without a p-tag and completes chat loading", async () => {
     jest.doMock("@/utils/db/db-client", () => ({
       cacheEventsToDatabase: jest.fn().mockResolvedValue(undefined),
     }));
@@ -4708,29 +4708,35 @@ describe("fetchGiftWrappedChatsAndMessages", () => {
         .mockResolvedValueOnce(JSON.stringify(msgEvent)),
     };
 
-    const consoleErrorSpy = jest
-      .spyOn(console, "error")
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
       .mockImplementation(() => {});
     const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+    const editChatContext = jest.fn();
 
-    fetchGiftWrappedChatsAndMessages(
-      nostr as any,
-      signer as any,
-      ["wss://relay.example"],
-      jest.fn(),
-      userPubkey
-    );
+    const result = await Promise.race([
+      fetchGiftWrappedChatsAndMessages(
+        nostr as any,
+        signer as any,
+        ["wss://relay.example"],
+        editChatContext,
+        userPubkey
+      ),
+      new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 100)
+      ),
+    ]);
 
-    // Wait for all nested awaits inside the function to complete
-    await new Promise((r) => setTimeout(r, 0));
+    expect(result).not.toBe("timeout");
+    expect(result).toEqual({ profileSetFromChats: new Set() });
+    expect(editChatContext).toHaveBeenCalledWith(new Map(), false);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "Skipping gift-wrapped chat message without recipient p tag",
+      { wrappedEventId: wrapEvent.id }
+    );
+    expect(alertMock).not.toHaveBeenCalled();
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("fetchAllOutgoingChats")
-    );
-    expect(alertMock).toHaveBeenCalledWith(
-      expect.stringContaining("fetchAllOutgoingChats")
-    );
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
     alertMock.mockRestore();
   });
 

--- a/utils/nostr/fetch-service.ts
+++ b/utils/nostr/fetch-service.ts
@@ -1169,17 +1169,13 @@ export const fetchGiftWrappedChatsAndMessages = async (
           ) {
             continue;
           }
-          const recipientPubkey = tagsMap.get("p") ? tagsMap.get("p") : null; // pubkey you sent the message to
-          if (typeof recipientPubkey !== "string") {
-            console.error(
-              `fetchAllOutgoingChats: Failed to get recipientPubkey from tagsMap",
-                ${tagsMap},
-                ${event}`
+          const recipientPubkey = tagsMap.get("p"); // pubkey you sent the message to
+          if (!recipientPubkey) {
+            console.warn(
+              "Skipping gift-wrapped chat message without recipient p tag",
+              { wrappedEventId: event.id }
             );
-            alert(
-              `fetchAllOutgoingChats: Failed to get recipientPubkey from tagsMap`
-            );
-            return;
+            continue;
           }
           const cachedMessage = chatMessagesFromCache.get(event.id);
           let chatMessage: NostrMessageEvent;


### PR DESCRIPTION
## Summary

- Skip supported gift-wrapped chat messages that lack the required recipient p tag.
- Remove the blocking alert and ensure chat loading always reaches its completion callback.
- Add a regression test proving malformed messages cannot leave the loader pending.

## Root cause

The loader returned from inside its Promise executor without resolving or rejecting. The app waits for that Promise before clearing ChatsContext loading, so Orders and My Listings / Orders could remain on the loading screen forever.