### PR TITLE
Add NIP-50 support to search-products tool - MCP server

### DIFF
--- a/packages/shopstr-mcp/.env.example
+++ b/packages/shopstr-mcp/.env.example
@@ -2,6 +2,9 @@
 # wss://nos.lol,wss://relay.damus.io,wss://purplepag.es
 SHOPSTR_MCP_RELAYS=wss://nos.lol,wss://relay.damus.io,wss://purplepag.es
 
+# Curated NIP-50 search relays used only for search_products keyword searches.
+SHOPSTR_MCP_NIP50_SEARCH_RELAYS=wss://relay.nostr.band,wss://nostr.wine,wss://relay.noswhere.com,wss://search.nos.today,wss://antiprimal.net,wss://relay.ditto.pub
+
 
 # Log level for json logs written to stderr.
 # levels : error, warn, info, debug

--- a/packages/shopstr-mcp/.env.example
+++ b/packages/shopstr-mcp/.env.example
@@ -2,7 +2,7 @@
 # wss://nos.lol,wss://relay.damus.io,wss://purplepag.es
 SHOPSTR_MCP_RELAYS=wss://nos.lol,wss://relay.damus.io,wss://purplepag.es
 
-# Curated NIP-50 search relays used only for search_products keyword searches.
+# Curated NIP-50 relays used for keyword searches. Set to an empty value to disable.
 SHOPSTR_MCP_NIP50_SEARCH_RELAYS=wss://nostr.wine,wss://relay.noswhere.com,wss://search.nos.today,wss://antiprimal.net
 
 

--- a/packages/shopstr-mcp/.env.example
+++ b/packages/shopstr-mcp/.env.example
@@ -2,8 +2,9 @@
 # wss://nos.lol,wss://relay.damus.io,wss://purplepag.es
 SHOPSTR_MCP_RELAYS=wss://nos.lol,wss://relay.damus.io,wss://purplepag.es
 
-# Curated NIP-50 relays used for keyword searches. Set to an empty value to disable.
-SHOPSTR_MCP_NIP50_SEARCH_RELAYS=wss://nostr.wine,wss://relay.noswhere.com,wss://search.nos.today,wss://antiprimal.net
+# Optional NIP-50 relays. Keyword queries are sent to these third parties.
+# Example: wss://relay.noswhere.com,wss://search.nos.today
+SHOPSTR_MCP_NIP50_SEARCH_RELAYS=
 
 
 # Log level for json logs written to stderr.

--- a/packages/shopstr-mcp/.env.example
+++ b/packages/shopstr-mcp/.env.example
@@ -3,7 +3,7 @@
 SHOPSTR_MCP_RELAYS=wss://nos.lol,wss://relay.damus.io,wss://purplepag.es
 
 # Curated NIP-50 search relays used only for search_products keyword searches.
-SHOPSTR_MCP_NIP50_SEARCH_RELAYS=wss://relay.nostr.band,wss://nostr.wine,wss://relay.noswhere.com,wss://search.nos.today,wss://antiprimal.net,wss://relay.ditto.pub
+SHOPSTR_MCP_NIP50_SEARCH_RELAYS=wss://nostr.wine,wss://relay.noswhere.com,wss://search.nos.today,wss://antiprimal.net
 
 
 # Log level for json logs written to stderr.

--- a/packages/shopstr-mcp/README.md
+++ b/packages/shopstr-mcp/README.md
@@ -124,6 +124,8 @@ or process manager should provide.
 ## Environment
 
 - `SHOPSTR_MCP_RELAYS`: comma-separated `ws://` or `wss://` relay URLs.
+- `SHOPSTR_MCP_NIP50_SEARCH_RELAYS`: comma-separated NIP-50 relay URLs used
+  for keyword searches. Set to an empty value to disable external search relays.
 - `SHOPSTR_MCP_LOG_LEVEL`: `error`, `warn`, `info`, or `debug`.
 - `SHOPSTR_MCP_TOOL_TIMEOUT_MS`: default future per-tool timeout in
   milliseconds.

--- a/packages/shopstr-mcp/README.md
+++ b/packages/shopstr-mcp/README.md
@@ -124,8 +124,9 @@ or process manager should provide.
 ## Environment
 
 - `SHOPSTR_MCP_RELAYS`: comma-separated `ws://` or `wss://` relay URLs.
-- `SHOPSTR_MCP_NIP50_SEARCH_RELAYS`: comma-separated NIP-50 relay URLs used
-  for keyword searches. Set to an empty value to disable external search relays.
+- `SHOPSTR_MCP_NIP50_SEARCH_RELAYS`: optional comma-separated NIP-50 relay URLs
+  used for keyword searches. Disabled by default. When configured, keyword
+  queries are disclosed to those third-party relay operators.
 - `SHOPSTR_MCP_LOG_LEVEL`: `error`, `warn`, `info`, or `debug`.
 - `SHOPSTR_MCP_TOOL_TIMEOUT_MS`: default future per-tool timeout in
   milliseconds.

--- a/packages/shopstr-mcp/src/config.ts
+++ b/packages/shopstr-mcp/src/config.ts
@@ -6,6 +6,15 @@ export const DEFAULT_RELAYS = [
   "wss://purplepag.es",
 ] as const;
 
+export const DEFAULT_NIP50_SEARCH_RELAYS = [
+  "wss://relay.nostr.band",
+  "wss://nostr.wine",
+  "wss://relay.noswhere.com",
+  "wss://search.nos.today",
+  "wss://antiprimal.net",
+  "wss://relay.ditto.pub",
+] as const;
+
 export const DEFAULT_TOOL_TIMEOUT_MS = 10_000;
 export const DEFAULT_RELAY_CONNECT_TIMEOUT_MS = 5_000;
 export const DEFAULT_RESOURCE_CACHE_TTL_MS = 60_000;
@@ -23,6 +32,7 @@ export type LogLevel = "error" | "warn" | "info" | "debug";
 export type ShopstrMcpConfig = {
   version: string;
   relays: string[];
+  nip50SearchRelays: string[];
   logLevel: LogLevel;
   defaultToolTimeoutMs: number;
   relayConnectTimeoutMs: number;
@@ -48,8 +58,11 @@ export function validateRelayUrl(value: string): boolean {
   }
 }
 
