### PR TITLE
MCP(fix) : Prevent adding of discarded entries to pagination cursor

### DIFF
--- a/packages/shopstr-mcp/src/tools/get-reviews.ts
+++ b/packages/shopstr-mcp/src/tools/get-reviews.ts
@@ -239,11 +239,18 @@ function buildResponse(
           returnedReviewEvents
         );
       } else {
+        const returnedIds = new Set(
+          returnedReviewEvents.map((event) => event.id)
+        );
         nextCursor = createNextCursor(
           query,
           cursorState,
           sparseScan!.boundary!,
-          sparseScan!.rawEvents
+          sparseScan!.rawEvents.filter(
+            (event) =>
+              event.created_at === sparseScan!.boundary ||
+              returnedIds.has(event.id)
+          )
         );
       }
     } catch (error) {

--- a/packages/shopstr-mcp/src/tools/list-companies.ts
+++ b/packages/shopstr-mcp/src/tools/list-companies.ts
@@ -255,11 +255,18 @@ export async function handleListCompanies(
           returnedCompanyEntries.map(({ profile }) => profile)
         );
       } else {
+        const returnedPubkeys = new Set(
+          returnedCompanies.map((company) => company.pubkey)
+        );
         nextCursor = createNextCursor(
           query,
           cursorState,
           sparseBoundary!,
-          rawProfileWindow
+          rawProfileWindow.filter(
+            (event) =>
+              event.created_at === sparseBoundary ||
+              returnedPubkeys.has(event.pubkey)
+          )
         );
       }
     } catch (error) {

--- a/packages/shopstr-mcp/test/tools/get-reviews.node.mjs
+++ b/packages/shopstr-mcp/test/tools/get-reviews.node.mjs
@@ -7,6 +7,7 @@ import { REVIEW_PRODUCT_FILTER_LIMIT } from "../../dist/tools/utils/common.js";
 import {
   createPaginationCursor,
   createQueryFingerprint,
+  decodePaginationCursor,
   hashPaginationLogicalIdentity,
 } from "../../dist/tools/utils/pagination-cursor.js";
 
@@ -536,6 +537,77 @@ test("get_reviews advances past a full raw window of revisions from one reviewer
   assert.equal(second.count, 1);
   assert.equal(second.reviews[0].pubkey, olderReviewer);
   assert.equal(capturedFilters[1][0].until, 950);
+});
+
+test("get_reviews does not overfill cursor seen ids for a large sparse relay window", async () => {
+  const reviewer = hex("1");
+  const matchingRevisions = Array.from({ length: 51 }, (_, index) =>
+    reviewEvent({
+      id: (index + 1).toString(16).padStart(64, "0"),
+      pubkey: reviewer,
+      created_at: 1_000 - index,
+      tags: [
+        ["d", `a:${productAddress}`],
+        ["a", productAddress],
+        ["rating", "1", "thumb"],
+      ],
+    })
+  );
+  const unrelatedReviews = Array.from({ length: 150 }, (_, index) =>
+    reviewEvent({
+      id: (1_000 + index).toString(16).padStart(64, "0"),
+      pubkey: (2_000 + index).toString(16).padStart(64, "0"),
+      created_at: 999 - index,
+      tags: [
+        ["d", `unrelated-${index}`],
+        ["rating", "1", "thumb"],
+      ],
+    })
+  );
+  const olderReview = reviewEvent({
+    id: hex("f"),
+    pubkey: hex("2"),
+    created_at: 949,
+    tags: [
+      ["d", `a:${productAddress}`],
+      ["a", productAddress],
+      ["rating", "0.8", "quality"],
+    ],
+  });
+  const saturatedWindow = [...matchingRevisions, ...unrelatedReviews];
+  const capturedFilters = [];
+  const ctx = context((filters) => {
+    capturedFilters.push(filters);
+    return filters[0].until === undefined ? saturatedWindow : [olderReview];
+  });
+
+  const first = JSON.parse(
+    (await handleGetReviews({ productAddress }, ctx)).content[0].text
+  );
+  const decodedCursor = decodePaginationCursor(first._pagination.nextCursor, {
+    tool: "get_reviews",
+    query: createQueryFingerprint("get_reviews", [
+      undefined,
+      productAddress,
+      undefined,
+      50,
+    ]),
+  });
+  const second = JSON.parse(
+    (
+      await handleGetReviews(
+        { productAddress, cursor: first._pagination.nextCursor },
+        ctx
+      )
+    ).content[0].text
+  );
+
+  assert.equal(first.count, 1);
+  assert.equal(first._pagination.hasMore, true);
+  assert.equal(decodedCursor.boundary, 950);
+  assert.ok(decodedCursor.seen.length <= 2);
+  assert.equal(capturedFilters[1][0].until, 950);
+  assert.equal(second.reviews[0].id, olderReview.id);
 });
 
 test("get_reviews advances from a saturated continuation window containing only consumed revisions", async () => {

--- a/packages/shopstr-mcp/test/tools/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/tools/search-products.node.mjs
@@ -6,6 +6,7 @@ import { MemoryCache } from "../../dist/cache.js";
 import {
   createPaginationCursor,
   createQueryFingerprint,
+  decodePaginationCursor,
   hashPaginationLogicalIdentity,
 } from "../../dist/tools/utils/pagination-cursor.js";
 
@@ -1134,6 +1135,72 @@ test("search_products advances a sparse search through a full relay window", asy
   );
   assert.equal(second.products[0].id, hex("6"));
   assert.equal(capturedFilters[1][0].until, 96);
+});
+
+test("search_products does not overfill cursor seen ids for a large sparse relay window", async () => {
+  const saturatedWindow = Array.from({ length: 185 }, (_, index) =>
+    productEvent({
+      id: index.toString(16).padStart(64, "0"),
+      created_at: 1_000 - index,
+      tags: [
+        ["d", `window-${index}`],
+        ["title", index === 0 ? "Electronics Match" : "Other Product"],
+      ],
+    })
+  );
+  const olderWindow = [
+    productEvent({
+      id: hex("f"),
+      created_at: 814,
+      tags: [
+        ["d", "older-electronics"],
+        ["title", "Older Electronics Match"],
+      ],
+    }),
+  ];
+  const capturedFilters = [];
+  const ctx = {
+    ...context({ "wss://relay.example.com": [] }),
+    nostr: {
+      async fetch(filters) {
+        capturedFilters.push(filters);
+        return filters[0].until === undefined ? saturatedWindow : olderWindow;
+      },
+    },
+  };
+
+  const first = JSON.parse(
+    (await handleSearchProducts({ keyword: "electronics" }, ctx)).content[0]
+      .text
+  );
+  const decodedCursor = decodePaginationCursor(first._pagination.nextCursor, {
+    tool: "search_products",
+    query: createQueryFingerprint("search_products", [
+      "electronics",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      37,
+      "newest",
+    ]),
+  });
+  const second = JSON.parse(
+    (
+      await handleSearchProducts(
+        { keyword: "electronics", cursor: first._pagination.nextCursor },
+        ctx
+      )
+    ).content[0].text
+  );
+
+  assert.equal(first.count, 1);
+  assert.equal(first._pagination.hasMore, true);
+  assert.equal(decodedCursor.boundary, 816);
+  assert.ok(decodedCursor.seen.length <= 2);
+  assert.equal(capturedFilters[1][0].until, 816);
+  assert.equal(second.products[0].id, olderWindow[0].id);
 });
 
 test("search_products advances from the newest saturated relay boundary", async () => {

--- a/packages/shopstr-mcp/test/tools/seller-tools.node.mjs
+++ b/packages/shopstr-mcp/test/tools/seller-tools.node.mjs
@@ -11,6 +11,7 @@ import { REVIEW_PRODUCT_FILTER_LIMIT } from "../../dist/tools/utils/common.js";
 import {
   createPaginationCursor,
   createQueryFingerprint,
+  decodePaginationCursor,
   hashPaginationLogicalIdentity,
 } from "../../dist/tools/utils/pagination-cursor.js";
 
@@ -413,6 +414,62 @@ test("list_companies advances sparse category windows from the oldest raw profil
   );
   assert.equal(second.companies[0].pubkey, secondSeller);
   assert.equal(profileFilters[1][0].until, 501);
+});
+
+test("list_companies does not overfill cursor seen ids for a large sparse category window", async () => {
+  const firstSeller = hex("1");
+  const olderSeller = hex("2");
+  const initialWindow = Array.from({ length: 500 }, (_, index) =>
+    shopEvent({
+      id: (index + 1).toString(16).padStart(64, "0"),
+      pubkey: (index + 20).toString(16).padStart(64, "0"),
+      created_at: 1_000 - index,
+    })
+  );
+  initialWindow[0] = shopEvent({
+    id: hex("1"),
+    pubkey: firstSeller,
+    created_at: 1_000,
+  });
+  const olderWindow = [
+    shopEvent({ id: hex("f"), pubkey: olderSeller, created_at: 500 }),
+  ];
+  const profileFilters = [];
+  const ctx = context((filters) => {
+    if (filters.some((filter) => filter.kinds?.includes(30019))) {
+      profileFilters.push(filters);
+      return filters[0].until === undefined ? initialWindow : olderWindow;
+    }
+    return [
+      productEvent({ pubkey: firstSeller }),
+      productEvent({ id: hex("e"), pubkey: olderSeller }),
+    ];
+  });
+
+  const first = JSON.parse(
+    (await handleListCompanies({ category: "coffee", limit: 1 }, ctx))
+      .content[0].text
+  );
+  const decodedCursor = decodePaginationCursor(first._pagination.nextCursor, {
+    tool: "list_companies",
+    query: createQueryFingerprint("list_companies", ["coffee", 1]),
+  });
+  const second = JSON.parse(
+    (
+      await handleListCompanies(
+        { category: "coffee", limit: 1, cursor: first._pagination.nextCursor },
+        ctx
+      )
+    ).content[0].text
+  );
+
+  assert.equal(first.count, 1);
+  assert.equal(first.companies[0].pubkey, firstSeller);
+  assert.equal(first._pagination.hasMore, true);
+  assert.equal(decodedCursor.boundary, 501);
+  assert.ok(decodedCursor.seen.length <= 2);
+  assert.equal(profileFilters[1][0].until, 501);
+  assert.equal(second.companies[0].pubkey, olderSeller);
 });
 
 test("list_companies advances from the newest saturated relay boundary", async () => {


### PR DESCRIPTION
### Description

- Currently unfiltered raw window is fed into seen - the sparse-window branch in each tool pushed the entire scanned window (e.g. 185 events) into the cursor's seen set instead of just events needing dedup protection, exceeding the 128-entry cap before any real results were returned.
- Fixed sparse-window pagination - cursor creation now tracks only boundary-tied events and items actually returned, instead of the entire scanned relay window.
- Preserved stale-revision protection - returned item identities remain tracked across pagination sessions.
- Kept sparse-window boundaries unchanged - pagination continues from the full scanned boundary

### Resolved or fixed issue
 `none`  

## Video
Before : https://drive.google.com/file/d/1nHKS0eolVLptf4679oz5p2sr11C7Z1Cm/view?usp=sharing 
After : https://drive.google.com/file/d/1pKRyWng21JvP-Sx2XhDSXVWGxjoyPHYh/view?usp=sharing
### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