-export function parseRelayList(rawRelays?: string): string[] {
-  if (!rawRelays) return [...DEFAULT_RELAYS];
+export function parseRelayList(
+  rawRelays?: string,
+  fallbackRelays: readonly string[] = DEFAULT_RELAYS
+): string[] {
+  if (!rawRelays) return [...fallbackRelays];
 
   const relays = rawRelays
     .split(",")
@@ -57,7 +70,7 @@ export function parseRelayList(rawRelays?: string): string[] {
     .filter(Boolean)
     .filter(validateRelayUrl);
 
-  return relays.length > 0 ? [...new Set(relays)] : [...DEFAULT_RELAYS];
+  return relays.length > 0 ? [...new Set(relays)] : [...fallbackRelays];
 }
 
 export function parseLogLevel(rawLogLevel?: string): LogLevel {
@@ -84,6 +97,10 @@ export function loadConfig(
   return {
     version: env.npm_package_version ?? "0.1.0",
     relays: parseRelayList(env.SHOPSTR_MCP_RELAYS),
+    nip50SearchRelays: parseRelayList(
+      env.SHOPSTR_MCP_NIP50_SEARCH_RELAYS,
+      DEFAULT_NIP50_SEARCH_RELAYS
+    ),
     logLevel: parseLogLevel(env.SHOPSTR_MCP_LOG_LEVEL),
     defaultToolTimeoutMs: parsePositiveInteger(
       env.SHOPSTR_MCP_TOOL_TIMEOUT_MS,

--- a/packages/shopstr-mcp/src/config.ts
+++ b/packages/shopstr-mcp/src/config.ts
@@ -7,12 +7,10 @@ export const DEFAULT_RELAYS = [
 ] as const;
 
 export const DEFAULT_NIP50_SEARCH_RELAYS = [
-  "wss://relay.nostr.band",
   "wss://nostr.wine",
   "wss://relay.noswhere.com",
   "wss://search.nos.today",
   "wss://antiprimal.net",
-  "wss://relay.ditto.pub",
 ] as const;
 
 export const DEFAULT_TOOL_TIMEOUT_MS = 10_000;

--- a/packages/shopstr-mcp/src/config.ts
+++ b/packages/shopstr-mcp/src/config.ts
@@ -6,12 +6,7 @@ export const DEFAULT_RELAYS = [
   "wss://purplepag.es",
 ] as const;
 
-export const DEFAULT_NIP50_SEARCH_RELAYS = [
-  "wss://nostr.wine",
-  "wss://relay.noswhere.com",
-  "wss://search.nos.today",
-  "wss://antiprimal.net",
-] as const;
+export const DEFAULT_NIP50_SEARCH_RELAYS = [] as const;
 
 export const DEFAULT_TOOL_TIMEOUT_MS = 10_000;
 export const DEFAULT_RELAY_CONNECT_TIMEOUT_MS = 5_000;

--- a/packages/shopstr-mcp/src/config.ts
+++ b/packages/shopstr-mcp/src/config.ts
@@ -95,10 +95,13 @@ export function loadConfig(
   return {
     version: env.npm_package_version ?? "0.1.0",
     relays: parseRelayList(env.SHOPSTR_MCP_RELAYS),
-    nip50SearchRelays: parseRelayList(
-      env.SHOPSTR_MCP_NIP50_SEARCH_RELAYS,
-      DEFAULT_NIP50_SEARCH_RELAYS
-    ),
+    nip50SearchRelays:
+      env.SHOPSTR_MCP_NIP50_SEARCH_RELAYS?.trim() === ""
+        ? []
+        : parseRelayList(
+            env.SHOPSTR_MCP_NIP50_SEARCH_RELAYS,
+            DEFAULT_NIP50_SEARCH_RELAYS
+          ),
     logLevel: parseLogLevel(env.SHOPSTR_MCP_LOG_LEVEL),
     defaultToolTimeoutMs: parsePositiveInteger(
       env.SHOPSTR_MCP_TOOL_TIMEOUT_MS,

--- a/packages/shopstr-mcp/src/server.ts
+++ b/packages/shopstr-mcp/src/server.ts
@@ -42,6 +42,7 @@ export function createMcpServer(
   registerCoreTools(server, {
     nostr,
     relays: config.relays,
+    nip50SearchRelays: config.nip50SearchRelays,
     timeoutMs: config.defaultToolTimeoutMs,
     cache,
     categoryCache,

--- a/packages/shopstr-mcp/src/tools/get-product-details.ts
+++ b/packages/shopstr-mcp/src/tools/get-product-details.ts
@@ -36,6 +36,27 @@ export const getProductDetailsInputSchema = {
     .describe("Product address as 30402:<seller-pubkey>:<product-d-tag>"),
 };
 
+const PRODUCT_DESCRIPTION_CHAR_LIMIT = 2_000;
+
+function truncateProductDescription(content: string): {
+  description?: string;
+  truncated: boolean;
+} {
+  const description = content.trim();
+  if (!description) return { truncated: false };
+  if (description.length <= PRODUCT_DESCRIPTION_CHAR_LIMIT) {
+    return { description, truncated: false };
+  }
+
+  const suffix = "...";
+  const maxBodyLength = PRODUCT_DESCRIPTION_CHAR_LIMIT - suffix.length;
+  const clipped = description.slice(0, maxBodyLength);
+  const lastWhitespace = clipped.search(/\s+\S*$/);
+  const body =
+    lastWhitespace > 0 ? clipped.slice(0, lastWhitespace).trimEnd() : clipped;
+  return { description: `${body}${suffix}`, truncated: true };
+}
+
 /**
  * Resolve a productId to a product coordinate by doing a pre-flight fetch.
  * Returns the pubkey and dTag so we can query by coordinate for the latest version.
@@ -170,6 +191,12 @@ export async function handleGetProductDetails(
   }
 
   const product = parseProductEvent(event);
+  const { description, truncated } = truncateProductDescription(event.content);
+  if (truncated) {
+    hints.push(
+      `descriptionTruncated: product description was shortened to ${PRODUCT_DESCRIPTION_CHAR_LIMIT} characters.`
+    );
+  }
   const successMeta = buildToolMeta(relayResult.meta, {
     resultCount: 1,
     totalMatches: 1,
@@ -178,5 +205,9 @@ export async function handleGetProductDetails(
     hints,
   });
 
-  return createSuccessResponse({ product }, successMeta, 1);
+  return createSuccessResponse(
+    { product, ...(description !== undefined && { description }) },
+    successMeta,
+    1
+  );
 }

--- a/packages/shopstr-mcp/src/tools/index.ts
+++ b/packages/shopstr-mcp/src/tools/index.ts
@@ -55,7 +55,7 @@ export function registerCoreTools(
     "search_products",
     {
       description:
-        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. Keyword searches also query curated NIP-50 relays in parallel on every page (including cursor pages); a few slots per page may be NIP-50-sourced matches, tagged matchedVia: `nip50`, that the normal relay stream wouldn't otherwise surface. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
+        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. Keyword searches also query curated NIP-50 relays in parallel on every page (including cursor pages); NIP-50 matches are tagged matchedVia: `nip50` and get a small guaranteed result share, plus any response capacity unused by normal relay matches. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
         UNTRUSTED_CONTENT_NOTE,
       inputSchema: searchProductsInputSchema,
     },
@@ -71,7 +71,7 @@ export function registerCoreTools(
     "get_product_details",
     {
       description:
-        "Get full details for one public Shopstr product listing by productAddress or productId. Prefer productAddress when available because it resolves replaceable listing coordinates directly." +
+        "Get full details for one public Shopstr product listing by productAddress or productId. Prefer productAddress when available because it resolves replaceable listing coordinates directly. May include a sibling description field from the event content, capped at 2,000 characters with a descriptionTruncated hint when shortened." +
         UNTRUSTED_CONTENT_NOTE,
       inputSchema: getProductDetailsInputSchema,
     },

--- a/packages/shopstr-mcp/src/tools/index.ts
+++ b/packages/shopstr-mcp/src/tools/index.ts
@@ -55,7 +55,7 @@ export function registerCoreTools(
     "search_products",
     {
       description:
-        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. Keyword searches also query curated NIP-50 relays in parallel on every page (including cursor pages); NIP-50 matches are tagged matchedVia: `nip50` and get a small guaranteed result share, plus any response capacity unused by normal relay matches. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
+        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. When NIP-50 relays are configured, keyword searches query them in parallel on every page (including cursor pages); NIP-50 matches are tagged matchedVia: `nip50` and get a small guaranteed result share, plus any response capacity unused by normal relay matches. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
         UNTRUSTED_CONTENT_NOTE,
       inputSchema: searchProductsInputSchema,
     },

--- a/packages/shopstr-mcp/src/tools/index.ts
+++ b/packages/shopstr-mcp/src/tools/index.ts
@@ -55,7 +55,7 @@ export function registerCoreTools(
     "search_products",
     {
       description:
-        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
+        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. Keyword searches without a cursor query curated NIP-50 search relays in parallel with normal relays, then merge and deduplicate results. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
         UNTRUSTED_CONTENT_NOTE,
       inputSchema: searchProductsInputSchema,
     },

--- a/packages/shopstr-mcp/src/tools/index.ts
+++ b/packages/shopstr-mcp/src/tools/index.ts
@@ -55,7 +55,7 @@ export function registerCoreTools(
     "search_products",
     {
       description:
-        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. Keyword searches without a cursor query curated NIP-50 search relays in parallel with normal relays, then merge and deduplicate results. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
+        "Search public Shopstr product listings by keyword, category, location, currency, price range, cursor pagination, or price/newest sort. Keyword searches also query curated NIP-50 relays in parallel on every page (including cursor pages); a few slots per page may be NIP-50-sourced matches, tagged matchedVia: `nip50`, that the normal relay stream wouldn't otherwise surface. Use get_categories first when an agent needs observed category names. Hidden listings are excluded. currency is required for price_asc and price_desc. Cursors are only supported with newest sorting; price-sorted searches reject cursors." +
         UNTRUSTED_CONTENT_NOTE,
       inputSchema: searchProductsInputSchema,
     },

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -562,11 +562,21 @@ export async function handleSearchProducts(
   const nip50Products = priceSorted
     ? sortProducts(assembly.nip50Products, filters.sortBy)
     : assembly.nip50Products;
-  const reservedSlots = Math.min(
+  // NIP50_RESERVED_SLOTS is a guaranteed minimum, not a hard cap — if normal
+  // matches don't use their full share of the budget, hand the leftover to NIP-50.
+  const reservedSlotsMin = Math.min(
     NIP50_RESERVED_SLOTS,
     nip50Products.length,
     Math.max(0, responseLimit - 1)
   );
+  const tentativeNormalBudget = responseLimit - reservedSlotsMin;
+  const normalDemand = Math.min(products.length, tentativeNormalBudget);
+  const unusedNormalBudget = tentativeNormalBudget - normalDemand;
+  const extraNip50Slots = Math.min(
+    unusedNormalBudget,
+    Math.max(0, nip50Products.length - reservedSlotsMin)
+  );
+  const reservedSlots = reservedSlotsMin + extraNip50Slots;
   const normalBudget = responseLimit - reservedSlots;
   const pageProducts = products.slice(0, normalBudget + 1);
   const returnedNormal = pageProducts.slice(0, normalBudget);

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -120,7 +120,8 @@ const NIP50_RESERVED_SLOTS = 5;
 
 function productMatchesFilters(
   product: ProductResponse,
-  filters: SearchProductsInput
+  filters: SearchProductsInput,
+  eventContent = ""
 ): boolean {
   // hidden products never returned in search results.
   if (product.visibility === "hidden") return false;
@@ -134,6 +135,7 @@ function productMatchesFilters(
       product.condition,
       product.productFormat,
       product.status,
+      eventContent,
       ...product.categories,
     ]
       .join(" ")
@@ -262,7 +264,11 @@ function sortProducts(
   products: ProductResponse[],
   sortBy: SearchProductsInput["sortBy"]
 ): ProductResponse[] {
-  if (sortBy === "newest") return products;
+  if (sortBy === "newest") {
+    return [...products].sort(
+      (a, b) => b.createdAt - a.createdAt || a.id.localeCompare(b.id)
+    );
+  }
 
   const knownPrice = products.filter(
     (product) => product.priceStatus === "known" && product.price !== undefined
@@ -275,6 +281,28 @@ function sortProducts(
     return sortBy === "price_asc" ? difference : -difference;
   });
   return [...knownPrice, ...unknownPrice];
+}
+
+function preserveSourceOrderWithLatestRevisions(
+  sourceEvents: readonly NostrEvent[],
+  latestEvents: readonly NostrEvent[]
+): NostrEvent[] {
+  const latestByIdentity = new Map(
+    latestEvents.map((event) => [getProductLogicalIdentity(event), event])
+  );
+  const seen = new Set<string>();
+  const ordered: NostrEvent[] = [];
+
+  for (const event of sourceEvents) {
+    const identity = getProductLogicalIdentity(event);
+    if (seen.has(identity)) continue;
+    const latest = latestByIdentity.get(identity);
+    if (!latest) continue;
+    seen.add(identity);
+    ordered.push(latest);
+  }
+
+  return ordered;
 }
 
 function shouldAttemptNip50Search(
@@ -384,19 +412,37 @@ function assemblePage(
         getProductLogicalIdentity
       )
     : rawProductWindow;
-  const scannedProducts = mergeAndDeduplicateProducts(eligibleRawProducts);
-  const products = scannedProducts
-    .map(parseProductEvent)
-    .filter((product) => productMatchesFilters(product, filters));
-  const normalIdentities = new Set(
-    scannedProducts.map(getProductLogicalIdentity)
+  const normalScannedProducts =
+    mergeAndDeduplicateProducts(eligibleRawProducts);
+  const latestProducts = mergeAndDeduplicateProducts([
+    ...normalScannedProducts,
+    ...relayResult.nip50Events,
+  ]);
+  const latestByIdentity = new Map(
+    latestProducts.map((event) => [getProductLogicalIdentity(event), event])
   );
-  const nip50ScannedProducts = mergeAndDeduplicateProducts(
-    relayResult.nip50Events
+  const normalIdentities = new Set(
+    normalScannedProducts.map(getProductLogicalIdentity)
+  );
+  const scannedProducts = normalScannedProducts.map(
+    (event) => latestByIdentity.get(getProductLogicalIdentity(event)) ?? event
+  );
+  const products = scannedProducts
+    .map((event) => ({ event, product: parseProductEvent(event) }))
+    .filter(({ event, product }) =>
+      productMatchesFilters(product, filters, event.content)
+    )
+    .map(({ product }) => product);
+  const nip50ScannedProducts = preserveSourceOrderWithLatestRevisions(
+    relayResult.nip50Events,
+    latestProducts
   ).filter((event) => !normalIdentities.has(getProductLogicalIdentity(event)));
   const nip50Products = nip50ScannedProducts
-    .map(parseProductEvent)
-    .filter((product) => productMatchesFilters(product, filters));
+    .map((event) => ({ event, product: parseProductEvent(event) }))
+    .filter(({ event, product }) =>
+      productMatchesFilters(product, filters, event.content)
+    )
+    .map(({ product }) => product);
 
   return {
     products,
@@ -511,27 +557,32 @@ export async function handleSearchProducts(
   }
 
   const products = sortProducts(assembly.products, filters.sortBy);
+  const priceSorted =
+    filters.sortBy === "price_asc" || filters.sortBy === "price_desc";
+  const nip50Products = priceSorted
+    ? sortProducts(assembly.nip50Products, filters.sortBy)
+    : assembly.nip50Products;
   const reservedSlots = Math.min(
     NIP50_RESERVED_SLOTS,
-    assembly.nip50Products.length,
+    nip50Products.length,
     Math.max(0, responseLimit - 1)
   );
   const normalBudget = responseLimit - reservedSlots;
   const pageProducts = products.slice(0, normalBudget + 1);
-  const priceSorted =
-    filters.sortBy === "price_asc" || filters.sortBy === "price_desc";
   const returnedNormal = pageProducts.slice(0, normalBudget);
-  const returnedNip50 = assembly.nip50Products
+  const returnedNip50 = nip50Products
     .slice(0, reservedSlots)
     .map((product): SearchProductResponse => ({
       ...product,
       matchedVia: "nip50",
     }));
-  const returnedProducts: SearchProductResponse[] = [
-    ...returnedNormal,
-    ...returnedNip50,
-  ];
+  const returnedProducts = sortProducts(
+    [...returnedNormal, ...returnedNip50],
+    filters.sortBy
+  ) as SearchProductResponse[];
   const hasMatchingProductsBeyondPage = pageProducts.length > normalBudget;
+  const hasNip50ProductsBeyondPage =
+    reservedSlots > 0 && nip50Products.length > reservedSlots;
   const shouldAdvanceSparseWindow =
     !priceSorted &&
     !hasMatchingProductsBeyondPage &&
@@ -539,7 +590,9 @@ export async function handleSearchProducts(
     assembly.rawProductWindow.length > 0;
   const hasMore =
     !priceSorted &&
-    (hasMatchingProductsBeyondPage || shouldAdvanceSparseWindow);
+    (hasMatchingProductsBeyondPage ||
+      shouldAdvanceSparseWindow ||
+      hasNip50ProductsBeyondPage);
   let nextCursor: string | null = null;
   if (hasMore) {
     try {
@@ -559,7 +612,7 @@ export async function handleSearchProducts(
           boundary,
           consumedForCursor
         );
-      } else {
+      } else if (shouldAdvanceSparseWindow) {
         const returnedIds = new Set(
           returnedProducts.map((product) => product.id)
         );
@@ -577,6 +630,28 @@ export async function handleSearchProducts(
           query,
           cursorState,
           assembly.sparseBoundary!,
+          consumedForCursor
+        );
+      } else {
+        const newestNormalTimestamp = assembly.rawProductWindow[0]?.created_at;
+        const boundary =
+          cursorState?.boundary ??
+          Math.max(Math.floor(Date.now() / 1000), newestNormalTimestamp ?? 0);
+        const returnedIds = new Set(
+          returnedProducts.map((product) => product.id)
+        );
+        const consumedForCursor = [
+          ...assembly.scannedProducts.filter((event) =>
+            returnedIds.has(event.id)
+          ),
+          ...assembly.nip50ScannedProducts.filter((event) =>
+            returnedIds.has(event.id)
+          ),
+        ];
+        nextCursor = createNextCursor(
+          query,
+          cursorState,
+          boundary,
           consumedForCursor
         );
       }

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -14,8 +14,14 @@ import { parseProductEvent } from "../parse-tags.js";
 import {
   fetchFromRelays,
   getNewestSaturatedFilterBoundary,
+  type RelayFetchResult,
 } from "../relay-fetch.js";
-import type { NostrEvent, NostrFilter, ProductResponse } from "../types.js";
+import type {
+  NostrEvent,
+  NostrFilter,
+  ProductResponse,
+  RelayFetchMeta,
+} from "../types.js";
 import { searchProductsSchema } from "../validation.js";
 import {
   PRODUCT_KIND,
@@ -83,6 +89,20 @@ export const searchProductsInputSchema = {
 };
 
 type SearchProductsInput = z.infer<typeof searchProductsSchema>;
+
+type Nip50Meta = {
+  attempted: boolean;
+  relaysQueried: string[];
+  eventCount: number;
+};
+
+type SearchWindowFetch = {
+  events: NostrEvent[];
+  normalResult: RelayFetchResult;
+  relayMetas: RelayFetchMeta[];
+  nip50: Nip50Meta;
+  errorResponse?: ToolTextResponse;
+};
 
 function productMatchesFilters(
   product: ProductResponse,
@@ -243,6 +263,98 @@ function sortProducts(
   return [...knownPrice, ...unknownPrice];
 }
 
+function shouldAttemptNip50Search(
+  filters: SearchProductsInput,
+  cursorState: PaginationCursorState | undefined,
+  context: CoreToolContext
+): boolean {
+  return Boolean(
+    filters.keyword &&
+    cursorState === undefined &&
+    (context.nip50SearchRelays?.length ?? 0) > 0
+  );
+}
+
+function buildNip50Filter(filter: NostrFilter, keyword: string): NostrFilter {
+  return {
+    ...filter,
+    search: keyword,
+  };
+}
+
+function combineNip50Meta(metas: readonly Nip50Meta[]): Nip50Meta {
+  const relaysQueried = new Set<string>();
+  let eventCount = 0;
+  let attempted = false;
+
+  for (const meta of metas) {
+    attempted ||= meta.attempted;
+    eventCount += meta.eventCount;
+    meta.relaysQueried.forEach((relay) => relaysQueried.add(relay));
+  }
+
+  return {
+    attempted,
+    relaysQueried: Array.from(relaysQueried),
+    eventCount,
+  };
+}
+
+async function fetchSearchWindow(
+  context: CoreToolContext,
+  filters: SearchProductsInput,
+  cursorState: PaginationCursorState | undefined,
+  relayFilter: NostrFilter
+): Promise<SearchWindowFetch> {
+  const startedAt = Date.now();
+  const attemptNip50 = shouldAttemptNip50Search(filters, cursorState, context);
+  const nip50Relays = context.nip50SearchRelays ?? [];
+
+  const normalPromise = fetchFromRelays(
+    context.nostr,
+    context.relays,
+    [relayFilter],
+    { timeoutMs: context.timeoutMs }
+  );
+  const nip50Promise = attemptNip50
+    ? fetchFromRelays(
+        context.nostr,
+        nip50Relays,
+        [buildNip50Filter(relayFilter, filters.keyword!)],
+        { timeoutMs: context.timeoutMs }
+      )
+    : Promise.resolve(undefined);
+
+  const [normalResult, nip50Result] = await Promise.all([
+    normalPromise,
+    nip50Promise,
+  ]);
+  const relayMetas = [
+    normalResult.meta,
+    ...(nip50Result ? [nip50Result.meta] : []),
+  ];
+  const normalFailed = allRelaysFailed(normalResult.meta);
+  const nip50Failed = nip50Result ? allRelaysFailed(nip50Result.meta) : true;
+  const errorResponse =
+    normalFailed && (!attemptNip50 || nip50Failed)
+      ? createRelayUnavailableResponse(
+          combineRelayMetas(relayMetas, Date.now() - startedAt)
+        )
+      : undefined;
+
+  return {
+    events: [...normalResult.events, ...(nip50Result?.events ?? [])],
+    normalResult,
+    relayMetas,
+    nip50: {
+      attempted: attemptNip50,
+      relaysQueried: nip50Result?.meta.relaysQueried ?? [],
+      eventCount: nip50Result?.meta.eventCount ?? 0,
+    },
+    ...(errorResponse && { errorResponse }),
+  };
+}
+
 export async function handleSearchProducts(
   args: Record<string, unknown>,
   context: CoreToolContext
@@ -287,25 +399,29 @@ export async function handleSearchProducts(
     cursorState
   );
   const startedAt = Date.now();
-  const relayMetas = [];
+  const relayMetas: RelayFetchMeta[] = [];
+  const nip50Metas: Nip50Meta[] = [];
   let usedFallbackQuery = false;
 
-  let relayResult = await fetchFromRelays(
-    context.nostr,
-    context.relays,
-    [primary],
-    { timeoutMs: context.timeoutMs }
+  let relayResult = await fetchSearchWindow(
+    context,
+    filters,
+    cursorState,
+    primary
   );
-  relayMetas.push(relayResult.meta);
+  relayMetas.push(...relayResult.relayMetas);
+  nip50Metas.push(relayResult.nip50);
 
-  if (allRelaysFailed(relayResult.meta)) {
-    return createRelayUnavailableResponse(relayResult.meta);
-  }
+  if (relayResult.errorResponse) return relayResult.errorResponse;
 
   observeProductEventsForCategories(relayResult.events);
   let sparseBoundary =
     filters.sortBy === "newest"
-      ? getNewestSaturatedFilterBoundary(relayResult, requestedRelayLimit, [0])
+      ? getNewestSaturatedFilterBoundary(
+          relayResult.normalResult,
+          requestedRelayLimit,
+          [0]
+        )
       : undefined;
   let rawProductWindow = sortEventsNewestFirst(relayResult.events).filter(
     (event) =>
@@ -328,21 +444,22 @@ export async function handleSearchProducts(
   // retry with the broad filter (merchant may have written category in description
   // but forgotten the official #t tag).
   if (products.length === 0 && fallback) {
-    relayResult = await fetchFromRelays(
-      context.nostr,
-      context.relays,
-      [fallback],
-      { timeoutMs: context.timeoutMs }
+    relayResult = await fetchSearchWindow(
+      context,
+      filters,
+      cursorState,
+      fallback
     );
-    relayMetas.push(relayResult.meta);
+    relayMetas.push(...relayResult.relayMetas);
+    nip50Metas.push(relayResult.nip50);
     usedFallbackQuery = true;
 
-    if (!allRelaysFailed(relayResult.meta)) {
+    if (!relayResult.errorResponse) {
       observeProductEventsForCategories(relayResult.events);
       sparseBoundary =
         filters.sortBy === "newest"
           ? getNewestSaturatedFilterBoundary(
-              relayResult,
+              relayResult.normalResult,
               requestedRelayLimit,
               [0]
             )
@@ -423,6 +540,7 @@ export async function handleSearchProducts(
       dataFreshness: getDataFreshness(returnedProducts),
       hints,
     }),
+    nip50: combineNip50Meta(nip50Metas),
     ...(usedFallbackQuery && { usedFallbackQuery }),
   };
 

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -46,6 +46,7 @@ import {
   createQueryFingerprint,
   decodePaginationCursor,
   getPaginatedRelayLimit,
+  hashPaginationLogicalIdentity,
   type PaginationCursorState,
 } from "./utils/pagination-cursor.js";
 
@@ -89,6 +90,7 @@ export const searchProductsInputSchema = {
 };
 
 type SearchProductsInput = z.infer<typeof searchProductsSchema>;
+type SearchProductResponse = ProductResponse & { matchedVia?: "nip50" };
 
 type Nip50Meta = {
   attempted: boolean;
@@ -97,12 +99,24 @@ type Nip50Meta = {
 };
 
 type SearchWindowFetch = {
-  events: NostrEvent[];
+  normalEvents: NostrEvent[];
+  nip50Events: NostrEvent[];
   normalResult: RelayFetchResult;
   relayMetas: RelayFetchMeta[];
   nip50: Nip50Meta;
   errorResponse?: ToolTextResponse;
 };
+
+type PageAssembly = {
+  products: ProductResponse[];
+  nip50Products: ProductResponse[];
+  rawProductWindow: NostrEvent[];
+  sparseBoundary: number | undefined;
+  scannedProducts: NostrEvent[];
+  nip50ScannedProducts: NostrEvent[];
+};
+
+const NIP50_RESERVED_SLOTS = 5;
 
 function productMatchesFilters(
   product: ProductResponse,
@@ -265,38 +279,18 @@ function sortProducts(
 
 function shouldAttemptNip50Search(
   filters: SearchProductsInput,
-  cursorState: PaginationCursorState | undefined,
   context: CoreToolContext
 ): boolean {
   return Boolean(
-    filters.keyword &&
-    cursorState === undefined &&
-    (context.nip50SearchRelays?.length ?? 0) > 0
+    filters.keyword && (context.nip50SearchRelays?.length ?? 0) > 0
   );
 }
 
 function buildNip50Filter(filter: NostrFilter, keyword: string): NostrFilter {
+  const { until: _until, ...rest } = filter;
   return {
-    ...filter,
+    ...rest,
     search: keyword,
-  };
-}
-
-function combineNip50Meta(metas: readonly Nip50Meta[]): Nip50Meta {
-  const relaysQueried = new Set<string>();
-  let eventCount = 0;
-  let attempted = false;
-
-  for (const meta of metas) {
-    attempted ||= meta.attempted;
-    eventCount += meta.eventCount;
-    meta.relaysQueried.forEach((relay) => relaysQueried.add(relay));
-  }
-
-  return {
-    attempted,
-    relaysQueried: Array.from(relaysQueried),
-    eventCount,
   };
 }
 
@@ -307,7 +301,7 @@ async function fetchSearchWindow(
   relayFilter: NostrFilter
 ): Promise<SearchWindowFetch> {
   const startedAt = Date.now();
-  const attemptNip50 = shouldAttemptNip50Search(filters, cursorState, context);
+  const attemptNip50 = shouldAttemptNip50Search(filters, context);
   const nip50Relays = context.nip50SearchRelays ?? [];
 
   const normalPromise = fetchFromRelays(
@@ -329,6 +323,13 @@ async function fetchSearchWindow(
     normalPromise,
     nip50Promise,
   ]);
+  const seenIds = new Set(cursorState?.seen ?? []);
+  const nip50Events = (nip50Result?.events ?? []).filter(
+    (event) =>
+      !seenIds.has(
+        hashPaginationLogicalIdentity(getProductLogicalIdentity(event))
+      )
+  );
   const relayMetas = [
     normalResult.meta,
     ...(nip50Result ? [nip50Result.meta] : []),
@@ -343,7 +344,8 @@ async function fetchSearchWindow(
       : undefined;
 
   return {
-    events: [...normalResult.events, ...(nip50Result?.events ?? [])],
+    normalEvents: normalResult.events,
+    nip50Events,
     normalResult,
     relayMetas,
     nip50: {
@@ -352,6 +354,57 @@ async function fetchSearchWindow(
       eventCount: nip50Result?.meta.eventCount ?? 0,
     },
     ...(errorResponse && { errorResponse }),
+  };
+}
+
+function assemblePage(
+  relayResult: SearchWindowFetch,
+  filters: SearchProductsInput,
+  cursorState: PaginationCursorState | undefined,
+  requestedRelayLimit: number
+): PageAssembly {
+  const sparseBoundary =
+    filters.sortBy === "newest"
+      ? getNewestSaturatedFilterBoundary(
+          relayResult.normalResult,
+          requestedRelayLimit,
+          [0]
+        )
+      : undefined;
+  const rawProductWindow = sortEventsNewestFirst(
+    relayResult.normalEvents
+  ).filter(
+    (event) =>
+      sparseBoundary === undefined || event.created_at >= sparseBoundary
+  );
+  const eligibleRawProducts = cursorState
+    ? applyPaginationCursor(
+        rawProductWindow,
+        cursorState,
+        getProductLogicalIdentity
+      )
+    : rawProductWindow;
+  const scannedProducts = mergeAndDeduplicateProducts(eligibleRawProducts);
+  const products = scannedProducts
+    .map(parseProductEvent)
+    .filter((product) => productMatchesFilters(product, filters));
+  const normalIdentities = new Set(
+    scannedProducts.map(getProductLogicalIdentity)
+  );
+  const nip50ScannedProducts = mergeAndDeduplicateProducts(
+    relayResult.nip50Events
+  ).filter((event) => !normalIdentities.has(getProductLogicalIdentity(event)));
+  const nip50Products = nip50ScannedProducts
+    .map(parseProductEvent)
+    .filter((product) => productMatchesFilters(product, filters));
+
+  return {
+    products,
+    nip50Products,
+    rawProductWindow,
+    sparseBoundary,
+    scannedProducts,
+    nip50ScannedProducts,
   };
 }
 
@@ -400,7 +453,7 @@ export async function handleSearchProducts(
   );
   const startedAt = Date.now();
   const relayMetas: RelayFetchMeta[] = [];
-  const nip50Metas: Nip50Meta[] = [];
+  let nip50Meta: Nip50Meta;
   let usedFallbackQuery = false;
 
   let relayResult = await fetchSearchWindow(
@@ -410,40 +463,29 @@ export async function handleSearchProducts(
     primary
   );
   relayMetas.push(...relayResult.relayMetas);
-  nip50Metas.push(relayResult.nip50);
+  nip50Meta = relayResult.nip50;
 
   if (relayResult.errorResponse) return relayResult.errorResponse;
 
-  observeProductEventsForCategories(relayResult.events);
-  let sparseBoundary =
-    filters.sortBy === "newest"
-      ? getNewestSaturatedFilterBoundary(
-          relayResult.normalResult,
-          requestedRelayLimit,
-          [0]
-        )
-      : undefined;
-  let rawProductWindow = sortEventsNewestFirst(relayResult.events).filter(
-    (event) =>
-      sparseBoundary === undefined || event.created_at >= sparseBoundary
+  observeProductEventsForCategories([
+    ...relayResult.normalEvents,
+    ...relayResult.nip50Events,
+  ]);
+  let assembly = assemblePage(
+    relayResult,
+    filters,
+    cursorState,
+    requestedRelayLimit
   );
-  let eligibleRawProducts = rawProductWindow;
-  if (cursorState) {
-    eligibleRawProducts = applyPaginationCursor(
-      rawProductWindow,
-      cursorState,
-      getProductLogicalIdentity
-    );
-  }
-  let scannedProducts = mergeAndDeduplicateProducts(eligibleRawProducts);
-  let products = scannedProducts
-    .map(parseProductEvent)
-    .filter((product) => productMatchesFilters(product, filters));
 
   // Fallback: if targeted #t query returned nothing and we have a broad fallback,
   // retry with the broad filter (merchant may have written category in description
   // but forgotten the official #t tag).
-  if (products.length === 0 && fallback) {
+  if (
+    assembly.products.length === 0 &&
+    assembly.nip50Products.length === 0 &&
+    fallback
+  ) {
     relayResult = await fetchSearchWindow(
       context,
       filters,
@@ -451,49 +493,50 @@ export async function handleSearchProducts(
       fallback
     );
     relayMetas.push(...relayResult.relayMetas);
-    nip50Metas.push(relayResult.nip50);
+    nip50Meta = relayResult.nip50;
     usedFallbackQuery = true;
 
     if (!relayResult.errorResponse) {
-      observeProductEventsForCategories(relayResult.events);
-      sparseBoundary =
-        filters.sortBy === "newest"
-          ? getNewestSaturatedFilterBoundary(
-              relayResult.normalResult,
-              requestedRelayLimit,
-              [0]
-            )
-          : undefined;
-      rawProductWindow = sortEventsNewestFirst(relayResult.events).filter(
-        (event) =>
-          sparseBoundary === undefined || event.created_at >= sparseBoundary
+      observeProductEventsForCategories([
+        ...relayResult.normalEvents,
+        ...relayResult.nip50Events,
+      ]);
+      assembly = assemblePage(
+        relayResult,
+        filters,
+        cursorState,
+        requestedRelayLimit
       );
-      eligibleRawProducts = rawProductWindow;
-      if (cursorState) {
-        eligibleRawProducts = applyPaginationCursor(
-          rawProductWindow,
-          cursorState,
-          getProductLogicalIdentity
-        );
-      }
-      scannedProducts = mergeAndDeduplicateProducts(eligibleRawProducts);
-      products = scannedProducts
-        .map(parseProductEvent)
-        .filter((product) => productMatchesFilters(product, filters));
     }
   }
 
-  products = sortProducts(products, filters.sortBy);
-  const pageProducts = products.slice(0, responseLimit + 1);
+  const products = sortProducts(assembly.products, filters.sortBy);
+  const reservedSlots = Math.min(
+    NIP50_RESERVED_SLOTS,
+    assembly.nip50Products.length,
+    Math.max(0, responseLimit - 1)
+  );
+  const normalBudget = responseLimit - reservedSlots;
+  const pageProducts = products.slice(0, normalBudget + 1);
   const priceSorted =
     filters.sortBy === "price_asc" || filters.sortBy === "price_desc";
-  const returnedProducts = pageProducts.slice(0, responseLimit);
-  const hasMatchingProductsBeyondPage = pageProducts.length > responseLimit;
+  const returnedNormal = pageProducts.slice(0, normalBudget);
+  const returnedNip50 = assembly.nip50Products
+    .slice(0, reservedSlots)
+    .map((product): SearchProductResponse => ({
+      ...product,
+      matchedVia: "nip50",
+    }));
+  const returnedProducts: SearchProductResponse[] = [
+    ...returnedNormal,
+    ...returnedNip50,
+  ];
+  const hasMatchingProductsBeyondPage = pageProducts.length > normalBudget;
   const shouldAdvanceSparseWindow =
     !priceSorted &&
     !hasMatchingProductsBeyondPage &&
-    sparseBoundary !== undefined &&
-    rawProductWindow.length > 0;
+    assembly.sparseBoundary !== undefined &&
+    assembly.rawProductWindow.length > 0;
   const hasMore =
     !priceSorted &&
     (hasMatchingProductsBeyondPage || shouldAdvanceSparseWindow);
@@ -501,22 +544,33 @@ export async function handleSearchProducts(
   if (hasMore) {
     try {
       if (hasMatchingProductsBeyondPage) {
-        const boundary =
-          returnedProducts[returnedProducts.length - 1]!.createdAt;
+        const boundary = returnedNormal[returnedNormal.length - 1]!.createdAt;
+        const consumedForCursor = [
+          ...assembly.scannedProducts.filter((event) =>
+            returnedNormal.some((product) => product.id === event.id)
+          ),
+          ...assembly.nip50ScannedProducts.filter((event) =>
+            returnedNip50.some((product) => product.id === event.id)
+          ),
+        ];
         nextCursor = createNextCursor(
           query,
           cursorState,
           boundary,
-          scannedProducts.filter((event) =>
-            returnedProducts.some((product) => product.id === event.id)
-          )
+          consumedForCursor
         );
       } else {
+        const consumedForCursor = [
+          ...assembly.rawProductWindow,
+          ...assembly.nip50ScannedProducts.filter((event) =>
+            returnedNip50.some((product) => product.id === event.id)
+          ),
+        ];
         nextCursor = createNextCursor(
           query,
           cursorState,
-          sparseBoundary!,
-          rawProductWindow
+          assembly.sparseBoundary!,
+          consumedForCursor
         );
       }
     } catch (error) {
@@ -526,28 +580,32 @@ export async function handleSearchProducts(
       throw error;
     }
   }
-  const truncated = products.length > returnedProducts.length;
+  const totalMatches = products.length + assembly.nip50Products.length;
+  const truncated = totalMatches > returnedProducts.length;
   const hints = buildSearchHints(
     filters,
-    products.length,
+    totalMatches,
     returnedProducts.length
   );
   const meta = {
     ...buildToolMeta(combineRelayMetas(relayMetas, Date.now() - startedAt), {
       resultCount: returnedProducts.length,
-      totalMatches: products.length,
+      totalMatches,
       truncated,
       dataFreshness: getDataFreshness(returnedProducts),
       hints,
     }),
-    nip50: combineNip50Meta(nip50Metas),
+    nip50: {
+      ...nip50Meta,
+      reservedSlotsUsed: returnedNip50.length,
+    },
     ...(usedFallbackQuery && { usedFallbackQuery }),
   };
 
   return createSuccessResponse(
     {
       count: returnedProducts.length,
-      totalMatches: products.length,
+      totalMatches,
       products: returnedProducts,
       _pagination: {
         nextCursor,

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -117,6 +117,9 @@ type PageAssembly = {
 };
 
 const NIP50_RESERVED_SLOTS = 5;
+const NIP50_MAX_TIMEOUT_MS = 3_000;
+const NIP50_MAX_RELAY_LIMIT = 100;
+const SEARCH_EVENT_CONTENT_CHAR_LIMIT = 20_000;
 
 function productMatchesFilters(
   product: ProductResponse,
@@ -135,7 +138,7 @@ function productMatchesFilters(
       product.condition,
       product.productFormat,
       product.status,
-      eventContent,
+      eventContent.slice(0, SEARCH_EVENT_CONTENT_CHAR_LIMIT),
       ...product.categories,
     ]
       .join(" ")
@@ -318,6 +321,7 @@ function buildNip50Filter(filter: NostrFilter, keyword: string): NostrFilter {
   const { until: _until, ...rest } = filter;
   return {
     ...rest,
+    limit: Math.min(rest.limit ?? NIP50_MAX_RELAY_LIMIT, NIP50_MAX_RELAY_LIMIT),
     search: keyword,
   };
 }
@@ -343,7 +347,7 @@ async function fetchSearchWindow(
         context.nostr,
         nip50Relays,
         [buildNip50Filter(relayFilter, filters.keyword!)],
-        { timeoutMs: context.timeoutMs }
+        { timeoutMs: Math.min(context.timeoutMs, NIP50_MAX_TIMEOUT_MS) }
       )
     : Promise.resolve(undefined);
 
@@ -592,7 +596,7 @@ export async function handleSearchProducts(
   ) as SearchProductResponse[];
   const hasMatchingProductsBeyondPage = pageProducts.length > normalBudget;
   const hasNip50ProductsBeyondPage =
-    reservedSlots > 0 && nip50Products.length > reservedSlots;
+    nip50Products.length > returnedNip50.length;
   const shouldAdvanceSparseWindow =
     !priceSorted &&
     !hasMatchingProductsBeyondPage &&

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -560,8 +560,15 @@ export async function handleSearchProducts(
           consumedForCursor
         );
       } else {
+        const returnedIds = new Set(
+          returnedProducts.map((product) => product.id)
+        );
         const consumedForCursor = [
-          ...assembly.rawProductWindow,
+          ...assembly.rawProductWindow.filter(
+            (event) =>
+              event.created_at === assembly.sparseBoundary ||
+              returnedIds.has(event.id)
+          ),
           ...assembly.nip50ScannedProducts.filter((event) =>
             returnedNip50.some((product) => product.id === event.id)
           ),

--- a/packages/shopstr-mcp/src/tools/search-products.ts
+++ b/packages/shopstr-mcp/src/tools/search-products.ts
@@ -597,7 +597,11 @@ export async function handleSearchProducts(
   if (hasMore) {
     try {
       if (hasMatchingProductsBeyondPage) {
-        const boundary = returnedNormal[returnedNormal.length - 1]!.createdAt;
+        const returnedBoundary =
+          returnedNormal[returnedNormal.length - 1]!.createdAt;
+        const boundary = cursorState
+          ? Math.min(returnedBoundary, cursorState.boundary)
+          : returnedBoundary;
         const consumedForCursor = [
           ...assembly.scannedProducts.filter((event) =>
             returnedNormal.some((product) => product.id === event.id)

--- a/packages/shopstr-mcp/src/tools/utils/context.ts
+++ b/packages/shopstr-mcp/src/tools/utils/context.ts
@@ -5,6 +5,7 @@ import type { RelayFetchClient } from "../../relay-fetch.js";
 export type CoreToolContext = {
   nostr: RelayFetchClient;
   relays: string[];
+  nip50SearchRelays?: string[];
   timeoutMs: number;
   cache: MemoryCache;
   categoryCache: MemoryCache;

--- a/packages/shopstr-mcp/test/config.node.mjs
+++ b/packages/shopstr-mcp/test/config.node.mjs
@@ -44,6 +44,10 @@ test("parses relay lists with trimming, dedupe, and defaults", () => {
   assert.deepEqual(parseRelayList("invalid", DEFAULT_NIP50_SEARCH_RELAYS), [
     ...DEFAULT_NIP50_SEARCH_RELAYS,
   ]);
+  assert.deepEqual(
+    loadConfig({ SHOPSTR_MCP_NIP50_SEARCH_RELAYS: "" }).nip50SearchRelays,
+    []
+  );
 });
 
 test("parses log levels and positive integers with safe fallbacks", () => {

--- a/packages/shopstr-mcp/test/config.node.mjs
+++ b/packages/shopstr-mcp/test/config.node.mjs
@@ -5,6 +5,7 @@ import {
   DEFAULT_CATEGORY_CACHE_TTL_MS,
   DEFAULT_MAX_CONCURRENT_REQUESTS,
   DEFAULT_NIP05_CACHE_TTL_MS,
+  DEFAULT_NIP50_SEARCH_RELAYS,
   DEFAULT_RELAYS,
   DEFAULT_TOOL_TIMEOUT_MS,
   loadConfig,
@@ -40,6 +41,9 @@ test("parses relay lists with trimming, dedupe, and defaults", () => {
     ["wss://relay.example.com", "ws://localhost"]
   );
   assert.deepEqual(parseRelayList("invalid"), expectedDefaultRelays);
+  assert.deepEqual(parseRelayList("invalid", DEFAULT_NIP50_SEARCH_RELAYS), [
+    ...DEFAULT_NIP50_SEARCH_RELAYS,
+  ]);
 });
 
 test("parses log levels and positive integers with safe fallbacks", () => {
@@ -53,6 +57,7 @@ test("parses log levels and positive integers with safe fallbacks", () => {
 test("loads config from environment overrides", () => {
   const config = loadConfig({
     SHOPSTR_MCP_RELAYS: "wss://relay.example.com",
+    SHOPSTR_MCP_NIP50_SEARCH_RELAYS: "wss://search.example.com",
     SHOPSTR_MCP_LOG_LEVEL: "warn",
     SHOPSTR_MCP_TOOL_TIMEOUT_MS: "1500",
     SHOPSTR_MCP_RELAY_CONNECT_TIMEOUT_MS: "2500",
@@ -60,6 +65,7 @@ test("loads config from environment overrides", () => {
   });
 
   assert.deepEqual(config.relays, ["wss://relay.example.com"]);
+  assert.deepEqual(config.nip50SearchRelays, ["wss://search.example.com"]);
   assert.equal(config.version, packageVersion);
   assert.equal(config.logLevel, "warn");
   assert.equal(config.defaultToolTimeoutMs, 1500);

--- a/packages/shopstr-mcp/test/config.node.mjs
+++ b/packages/shopstr-mcp/test/config.node.mjs
@@ -33,6 +33,7 @@ test("parses relay lists with trimming, dedupe, and defaults", () => {
   ];
 
   assert.deepEqual(DEFAULT_RELAYS, expectedDefaultRelays);
+  assert.deepEqual(DEFAULT_NIP50_SEARCH_RELAYS, []);
   assert.deepEqual(parseRelayList(), expectedDefaultRelays);
   assert.deepEqual(
     parseRelayList(
@@ -44,6 +45,7 @@ test("parses relay lists with trimming, dedupe, and defaults", () => {
   assert.deepEqual(parseRelayList("invalid", DEFAULT_NIP50_SEARCH_RELAYS), [
     ...DEFAULT_NIP50_SEARCH_RELAYS,
   ]);
+  assert.deepEqual(loadConfig({}).nip50SearchRelays, []);
   assert.deepEqual(
     loadConfig({ SHOPSTR_MCP_NIP50_SEARCH_RELAYS: "" }).nip50SearchRelays,
     []

--- a/packages/shopstr-mcp/test/server.node.mjs
+++ b/packages/shopstr-mcp/test/server.node.mjs
@@ -147,11 +147,11 @@ test("rate limits concurrent relay-backed tool calls", async () => {
 
     const firstCall = client.callTool({
       name: "search_products",
-      arguments: { keyword: "shirt" },
+      arguments: {},
     });
     const secondResult = await client.callTool({
       name: "search_products",
-      arguments: { keyword: "shirt" },
+      arguments: {},
     });
     releaseFetch();
     const firstResult = await firstCall;

--- a/packages/shopstr-mcp/test/tools/get-product-details.node.mjs
+++ b/packages/shopstr-mcp/test/tools/get-product-details.node.mjs
@@ -60,6 +60,54 @@ test("get_product_details returns a product by event id via coordinate resolutio
   assert.equal(body._meta.resultCount, 1);
 });
 
+test("get_product_details returns short event content as product description", async () => {
+  const productId = hex("1");
+  const description = "Soft linen shirt with pearl buttons.";
+  const ctx = context((filters) => {
+    if (filters.some((f) => f.ids?.includes(productId))) {
+      return [productEvent({ id: productId, content: description })];
+    }
+    if (filters.some((f) => f["#d"]?.includes("product"))) {
+      return [productEvent({ id: productId, content: description })];
+    }
+    return [];
+  });
+
+  const response = await handleGetProductDetails({ productId }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.description, description);
+  assert.equal(
+    body._meta._hints.some((hint) => hint.startsWith("descriptionTruncated")),
+    false
+  );
+});
+
+test("get_product_details truncates long descriptions at a word boundary", async () => {
+  const productId = hex("1");
+  const description = "leather ".repeat(300);
+  const ctx = context((filters) => {
+    if (filters.some((f) => f.ids?.includes(productId))) {
+      return [productEvent({ id: productId, content: description })];
+    }
+    if (filters.some((f) => f["#d"]?.includes("product"))) {
+      return [productEvent({ id: productId, content: description })];
+    }
+    return [];
+  });
+
+  const response = await handleGetProductDetails({ productId }, ctx);
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.description.endsWith("..."), true);
+  assert.equal(body.description.endsWith("leather..."), true);
+  assert.ok(body.description.length <= 2_000);
+  assert.equal(
+    body._meta._hints.some((hint) => hint.startsWith("descriptionTruncated")),
+    true
+  );
+});
+
 test("get_product_details accepts productAddress and skips pre-flight", async () => {
   const productAddress = `30402:${hex("b")}:product`;
   let fetchCallCount = 0;

--- a/packages/shopstr-mcp/test/tools/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/tools/search-products.node.mjs
@@ -266,9 +266,9 @@ test("search_products queries normal and NIP-50 relays concurrently for keyword 
   const body = JSON.parse((await responsePromise).content[0].text);
 
   assert.equal(body.count, 2);
-  assert.equal(body.products[0].id, hex("1"));
-  assert.equal(body.products[1].id, hex("2"));
-  assert.equal(body.products[1].matchedVia, "nip50");
+  assert.equal(body.products[0].id, hex("2"));
+  assert.equal(body.products[0].matchedVia, "nip50");
+  assert.equal(body.products[1].id, hex("1"));
   assert.deepEqual(body._meta.nip50, {
     attempted: true,
     relaysQueried: [nip50Relay],
@@ -415,8 +415,9 @@ test("search_products keeps older NIP-50 matches outside the normal sparse bound
     created_at: 1,
     tags: [
       ["d", "rare-match"],
-      ["title", "Rare Search Match"],
+      ["title", "Unrelated Product"],
     ],
+    content: "Rare Search Match in the listing description",
   });
 
   const response = await handleSearchProducts(
@@ -442,17 +443,59 @@ test("search_products keeps older NIP-50 matches outside the normal sparse bound
   assert.equal(body.products[0].matchedVia, "nip50");
 });
 
-test("search_products does not duplicate a product that appears in normal and NIP-50 streams", async () => {
-  const duplicateFromNip50 = productEvent({
+test("search_products keeps the latest cross-stream revision and applies the requested price sort", async () => {
+  const staleNormal = productEvent({
+    id: hex("1"),
+    created_at: 100,
+    tags: [
+      ["d", "product"],
+      ["title", "Hardware Wallet"],
+      ["price", "100", "USD"],
+    ],
+  });
+  const normalMidPrice = productEvent({
     id: hex("2"),
+    created_at: 90,
+    tags: [
+      ["d", "mid-price"],
+      ["title", "Hardware Wallet"],
+      ["price", "50", "USD"],
+    ],
+  });
+  const latestFromNip50 = productEvent({
+    id: hex("3"),
     created_at: 120,
     tags: [
       ["d", "product"],
       ["title", "Hardware Wallet"],
+      ["price", "10", "USD"],
+    ],
+  });
+  const nip50HighPrice = productEvent({
+    id: hex("4"),
+    created_at: 110,
+    tags: [
+      ["d", "high-price"],
+      ["title", "Hardware Wallet"],
+      ["price", "200", "USD"],
+    ],
+  });
+  const nip50LowPrice = productEvent({
+    id: hex("5"),
+    created_at: 80,
+    tags: [
+      ["d", "low-price"],
+      ["title", "Hardware Wallet"],
+      ["price", "5", "USD"],
     ],
   });
   const response = await handleSearchProducts(
-    { keyword: "wallet" },
+    {
+      keyword: "wallet",
+      currency: "USD",
+      sortBy: "price_asc",
+      limit: 4,
+    },
     {
       ...context({}),
       relays: ["wss://normal.example.com"],
@@ -460,17 +503,19 @@ test("search_products does not duplicate a product that appears in normal and NI
       nostr: {
         async fetch(_filters, _params, relayUrls) {
           return relayUrls[0] === "wss://search.example.com"
-            ? [duplicateFromNip50]
-            : [productEvent()];
+            ? [latestFromNip50, nip50HighPrice, nip50LowPrice]
+            : [staleNormal, normalMidPrice];
         },
       },
     }
   );
   const body = JSON.parse(response.content[0].text);
 
-  assert.equal(body.count, 1);
-  assert.equal(body.products[0].id, productEvent().id);
-  assert.equal(body.products[0].matchedVia, undefined);
+  assert.deepEqual(
+    body.products.map((product) => product.price),
+    [5, 10, 50, 200]
+  );
+  assert.equal(body.products[1].id, latestFromNip50.id);
 });
 
 test("search_products reserves NIP-50 slots without crowding out limit-1 normal results", async () => {
@@ -504,67 +549,44 @@ test("search_products reserves NIP-50 slots without crowding out limit-1 normal 
   assert.equal(body.products[0].id, productEvent().id);
   assert.equal(body.products[0].matchedVia, undefined);
   assert.equal(body._meta.nip50.reservedSlotsUsed, 0);
+  assert.equal(body._pagination.hasMore, false);
 });
 
-test("search_products does not repeat a returned NIP-50 item on the next page", async () => {
-  const normalOne = productEvent({
-    id: hex("1"),
-    created_at: 100,
-    tags: [
-      ["d", "normal-one"],
-      ["title", "Hardware Wallet One"],
-    ],
-  });
-  const normalTwo = productEvent({
-    id: hex("2"),
-    created_at: 99,
-    tags: [
-      ["d", "normal-two"],
-      ["title", "Hardware Wallet Two"],
-    ],
-  });
-  const nip50One = productEvent({
-    id: hex("3"),
-    created_at: 50,
-    tags: [
-      ["d", "nip50-one"],
-      ["title", "Hardware Wallet Search One"],
-    ],
-  });
-  const nip50Two = productEvent({
-    id: hex("4"),
-    created_at: 49,
-    tags: [
-      ["d", "nip50-two"],
-      ["title", "Hardware Wallet Search Two"],
-    ],
-  });
+test("search_products paginates NIP-50-only results without skipping relay-ranked candidates", async () => {
+  const nip50Products = Array.from({ length: 6 }, (_, index) =>
+    productEvent({
+      id: (index + 1).toString(16).padStart(64, "0"),
+      created_at: index + 1,
+      tags: [
+        ["d", `nip50-${index + 1}`],
+        ["title", `Hardware Wallet Search ${index + 1}`],
+      ],
+    })
+  );
   const ctx = {
     ...context({}),
     relays: ["wss://normal.example.com"],
     nip50SearchRelays: ["wss://search.example.com"],
     nostr: {
-      async fetch(filters, _params, relayUrls) {
-        if (relayUrls[0] === "wss://search.example.com") {
-          return [nip50One, nip50Two];
-        }
-        return filters[0].until === undefined
-          ? [normalOne, normalTwo]
-          : [normalTwo];
+      async fetch(_filters, _params, relayUrls) {
+        return relayUrls[0] === "wss://search.example.com" ? nip50Products : [];
       },
     },
   };
 
   const first = JSON.parse(
-    (await handleSearchProducts({ keyword: "wallet", limit: 2 }, ctx))
+    (await handleSearchProducts({ keyword: "wallet", limit: 3 }, ctx))
       .content[0].text
   );
+  assert.equal(first._pagination.hasMore, true);
+  assert.equal(typeof first._pagination.nextCursor, "string");
+
   const second = JSON.parse(
     (
       await handleSearchProducts(
         {
           keyword: "wallet",
-          limit: 2,
+          limit: 3,
           cursor: first._pagination.nextCursor,
         },
         ctx
@@ -573,19 +595,19 @@ test("search_products does not repeat a returned NIP-50 item on the next page", 
   );
 
   assert.deepEqual(
-    first.products.map((product) => product.id),
-    [normalOne.id, nip50One.id]
+    first.products.map((product) => product.id).sort(),
+    nip50Products
+      .slice(0, 2)
+      .map((product) => product.id)
+      .sort()
   );
-  assert.equal(first.products[1].matchedVia, "nip50");
-  assert.equal(
-    second.products.some((product) => product.id === nip50One.id),
-    false
+  assert.deepEqual(
+    second.products.map((product) => product.id).sort(),
+    nip50Products
+      .slice(2, 4)
+      .map((product) => product.id)
+      .sort()
   );
-  assert.equal(
-    second.products.some((product) => product.id === nip50Two.id),
-    true
-  );
-  assert.ok(second.products.length <= 2);
 });
 
 test("search_products applies NIP-50 to category fallback keyword retries", async () => {

--- a/packages/shopstr-mcp/test/tools/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/tools/search-products.node.mjs
@@ -352,7 +352,7 @@ test("search_products fails only when normal and NIP-50 relays both fail", async
   );
 });
 
-test("search_products queries NIP-50 on cursor pages without sending until", async () => {
+test("search_products keeps cursor progress when NIP-50 reveals a newer revision", async () => {
   const seenIdentity = `30402:${hex("b")}:already-seen`;
   const cursor = createPaginationCursor({
     tool: "search_products",
@@ -363,15 +363,28 @@ test("search_products queries NIP-50 on cursor pages without sending until", asy
       undefined,
       undefined,
       undefined,
-      1,
+      2,
       "newest",
     ]),
     boundary: 100,
     seen: [hashPaginationLogicalIdentity(seenIdentity)],
   });
+  const listing = (id, dTag, createdAt) =>
+    productEvent({
+      id: hex(id),
+      created_at: createdAt,
+      tags: [
+        ["d", dTag],
+        ["title", "Hardware Wallet"],
+      ],
+    });
+  const staleNormal = listing("2", "updated-product", 99);
+  const nextNormal = listing("3", "next-product", 98);
+  const latestFromNip50 = listing("5", "updated-product", 200);
+  const rankedNip50Match = listing("6", "nip50-result", 50);
   const calls = [];
   const response = await handleSearchProducts(
-    { keyword: "wallet", limit: 1, cursor },
+    { keyword: "wallet", limit: 2, cursor },
     {
       ...context({}),
       relays: ["wss://normal.example.com"],
@@ -379,7 +392,9 @@ test("search_products queries NIP-50 on cursor pages without sending until", asy
       nostr: {
         async fetch(filters, _params, relayUrls) {
           calls.push({ relay: relayUrls[0], filters });
-          return [];
+          return relayUrls[0] === "wss://search.example.com"
+            ? [latestFromNip50, rankedNip50Match]
+            : [staleNormal, nextNormal];
         },
       },
     }
@@ -391,11 +406,17 @@ test("search_products queries NIP-50 on cursor pages without sending until", asy
   assert.equal(calls[0].relay, "wss://normal.example.com");
   assert.equal(calls[0].filters[0].search, undefined);
   assert.equal(calls[0].filters[0].until, 100);
-  assert.equal(calls[0].filters[0].limit, 6);
+  assert.equal(calls[0].filters[0].limit, 11);
   assert.equal(calls[1].relay, "wss://search.example.com");
   assert.equal(calls[1].filters[0].search, "wallet");
   assert.equal(calls[1].filters[0].until, undefined);
-  assert.equal(calls[1].filters[0].limit, 6);
+  assert.equal(calls[1].filters[0].limit, 11);
+  assert.deepEqual(
+    body.products.map((product) => product.id),
+    [latestFromNip50.id, rankedNip50Match.id]
+  );
+  assert.equal(body._pagination.hasMore, true);
+  assert.equal(typeof body._pagination.nextCursor, "string");
   assert.equal(body._meta.nip50.attempted, true);
 });
 

--- a/packages/shopstr-mcp/test/tools/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/tools/search-products.node.mjs
@@ -204,6 +204,235 @@ test("search_products falls back to broad query when #t category returns no matc
   assert.equal(body._meta.eventCount, 1);
 });
 
+test("search_products queries normal and NIP-50 relays concurrently for keyword searches", async () => {
+  const normalRelay = "wss://normal.example.com";
+  const nip50Relay = "wss://search.example.com";
+  const calls = [];
+  let resolveNormal;
+  const normalResult = new Promise((resolve) => {
+    resolveNormal = resolve;
+  });
+  const ctx = {
+    ...context({}),
+    relays: [normalRelay],
+    nip50SearchRelays: [nip50Relay],
+    nostr: {
+      async fetch(filters, _params, relayUrls) {
+        const relay = relayUrls[0];
+        calls.push({ relay, filters });
+        if (relay === normalRelay) return normalResult;
+        return [
+          productEvent({
+            id: hex("2"),
+            created_at: 20,
+            tags: [
+              ["d", "wallet"],
+              ["title", "Hardware Wallet"],
+              ["summary", "NIP-50 result"],
+              ["price", "35", "USD"],
+            ],
+          }),
+        ];
+      },
+    },
+  };
+
+  const responsePromise = handleSearchProducts({ keyword: "wallet" }, ctx);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(calls.length, 2, "normal and NIP-50 fetches should be started");
+  assert.equal(
+    calls.find((call) => call.relay === normalRelay).filters[0].search,
+    undefined
+  );
+  assert.equal(
+    calls.find((call) => call.relay === nip50Relay).filters[0].search,
+    "wallet"
+  );
+
+  resolveNormal([
+    productEvent({
+      id: hex("1"),
+      created_at: 10,
+      tags: [
+        ["d", "wallet"],
+        ["title", "Hardware Wallet"],
+        ["summary", "Normal relay result"],
+        ["price", "40", "USD"],
+      ],
+    }),
+  ]);
+
+  const body = JSON.parse((await responsePromise).content[0].text);
+
+  assert.equal(body.count, 1);
+  assert.equal(body.products[0].id, hex("2"));
+  assert.deepEqual(body._meta.nip50, {
+    attempted: true,
+    relaysQueried: [nip50Relay],
+    eventCount: 1,
+  });
+});
+
+test("search_products returns normal relay results when NIP-50 relays fail", async () => {
+  const normalRelay = "wss://normal.example.com";
+  const nip50Relay = "wss://search.example.com";
+  const response = await handleSearchProducts(
+    { keyword: "wallet" },
+    {
+      ...context({}),
+      relays: [normalRelay],
+      nip50SearchRelays: [nip50Relay],
+      nostr: {
+        async fetch(_filters, _params, relayUrls) {
+          if (relayUrls[0] === nip50Relay) throw new Error("search down");
+          return [productEvent()];
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(body.count, 1);
+  assert.equal(body._meta.nip50.attempted, true);
+  assert.equal(body._meta.nip50.eventCount, 0);
+  assert.equal(body._meta.degraded, true);
+});
+
+test("search_products returns NIP-50 results when normal relays fail", async () => {
+  const normalRelay = "wss://normal.example.com";
+  const nip50Relay = "wss://search.example.com";
+  const response = await handleSearchProducts(
+    { keyword: "wallet" },
+    {
+      ...context({}),
+      relays: [normalRelay],
+      nip50SearchRelays: [nip50Relay],
+      nostr: {
+        async fetch(_filters, _params, relayUrls) {
+          if (relayUrls[0] === normalRelay) throw new Error("normal down");
+          return [productEvent()];
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(body.count, 1);
+  assert.equal(body._meta.nip50.eventCount, 1);
+  assert.equal(body._meta.degraded, true);
+});
+
+test("search_products fails only when normal and NIP-50 relays both fail", async () => {
+  const response = await handleSearchProducts(
+    { keyword: "wallet" },
+    {
+      ...context({}),
+      relays: ["wss://normal.example.com"],
+      nip50SearchRelays: ["wss://search.example.com"],
+      nostr: {
+        async fetch() {
+          throw new Error("relay down");
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, true);
+  assert.equal(body.errorCode, "RELAY_UNAVAILABLE");
+  assert.deepEqual(
+    body._meta.relaysQueried.sort(),
+    ["wss://normal.example.com", "wss://search.example.com"].sort()
+  );
+});
+
+test("search_products does not query NIP-50 relays when a cursor is supplied", async () => {
+  const cursor = createPaginationCursor({
+    tool: "search_products",
+    query: createQueryFingerprint("search_products", [
+      "wallet",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1,
+      "newest",
+    ]),
+    boundary: 100,
+    seen: [],
+  });
+  const calls = [];
+  const response = await handleSearchProducts(
+    { keyword: "wallet", limit: 1, cursor },
+    {
+      ...context({}),
+      relays: ["wss://normal.example.com"],
+      nip50SearchRelays: ["wss://search.example.com"],
+      nostr: {
+        async fetch(filters, _params, relayUrls) {
+          calls.push({ relay: relayUrls[0], filters });
+          return [];
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].relay, "wss://normal.example.com");
+  assert.equal(calls[0].filters[0].search, undefined);
+  assert.equal(body._meta.nip50.attempted, false);
+});
+
+test("search_products applies NIP-50 to category fallback keyword retries", async () => {
+  const calls = [];
+  const response = await handleSearchProducts(
+    { keyword: "running", category: "Shoes" },
+    {
+      ...context({}),
+      relays: ["wss://normal.example.com"],
+      nip50SearchRelays: ["wss://search.example.com"],
+      nostr: {
+        async fetch(filters, _params, relayUrls) {
+          calls.push({ relay: relayUrls[0], filters });
+          const filter = filters[0];
+          if (filter["#t"]) return [];
+          if (filter.search) {
+            return [
+              productEvent({
+                id: hex("1"),
+                tags: [
+                  ["d", "running-shoes"],
+                  ["title", "Running Shoes"],
+                  ["summary", "NIP-50 fallback result"],
+                  ["price", "100", "USD"],
+                  ["t", "shoes"],
+                ],
+              }),
+            ];
+          }
+          return [];
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(body.count, 1);
+  assert.equal(body._meta.usedFallbackQuery, true);
+  assert.equal(calls.length, 4);
+  assert.equal(calls[0].filters[0].search, undefined);
+  assert.equal(calls[1].filters[0].search, "running");
+  assert.equal(calls[2].filters[0].search, undefined);
+  assert.equal(calls[3].filters[0].search, "running");
+});
+
 test("search_products excludes hidden products", async () => {
   const response = await handleSearchProducts(
     {},

--- a/packages/shopstr-mcp/test/tools/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/tools/search-products.node.mjs
@@ -216,10 +216,11 @@ test("search_products queries normal and NIP-50 relays concurrently for keyword 
     ...context({}),
     relays: [normalRelay],
     nip50SearchRelays: [nip50Relay],
+    timeoutMs: 10_000,
     nostr: {
-      async fetch(filters, _params, relayUrls) {
+      async fetch(filters, _params, relayUrls, options) {
         const relay = relayUrls[0];
-        calls.push({ relay, filters });
+        calls.push({ relay, filters, options });
         if (relay === normalRelay) return normalResult;
         return [
           productEvent({
@@ -248,6 +249,18 @@ test("search_products queries normal and NIP-50 relays concurrently for keyword 
   assert.equal(
     calls.find((call) => call.relay === nip50Relay).filters[0].search,
     "wallet"
+  );
+  assert.equal(
+    calls.find((call) => call.relay === normalRelay).options.timeoutMs,
+    10_000
+  );
+  assert.equal(
+    calls.find((call) => call.relay === nip50Relay).options.timeoutMs,
+    3_000
+  );
+  assert.equal(
+    calls.find((call) => call.relay === nip50Relay).filters[0].limit,
+    100
   );
 
   resolveNormal([
@@ -539,38 +552,84 @@ test("search_products keeps the latest cross-stream revision and applies the req
   assert.equal(body.products[1].id, latestFromNip50.id);
 });
 
-test("search_products reserves NIP-50 slots without crowding out limit-1 normal results", async () => {
+test("search_products preserves limit-1 normal priority and paginates NIP-50 matches", async () => {
+  const ctx = {
+    ...context({}),
+    relays: ["wss://normal.example.com"],
+    nip50SearchRelays: ["wss://search.example.com"],
+    nostr: {
+      async fetch(_filters, _params, relayUrls) {
+        if (relayUrls[0] === "wss://search.example.com") {
+          return [
+            productEvent({
+              id: hex("2"),
+              tags: [
+                ["d", "nip50-wallet"],
+                ["title", "Hardware Wallet"],
+              ],
+            }),
+          ];
+        }
+        return [productEvent()];
+      },
+    },
+  };
+  const first = JSON.parse(
+    (await handleSearchProducts({ keyword: "wallet", limit: 1 }, ctx))
+      .content[0].text
+  );
+
+  assert.equal(first.count, 1);
+  assert.equal(first.products[0].id, productEvent().id);
+  assert.equal(first.products[0].matchedVia, undefined);
+  assert.equal(first._meta.nip50.reservedSlotsUsed, 0);
+  assert.equal(first._pagination.hasMore, true);
+  assert.equal(typeof first._pagination.nextCursor, "string");
+
+  const second = JSON.parse(
+    (
+      await handleSearchProducts(
+        {
+          keyword: "wallet",
+          limit: 1,
+          cursor: first._pagination.nextCursor,
+        },
+        ctx
+      )
+    ).content[0].text
+  );
+
+  assert.equal(second.count, 1);
+  assert.equal(second.products[0].id, hex("2"));
+  assert.equal(second.products[0].matchedVia, "nip50");
+  assert.equal(second._pagination.hasMore, false);
+});
+
+test("search_products bounds content scanned during keyword verification", async () => {
   const response = await handleSearchProducts(
-    { keyword: "wallet", limit: 1 },
+    { keyword: "needle" },
     {
       ...context({}),
       relays: ["wss://normal.example.com"],
       nip50SearchRelays: ["wss://search.example.com"],
       nostr: {
         async fetch(_filters, _params, relayUrls) {
-          if (relayUrls[0] === "wss://search.example.com") {
-            return [
-              productEvent({
-                id: hex("2"),
-                tags: [
-                  ["d", "nip50-wallet"],
-                  ["title", "Hardware Wallet"],
-                ],
-              }),
-            ];
-          }
-          return [productEvent()];
+          return relayUrls[0] === "wss://search.example.com"
+            ? [
+                productEvent({
+                  id: hex("2"),
+                  tags: [["d", "oversized-content"]],
+                  content: `${"x".repeat(20_000)}needle`,
+                }),
+              ]
+            : [];
         },
       },
     }
   );
   const body = JSON.parse(response.content[0].text);
 
-  assert.equal(body.count, 1);
-  assert.equal(body.products[0].id, productEvent().id);
-  assert.equal(body.products[0].matchedVia, undefined);
-  assert.equal(body._meta.nip50.reservedSlotsUsed, 0);
-  assert.equal(body._pagination.hasMore, false);
+  assert.equal(body.count, 0);
 });
 
 test("search_products reallocates unused normal capacity to NIP-50 matches", async () => {

--- a/packages/shopstr-mcp/test/tools/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/tools/search-products.node.mjs
@@ -226,7 +226,7 @@ test("search_products queries normal and NIP-50 relays concurrently for keyword 
             id: hex("2"),
             created_at: 20,
             tags: [
-              ["d", "wallet"],
+              ["d", "wallet-nip50"],
               ["title", "Hardware Wallet"],
               ["summary", "NIP-50 result"],
               ["price", "35", "USD"],
@@ -255,7 +255,7 @@ test("search_products queries normal and NIP-50 relays concurrently for keyword 
       id: hex("1"),
       created_at: 10,
       tags: [
-        ["d", "wallet"],
+        ["d", "wallet-normal"],
         ["title", "Hardware Wallet"],
         ["summary", "Normal relay result"],
         ["price", "40", "USD"],
@@ -265,12 +265,15 @@ test("search_products queries normal and NIP-50 relays concurrently for keyword 
 
   const body = JSON.parse((await responsePromise).content[0].text);
 
-  assert.equal(body.count, 1);
-  assert.equal(body.products[0].id, hex("2"));
+  assert.equal(body.count, 2);
+  assert.equal(body.products[0].id, hex("1"));
+  assert.equal(body.products[1].id, hex("2"));
+  assert.equal(body.products[1].matchedVia, "nip50");
   assert.deepEqual(body._meta.nip50, {
     attempted: true,
     relaysQueried: [nip50Relay],
     eventCount: 1,
+    reservedSlotsUsed: 1,
   });
 });
 
@@ -349,7 +352,8 @@ test("search_products fails only when normal and NIP-50 relays both fail", async
   );
 });
 
-test("search_products does not query NIP-50 relays when a cursor is supplied", async () => {
+test("search_products queries NIP-50 on cursor pages without sending until", async () => {
+  const seenIdentity = `30402:${hex("b")}:already-seen`;
   const cursor = createPaginationCursor({
     tool: "search_products",
     query: createQueryFingerprint("search_products", [
@@ -363,7 +367,7 @@ test("search_products does not query NIP-50 relays when a cursor is supplied", a
       "newest",
     ]),
     boundary: 100,
-    seen: [],
+    seen: [hashPaginationLogicalIdentity(seenIdentity)],
   });
   const calls = [];
   const response = await handleSearchProducts(
@@ -383,10 +387,205 @@ test("search_products does not query NIP-50 relays when a cursor is supplied", a
   const body = JSON.parse(response.content[0].text);
 
   assert.equal(response.isError, undefined);
-  assert.equal(calls.length, 1);
+  assert.equal(calls.length, 2);
   assert.equal(calls[0].relay, "wss://normal.example.com");
   assert.equal(calls[0].filters[0].search, undefined);
-  assert.equal(body._meta.nip50.attempted, false);
+  assert.equal(calls[0].filters[0].until, 100);
+  assert.equal(calls[0].filters[0].limit, 6);
+  assert.equal(calls[1].relay, "wss://search.example.com");
+  assert.equal(calls[1].filters[0].search, "wallet");
+  assert.equal(calls[1].filters[0].until, undefined);
+  assert.equal(calls[1].filters[0].limit, 6);
+  assert.equal(body._meta.nip50.attempted, true);
+});
+
+test("search_products keeps older NIP-50 matches outside the normal sparse boundary", async () => {
+  const normalWindow = Array.from({ length: 10 }, (_, index) =>
+    productEvent({
+      id: (index + 1).toString(16).padStart(64, "0"),
+      created_at: 100 - index,
+      tags: [
+        ["d", `normal-${index}`],
+        ["title", "Unrelated Product"],
+      ],
+    })
+  );
+  const nip50Match = productEvent({
+    id: hex("f"),
+    created_at: 1,
+    tags: [
+      ["d", "rare-match"],
+      ["title", "Rare Search Match"],
+    ],
+  });
+
+  const response = await handleSearchProducts(
+    { keyword: "rare", limit: 2 },
+    {
+      ...context({}),
+      relays: ["wss://normal.example.com"],
+      nip50SearchRelays: ["wss://search.example.com"],
+      nostr: {
+        async fetch(_filters, _params, relayUrls) {
+          return relayUrls[0] === "wss://search.example.com"
+            ? [nip50Match]
+            : normalWindow;
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.isError, undefined);
+  assert.equal(body.count, 1);
+  assert.equal(body.products[0].id, nip50Match.id);
+  assert.equal(body.products[0].matchedVia, "nip50");
+});
+
+test("search_products does not duplicate a product that appears in normal and NIP-50 streams", async () => {
+  const duplicateFromNip50 = productEvent({
+    id: hex("2"),
+    created_at: 120,
+    tags: [
+      ["d", "product"],
+      ["title", "Hardware Wallet"],
+    ],
+  });
+  const response = await handleSearchProducts(
+    { keyword: "wallet" },
+    {
+      ...context({}),
+      relays: ["wss://normal.example.com"],
+      nip50SearchRelays: ["wss://search.example.com"],
+      nostr: {
+        async fetch(_filters, _params, relayUrls) {
+          return relayUrls[0] === "wss://search.example.com"
+            ? [duplicateFromNip50]
+            : [productEvent()];
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.count, 1);
+  assert.equal(body.products[0].id, productEvent().id);
+  assert.equal(body.products[0].matchedVia, undefined);
+});
+
+test("search_products reserves NIP-50 slots without crowding out limit-1 normal results", async () => {
+  const response = await handleSearchProducts(
+    { keyword: "wallet", limit: 1 },
+    {
+      ...context({}),
+      relays: ["wss://normal.example.com"],
+      nip50SearchRelays: ["wss://search.example.com"],
+      nostr: {
+        async fetch(_filters, _params, relayUrls) {
+          if (relayUrls[0] === "wss://search.example.com") {
+            return [
+              productEvent({
+                id: hex("2"),
+                tags: [
+                  ["d", "nip50-wallet"],
+                  ["title", "Hardware Wallet"],
+                ],
+              }),
+            ];
+          }
+          return [productEvent()];
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(body.count, 1);
+  assert.equal(body.products[0].id, productEvent().id);
+  assert.equal(body.products[0].matchedVia, undefined);
+  assert.equal(body._meta.nip50.reservedSlotsUsed, 0);
+});
+
+test("search_products does not repeat a returned NIP-50 item on the next page", async () => {
+  const normalOne = productEvent({
+    id: hex("1"),
+    created_at: 100,
+    tags: [
+      ["d", "normal-one"],
+      ["title", "Hardware Wallet One"],
+    ],
+  });
+  const normalTwo = productEvent({
+    id: hex("2"),
+    created_at: 99,
+    tags: [
+      ["d", "normal-two"],
+      ["title", "Hardware Wallet Two"],
+    ],
+  });
+  const nip50One = productEvent({
+    id: hex("3"),
+    created_at: 50,
+    tags: [
+      ["d", "nip50-one"],
+      ["title", "Hardware Wallet Search One"],
+    ],
+  });
+  const nip50Two = productEvent({
+    id: hex("4"),
+    created_at: 49,
+    tags: [
+      ["d", "nip50-two"],
+      ["title", "Hardware Wallet Search Two"],
+    ],
+  });
+  const ctx = {
+    ...context({}),
+    relays: ["wss://normal.example.com"],
+    nip50SearchRelays: ["wss://search.example.com"],
+    nostr: {
+      async fetch(filters, _params, relayUrls) {
+        if (relayUrls[0] === "wss://search.example.com") {
+          return [nip50One, nip50Two];
+        }
+        return filters[0].until === undefined
+          ? [normalOne, normalTwo]
+          : [normalTwo];
+      },
+    },
+  };
+
+  const first = JSON.parse(
+    (await handleSearchProducts({ keyword: "wallet", limit: 2 }, ctx))
+      .content[0].text
+  );
+  const second = JSON.parse(
+    (
+      await handleSearchProducts(
+        {
+          keyword: "wallet",
+          limit: 2,
+          cursor: first._pagination.nextCursor,
+        },
+        ctx
+      )
+    ).content[0].text
+  );
+
+  assert.deepEqual(
+    first.products.map((product) => product.id),
+    [normalOne.id, nip50One.id]
+  );
+  assert.equal(first.products[1].matchedVia, "nip50");
+  assert.equal(
+    second.products.some((product) => product.id === nip50One.id),
+    false
+  );
+  assert.equal(
+    second.products.some((product) => product.id === nip50Two.id),
+    true
+  );
+  assert.ok(second.products.length <= 2);
 });
 
 test("search_products applies NIP-50 to category fallback keyword retries", async () => {

--- a/packages/shopstr-mcp/test/tools/search-products.node.mjs
+++ b/packages/shopstr-mcp/test/tools/search-products.node.mjs
@@ -573,6 +573,54 @@ test("search_products reserves NIP-50 slots without crowding out limit-1 normal 
   assert.equal(body._pagination.hasMore, false);
 });
 
+test("search_products reallocates unused normal capacity to NIP-50 matches", async () => {
+  const normalProducts = Array.from({ length: 5 }, (_, index) =>
+    productEvent({
+      id: (index + 1).toString(16).padStart(64, "0"),
+      created_at: 1_000 - index,
+      tags: [
+        ["d", `normal-wallet-${index}`],
+        ["title", `Normal Hardware Wallet ${index}`],
+      ],
+    })
+  );
+  const nip50Products = Array.from({ length: 60 }, (_, index) =>
+    productEvent({
+      id: (100 + index).toString(16).padStart(64, "0"),
+      created_at: 900 - index,
+      tags: [
+        ["d", `nip50-wallet-${index}`],
+        ["title", `NIP-50 Hardware Wallet ${index}`],
+      ],
+    })
+  );
+  const response = await handleSearchProducts(
+    { keyword: "wallet" },
+    {
+      ...context({}),
+      relays: ["wss://normal.example.com"],
+      nip50SearchRelays: ["wss://search.example.com"],
+      nostr: {
+        async fetch(_filters, _params, relayUrls) {
+          return relayUrls[0] === "wss://search.example.com"
+            ? nip50Products
+            : normalProducts;
+        },
+      },
+    }
+  );
+  const body = JSON.parse(response.content[0].text);
+
+  assert.equal(response.resultCount, 37);
+  assert.equal(body.count, 37);
+  assert.equal(
+    body.products.filter((product) => product.matchedVia === "nip50").length,
+    32
+  );
+  assert.equal(body._meta.nip50.reservedSlotsUsed, 32);
+  assert.equal(body._pagination.hasMore, true);
+});
+
 test("search_products paginates NIP-50-only results without skipping relay-ranked candidates", async () => {
   const nip50Products = Array.from({ length: 6 }, (_, index) =>
     productEvent({
@@ -618,14 +666,14 @@ test("search_products paginates NIP-50-only results without skipping relay-ranke
   assert.deepEqual(
     first.products.map((product) => product.id).sort(),
     nip50Products
-      .slice(0, 2)
+      .slice(0, 3)
       .map((product) => product.id)
       .sort()
   );
   assert.deepEqual(
     second.products.map((product) => product.id).sort(),
     nip50Products
-      .slice(2, 4)
+      .slice(3, 6)
       .map((product) => product.id)
       .sort()
   );


### PR DESCRIPTION
### Description
This PR adds NIP50 support for search_products tool of MCP server

- Added NIP-50 (search) relay querying - search_products now queries NIP-50-capable relays in parallel with the existing keyword/tag scan and merges matches into the response.
- Separated NIP-50 from normal relay pagination - normal and NIP-50 events are tracked independently so sparseBoundary and cursor calculations only use the normal stream.
- Reserved response slots for NIP-50 matches (fixed at 5) guarantees NIP-50 results get space in the response alongside normal matches.
- Tagged NIP-50 results - products returned through NIP-50 are marked with matchedVia: `nip50`.
- NIP-50 queries run for cursor-based requests instead of only the first page.
- Each page increases the NIP-50 relay limit and excludes identities already present in the pagination cursor.
- Prevented duplicate results - NIP-50 candidates already returned by the normal stream are excluded.
- Applied the the sparse-window cursor fix so that things are working perfectly
- NIP-50 results are not limited to a fixed NIP50_RESERVED_SLOTS allocation; unused response capacity from normal results is  reallocated to additional NIP-50 matches.
 - NIP-50 content matching added through event.content
 
### Resolved or fixed issue
`none`  


### Video  
https://drive.google.com/file/d/1nHKS0eolVLptf4679oz5p2sr11C7Z1Cm/view?usp=sharing

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/hxrshxz/shopstr/blob/main/contributing.md) guidelines
